### PR TITLE
feat: add Pi session provider

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,7 +1,7 @@
 # Obelisk
 
 Obelisk is explicit memory infrastructure for coding agents: it indexes local
-Claude Code, Codex, and Kimi Code sessions into a queryable SQLite evidence layer, and a
+Claude Code, Codex, Kimi Code, and Pi sessions into a queryable SQLite evidence layer, and a
 CodeAct runtime lets an agent write a small query, run it, and answer from real
 session history. This glossary pins the terms that are specific to Obelisk; it is
 not a spec.
@@ -29,7 +29,7 @@ promoted to an external tool surface.
 ## Indexing
 
 **Provider adapter**:
-A pure per-source module (claude, codex, kimi, later pi, …) that owns its
+A pure per-source module (claude, codex, kimi, pi, …) that owns its
 descriptor, watch roots, discovery, parsing, cursor interpretation, and raw
 record lookup. It discovers `IndexUnit`s rather than assuming one transcript
 file per unit; Kimi uses a session directory containing multiple wire logs. It

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![version](https://img.shields.io/github/v/tag/tommy0103/obelisk?label=version&style=flat-square)](https://github.com/tommy0103/obelisk/releases)
 [![license](https://img.shields.io/badge/license-AGPL--3.0-blue.svg?style=flat-square)](LICENSE)
 
-Past Claude Code, Codex, and Kimi Code sessions -- queryable by your agent, browsable by you.
+Past Claude Code, Codex, Kimi Code, and Pi sessions -- queryable by your agent, browsable by you.
 
 </div>
 
@@ -25,7 +25,7 @@ The agent writes JS queries, runs them locally, and answers in plain language.
 
 **App side** — an Electron desktop app for humans to browse sessions, manage memories, view usage stats, and see weekly recap cards.
 
-Both read from the same `~/.obelisk/obelisk.sqlite` database. The indexer reads Claude Code transcripts from `~/.claude/projects`, Codex transcripts from `~/.codex/sessions`, and Kimi Code sessions from `~/.kimi-code/sessions` (or `$KIMI_CODE_HOME/sessions`).
+Both read from the same `~/.obelisk/obelisk.sqlite` database. The indexer reads Claude Code transcripts from `~/.claude/projects`, Codex transcripts from `~/.codex/sessions`, Kimi Code sessions from `~/.kimi-code/sessions` (or `$KIMI_CODE_HOME/sessions`), and standard Pi v3 sessions from `~/.pi/agent/sessions`. Pi also honors `PI_CODING_AGENT_SESSION_DIR`, `PI_CODING_AGENT_DIR`, and the global Pi `settings.json` `sessionDir` setting.
 
 ## Multi-provider support
 
@@ -38,7 +38,12 @@ Kimi session directories become one Obelisk session each. Main and child-agent
 subagents tables. Undo/clear is handled as a full session replay, so retracted
 wire records do not remain in the index.
 
-For live app refresh, Obelisk watches the roots declared by every registered provider, including `~/.claude/projects`, `~/.codex/sessions`, and `~/.kimi-code/sessions`. Codex's `session_index.jsonl` is used as lightweight title/update metadata during indexing, not as the message transcript source.
+Pi tree sessions are replayed as canonical messages, tools, summaries, and
+sidechains. This first Pi provider indexes only standard top-level files shaped
+`<project-dir>/<session>.jsonl`; deeper nested subagent run `session.jsonl`
+transcripts are intentionally excluded.
+
+For live app refresh, Obelisk watches the roots declared by every registered provider, including `~/.claude/projects`, `~/.codex/sessions`, `~/.kimi-code/sessions`, and the resolved Pi sessions directory. Codex's `session_index.jsonl` is used as lightweight title/update metadata during indexing, not as the message transcript source.
 
 ## Skill: agent-first retrieval
 
@@ -61,7 +66,7 @@ You can use obelisk like:
 #### Let your agent install it (recommended)
 
 The shortest path is to give the bootstrap guide directly to a coding agent
-with shell access. Paste this as a prompt into Claude Code, Codex, or another
+with shell access. Paste this as a prompt into Claude Code, Codex, Kimi Code, Pi, or another
 agent — not into your terminal:
 
 ```text
@@ -98,7 +103,7 @@ obelisk install
 `obelisk install` delegates to the standard skills installer for
 `tommy0103/obelisk-skill`.
 
-Then in any Claude Code session:
+Then in any supported coding-agent session:
 
 ```
 /obelisk <your question>
@@ -157,9 +162,10 @@ npm run dev
 
 `electron-vite` starts the renderer dev server and launches Electron. On first
 run, Obelisk creates `~/.obelisk/obelisk.sqlite`, indexes the available Claude
-Code and Codex transcripts, and then watches them for changes. The default
-sources are `~/.claude/projects` and `~/.codex/sessions`; use **Settings** to
-point the app at different directories. On Windows, Obelisk also checks common
+Code, Codex, Kimi Code, and Pi transcripts, and then watches them for changes.
+The default roots are `~/.claude/projects`, `~/.codex/sessions`,
+`~/.kimi-code/sessions`, and the resolved Pi sessions directory; use
+**Settings** to point the app at different directories. On Windows, Obelisk also checks common
 WSL distributions for the Claude Code directory.
 
 ### Debug the app
@@ -184,10 +190,10 @@ run `npm ci` again.
 
 | Layer | Source | What's captured |
 |-------|--------|----------------|
-| **Sessions** | Claude `<project>/<sessionId>.jsonl`; Codex `sessions/YYYY/MM/DD/*.jsonl` | Title, project, timestamps, git branch, source |
+| **Sessions** | Claude JSONL; Codex rollouts; Kimi session directories; top-level Pi v3 JSONL | Title, project, timestamps, git branch, source |
 | **Messages** | user + assistant turns | Full text, model, token usage, parent chain |
 | **Tool calls** | every tool invocation | Tool name, input, file paths |
-| **Subagents** | Claude `subagents/agent-<id>.jsonl`; Codex child threads | Agent type, description, full conversation |
+| **Subagents** | Claude subagent JSONL; Codex child threads; Kimi child agents | Agent type, description, full conversation (nested Pi runs excluded in v1) |
 | **Workflows** | Claude `workflows/wf_<runId>.json` | Script, result, agent count |
 | **Workflow agents** | Claude `subagents/workflows/wf_<runId>/` | Per-agent transcripts |
 | **Memories** | registered markdown files | Conclusions linked to source sessions |
@@ -203,7 +209,8 @@ packages/core/                # @obelisk/core npm workspace (TypeScript + ESM)
 │   │   ├── types.ts          # Provider + TranscriptRecord contract
 │   │   ├── claude.ts         # Claude Code adapter (line-incremental)
 │   │   ├── codex.ts          # Codex adapter (full-reparse)
-│   │   └── kimi.ts           # Kimi Code adapter (session projection)
+│   │   ├── kimi.ts           # Kimi Code adapter (session projection)
+│   │   └── pi.ts             # Pi v3 adapter (tree-aware full replay)
 │   ├── session-detail.ts     # Provider-independent transcript projection
 │   ├── persist.ts            # Binding-agnostic record writer (upsert/merge)
 │   ├── tx.ts                 # Write transaction + connection config

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "obelisk",
   "version": "0.2.1",
-  "description": "Memory management for Obelisk — let Claude Code search its own memory",
+  "description": "Browse and manage indexed Claude Code, Codex, Kimi Code, and Pi session memory",
   "homepage": "https://github.com/tommy0103/obelisk",
   "author": {
     "name": "Obelisk contributors",

--- a/docs/adr/0004-skill-artifact-readable-not-bundled.md
+++ b/docs/adr/0004-skill-artifact-readable-not-bundled.md
@@ -1,6 +1,6 @@
 # The CLI ships readable compiled JS; the skill remains docs-only
 
-**Context.** Obelisk reads a user's entire local Claude Code and Codex history,
+**Context.** Obelisk reads a user's local Claude Code, Codex, Kimi Code, and Pi history,
 so auditability is the foundation of trust. Bundling/minifying Core into one
 opaque file would make the runtime harder to inspect. Shipping executable Core
 inside `.claude/skills` / `.agents/skills` would also blur the boundary between

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "private": true,
   "type": "module",
-  "description": "Explicit memory infrastructure for coding agents — a queryable SQLite evidence layer over local Claude Code and Codex history, plus human-approved durable memory.",
+  "description": "Explicit memory infrastructure for coding agents — a queryable SQLite evidence layer over local Claude Code, Codex, Kimi Code, and Pi history, plus human-approved durable memory.",
   "license": "AGPL-3.0",
   "workspaces": [
     "packages/*"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,7 +1,8 @@
 # Obelisk CLI
 
-The local Obelisk runtime used by coding agents. It indexes Claude Code and
-Codex transcripts into `~/.obelisk/obelisk.sqlite` and exposes the stable
+The local Obelisk runtime used by coding agents. It indexes Claude Code, Codex,
+Kimi Code, and standard top-level Pi v3 transcripts into
+`~/.obelisk/obelisk.sqlite` and exposes the stable
 `build`, `search`, `query`, and `attune` process interface.
 
 ```bash

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "private": true,
   "type": "module",
-  "description": "Shared indexing and query core for Obelisk transports.",
+  "description": "Shared multi-provider transcript indexing and query core for Obelisk transports.",
   "exports": {
     ".": "./dist/core.js",
     "./db": "./dist/db.js",
@@ -15,6 +15,7 @@
     "./providers/claude": "./dist/providers/claude.js",
     "./providers/codex": "./dist/providers/codex.js",
     "./providers/kimi": "./dist/providers/kimi.js",
+    "./providers/pi": "./dist/providers/pi.js",
     "./providers/registry": "./dist/providers/registry.js",
     "./providers/builtins": "./dist/providers/builtins.js",
     "./providers/types": "./dist/providers/types.js",

--- a/packages/core/src/providers/builtins.ts
+++ b/packages/core/src/providers/builtins.ts
@@ -1,6 +1,7 @@
 import { createClaudeProvider } from './claude.ts';
 import { createCodexProvider } from './codex.ts';
 import { createKimiProvider } from './kimi.ts';
+import { createPiProvider } from './pi.ts';
 import { createProviderRegistry, type ProviderRegistry } from './registry.ts';
 
 export type BuiltinProviderRoots = Readonly<Record<string, string | undefined>>;
@@ -10,5 +11,6 @@ export function createBuiltinProviderRegistry(roots: BuiltinProviderRoots = {}):
     createClaudeProvider({ rootDir: roots['claude'] }),
     createCodexProvider({ rootDir: roots['codex'] }),
     createKimiProvider({ rootDir: roots['kimi'] }),
+    createPiProvider({ rootDir: roots['pi'] }),
   ]);
 }

--- a/packages/core/src/providers/pi.ts
+++ b/packages/core/src/providers/pi.ts
@@ -1,0 +1,629 @@
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  type Dirent,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import {
+  isAbsolute,
+  join,
+  normalize,
+  relative,
+  resolve,
+  sep,
+} from 'node:path';
+
+import { projectSlugFromPath, readLines, trunc, truncJson } from '../parsing.ts';
+import type {
+  Cursor,
+  DiscoverContext,
+  IndexUnit,
+  MessageRecord,
+  ProviderAdapter,
+  RawLookup,
+  RawRecord,
+  TranscriptRecord,
+} from './types.ts';
+
+type JsonRecord = Record<string, any>;
+
+interface PiLineRecord {
+  readonly line: number;
+  readonly entry: JsonRecord;
+}
+
+interface PiUnitMeta {
+  readonly header: JsonRecord;
+}
+
+interface ProjectedMessage {
+  readonly id: string;
+  readonly part: number;
+  readonly type: string;
+  readonly role: string;
+  readonly text: string | null;
+  readonly contentType: string;
+  readonly isMeta: 0 | 1;
+  readonly visibility: 'visible' | 'hidden';
+  readonly toolCall?: JsonRecord;
+  readonly toolResult?: JsonRecord;
+}
+
+const SOURCE = 'pi';
+const TITLE_LIMIT = 200;
+export const PI_CANONICAL_TRANSCRIPT_MARKER = '__pi_canonical_transcript_v1__';
+
+function resolvePath(value: string, home: string, cwd: string): string {
+  if (value === '~') return home;
+  if (value.startsWith(`~${sep}`) || value.startsWith('~/') || value.startsWith('~\\')) {
+    return resolve(home, value.slice(2));
+  }
+  return isAbsolute(value) ? normalize(value) : resolve(cwd, value);
+}
+
+export function defaultPiSessionsRoot({
+  env = process.env,
+  home = homedir(),
+  cwd = process.cwd(),
+}: {
+  env?: NodeJS.ProcessEnv;
+  home?: string;
+  cwd?: string;
+} = {}): string {
+  const explicitSessions = env['PI_CODING_AGENT_SESSION_DIR'];
+  if (explicitSessions) return resolvePath(explicitSessions, home, cwd);
+
+  const agentDir = resolvePath(env['PI_CODING_AGENT_DIR'] || join(home, '.pi', 'agent'), home, cwd);
+  const settingsPath = join(agentDir, 'settings.json');
+  if (existsSync(settingsPath)) {
+    try {
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as JsonRecord;
+      if (typeof settings.sessionDir === 'string' && settings.sessionDir.trim().length > 0) {
+        return resolvePath(settings.sessionDir, home, cwd);
+      }
+    } catch { /* malformed optional global Pi settings */ }
+  }
+  return join(agentDir, 'sessions');
+}
+
+function lineCount(raw: string): number {
+  if (raw.length === 0) return 0;
+  const newlines = raw.match(/\n/g)?.length ?? 0;
+  return newlines + (raw.endsWith('\n') ? 0 : 1);
+}
+
+function cursorMtime(cursor: Cursor): number | null {
+  if (typeof cursor !== 'string') return null;
+  const separator = cursor.indexOf(':');
+  if (separator <= 0) return null;
+  const mtime = Number(cursor.slice(0, separator));
+  return Number.isFinite(mtime) ? mtime : null;
+}
+
+function readHeader(path: string): JsonRecord | null {
+  let first: string | null = null;
+  try {
+    readLines(path, (line) => {
+      first = line.endsWith('\r') ? line.slice(0, -1) : line;
+      return false;
+    });
+    if (!first) return null;
+    const header = JSON.parse(first) as JsonRecord;
+    return header?.type === 'session'
+      && header.version === 3
+      && typeof header.id === 'string'
+      && header.id.length > 0
+      ? header
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function standardSessionFiles(rootDir: string): string[] {
+  if (!existsSync(rootDir)) return [];
+  const paths: string[] = [];
+  let projects: Dirent<string>[];
+  try { projects = readdirSync(rootDir, { withFileTypes: true }); } catch { return []; }
+  for (const project of projects) {
+    if (!project.isDirectory()) continue;
+    const projectDir = join(rootDir, project.name);
+    let sessions: Dirent<string>[];
+    try { sessions = readdirSync(projectDir, { withFileTypes: true }); } catch { continue; }
+    for (const session of sessions) {
+      if (session.isFile() && session.name.toLowerCase().endsWith('.jsonl')) {
+        paths.push(join(projectDir, session.name));
+      }
+    }
+  }
+  return paths.sort();
+}
+
+function changedStandardFiles(rootDir: string, changedPaths: readonly string[]): Set<string> {
+  const changed = changedPaths.map((path) => (
+    isAbsolute(path) ? normalize(path) : normalize(join(rootDir, path))
+  ));
+  const files = new Set<string>();
+  for (const path of standardSessionFiles(rootDir)) {
+    const normalizedPath = normalize(path);
+    const projectDir = normalize(join(rootDir, relative(rootDir, path).split(sep)[0]!));
+    if (changed.some((candidate) => (
+      candidate === normalizedPath || candidate === projectDir || candidate === normalize(rootDir)
+    ))) files.add(normalizedPath);
+  }
+  return files;
+}
+
+function discoverAt(rootDir: string, ctx: DiscoverContext): IndexUnit[] {
+  const selected = ctx.changedPaths === undefined
+    ? null
+    : changedStandardFiles(rootDir, ctx.changedPaths);
+  const units: IndexUnit[] = [];
+  for (const path of standardSessionFiles(rootDir)) {
+    const normalizedPath = normalize(path);
+    if (selected !== null && !selected.has(normalizedPath)) continue;
+    let mtimeMs: number;
+    try { mtimeMs = statSync(path).mtimeMs; } catch { continue; }
+    if (selected === null && cursorMtime(ctx.lastCursor(path)) === mtimeMs) continue;
+    const header = readHeader(path);
+    if (header === null) continue;
+    const sessionId = namespacedSessionId(header.id);
+    units.push({
+      key: path,
+      sessionId,
+      project: projectSlugFromPath(typeof header.cwd === 'string' ? header.cwd : null) ?? undefined,
+      meta: { header } satisfies PiUnitMeta,
+    });
+  }
+  return units;
+}
+
+function readPiLines(path: string): { raw: string; records: PiLineRecord[]; cursor: Exclude<Cursor, null> } {
+  const before = statSync(path);
+  const raw = readFileSync(path, 'utf8');
+  const physicalLines = raw.split('\n');
+  if (raw.endsWith('\n')) physicalLines.pop();
+  const records: PiLineRecord[] = [];
+  for (let index = 0; index < physicalLines.length; index++) {
+    const source = physicalLines[index]!.endsWith('\r')
+      ? physicalLines[index]!.slice(0, -1)
+      : physicalLines[index]!;
+    if (source.length === 0) continue;
+    try {
+      records.push({ line: index + 1, entry: JSON.parse(source) as JsonRecord });
+    } catch (error) {
+      const tornFinalLine = index === physicalLines.length - 1 && !raw.endsWith('\n');
+      if (tornFinalLine) break;
+      throw new Error(`Pi session: corrupted line ${index + 1} in ${path}: ${String(error)}`, { cause: error });
+    }
+  }
+  const after = statSync(path);
+  if (before.mtimeMs !== after.mtimeMs || before.size !== after.size) {
+    throw new Error(`Pi session changed while indexing: ${path}`);
+  }
+  return { raw, records, cursor: `${after.mtimeMs}:${lineCount(raw)}` };
+}
+
+function namespacedSessionId(nativeId: unknown): string {
+  return `pi:${String(nativeId).replace(/^pi:/, '')}`;
+}
+
+function messageId(sessionId: string, entryId: unknown, part: number): string {
+  return `${sessionId}:message:${String(entryId)}:${part}`;
+}
+
+function toolId(sessionId: string, nativeId: unknown): string {
+  return `${sessionId}:tool:${String(nativeId)}`;
+}
+
+function summaryId(sessionId: string, entryId: unknown, source: string): string {
+  return `${sessionId}:summary:${String(entryId)}:${source}`;
+}
+
+function normalizeTimestamp(value: unknown): string | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return new Date(value).toISOString();
+  return typeof value === 'string' && !Number.isNaN(Date.parse(value)) ? value : null;
+}
+
+function textBlocks(content: unknown): Array<{ part: number; text: string }> {
+  if (typeof content === 'string') return [{ part: 0, text: content }];
+  if (!Array.isArray(content)) return [];
+  return content.flatMap((block, part) => (
+    block?.type === 'text' && typeof block.text === 'string'
+      ? [{ part, text: block.text }]
+      : []
+  ));
+}
+
+function joinedText(content: unknown): string | null {
+  const parts = textBlocks(content).map((part) => part.text);
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
+function bashText(message: JsonRecord): string {
+  const command = typeof message.command === 'string' ? message.command : '';
+  const output = typeof message.output === 'string' ? message.output : '';
+  const lines = [output.length > 0 ? `$ ${command}\n${output}` : `$ ${command}`];
+  if (typeof message.exitCode === 'number' && message.exitCode !== 0) {
+    lines.push(`[exit code: ${message.exitCode}]`);
+  }
+  if (message.cancelled === true) lines.push('[cancelled]');
+  if (message.truncated === true) lines.push('[output truncated]');
+  return lines.join('\n');
+}
+
+function projectedMessages(entry: JsonRecord, sessionId: string): ProjectedMessage[] {
+  if (entry.type === 'custom_message') {
+    return textBlocks(entry.content).map(({ part, text }) => ({
+      id: messageId(sessionId, entry.id, part), part, type: 'custom', role: 'custom', text,
+      contentType: 'text', isMeta: 1, visibility: entry.display === false ? 'hidden' : 'visible',
+    }));
+  }
+  if (entry.type !== 'message') return [];
+  const message = entry.message as JsonRecord | undefined;
+  if (!message || typeof message.role !== 'string') return [];
+
+  if (message.role === 'assistant') {
+    const content = Array.isArray(message.content) ? message.content : [];
+    const projected: ProjectedMessage[] = [];
+    for (let part = 0; part < content.length; part++) {
+      const block = content[part];
+      if (block?.type === 'text' && typeof block.text === 'string') {
+        projected.push({
+          id: messageId(sessionId, entry.id, part), part, type: 'assistant', role: 'assistant',
+          text: block.text, contentType: 'text', isMeta: 0, visibility: 'visible',
+        });
+      } else if (block?.type === 'thinking' && typeof block.thinking === 'string') {
+        projected.push({
+          id: messageId(sessionId, entry.id, part), part, type: 'assistant', role: 'assistant',
+          text: block.thinking, contentType: 'thinking', isMeta: 0, visibility: 'visible',
+        });
+      } else if (block?.type === 'toolCall' && block.id !== undefined) {
+        projected.push({
+          id: messageId(sessionId, entry.id, part), part, type: 'assistant', role: 'assistant',
+          text: null, contentType: 'tool_use', isMeta: 0, visibility: 'visible', toolCall: block,
+        });
+      }
+    }
+    if (typeof message.errorMessage === 'string' && message.errorMessage.length > 0) {
+      const part = content.length;
+      projected.push({
+        id: messageId(sessionId, entry.id, part), part, type: 'assistant', role: 'assistant',
+        text: message.errorMessage, contentType: 'text', isMeta: 0, visibility: 'visible',
+      });
+    }
+    return projected;
+  }
+
+  if (message.role === 'toolResult') {
+    const text = joinedText(message.content) ?? '';
+    return [{
+      id: messageId(sessionId, entry.id, 0), part: 0, type: 'toolResult', role: 'toolResult',
+      text, contentType: 'tool_result', isMeta: 0, visibility: 'visible', toolResult: message,
+    }];
+  }
+
+  if (message.role === 'bashExecution') {
+    return [{
+      id: messageId(sessionId, entry.id, 0), part: 0, type: 'bashExecution', role: 'bashExecution',
+      text: bashText(message), contentType: 'text', isMeta: 0, visibility: 'visible',
+    }];
+  }
+
+  if (message.role === 'custom') {
+    return textBlocks(message.content).map(({ part, text }) => ({
+      id: messageId(sessionId, entry.id, part), part, type: 'custom', role: 'custom', text,
+      contentType: 'text', isMeta: 1, visibility: message.display === false ? 'hidden' : 'visible',
+    }));
+  }
+
+  if (message.role !== 'user') return [];
+  return textBlocks(message.content).map(({ part, text }) => ({
+    id: messageId(sessionId, entry.id, part), part, type: 'user', role: 'user', text,
+    contentType: 'text', isMeta: 0, visibility: 'visible',
+  }));
+}
+
+function numeric(usage: JsonRecord, ...names: string[]): number | null {
+  for (const name of names) {
+    const value = usage[name];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function inputUsage(usage: JsonRecord): number | null {
+  const values = [
+    numeric(usage, 'input', 'input_tokens'),
+    numeric(usage, 'cacheRead', 'cache_read_input_tokens'),
+    numeric(usage, 'cacheWrite', 'cache_creation_input_tokens'),
+  ];
+  return values.some((value) => value !== null)
+    ? values.reduce<number>((sum, value) => sum + (value ?? 0), 0)
+    : null;
+}
+
+function piFilePath(name: unknown, args: unknown): string | null {
+  if (typeof name !== 'string' || !['read', 'edit', 'write'].includes(name.toLowerCase())) return null;
+  if (args === null || typeof args !== 'object' || Array.isArray(args)) return null;
+  const input = args as JsonRecord;
+  return typeof input.path === 'string'
+    ? input.path
+    : typeof input.file_path === 'string'
+      ? input.file_path
+      : null;
+}
+
+function structuralGitBranch(header: JsonRecord, entries: readonly JsonRecord[]): string | null {
+  const values = [header, ...entries].reverse();
+  for (const value of values) {
+    if (typeof value.gitBranch === 'string') return value.gitBranch;
+    if (typeof value.git_branch === 'string') return value.git_branch;
+    if (typeof value.git?.branch === 'string') return value.git.branch;
+  }
+  return null;
+}
+
+function titleFor(entries: readonly JsonRecord[]): string | null {
+  for (let index = entries.length - 1; index >= 0; index--) {
+    const entry = entries[index]!;
+    if (entry.type === 'session_info') {
+      if (typeof entry.name !== 'string') return null;
+      return entry.name.trim() || null;
+    }
+  }
+  for (const entry of entries) {
+    if (entry.type !== 'message' || entry.message?.role !== 'user') continue;
+    const text = joinedText(entry.message.content)?.trim();
+    if (text) return text.slice(0, TITLE_LIMIT);
+  }
+  return null;
+}
+
+function summaryRecord(entry: JsonRecord, sessionId: string): TranscriptRecord | null {
+  if (entry.type === 'compaction' && typeof entry.summary === 'string') {
+    return {
+      kind: 'summary', id: summaryId(sessionId, entry.id, 'compaction'), session_id: sessionId,
+      timestamp: normalizeTimestamp(entry.timestamp), source: 'compaction', content: trunc(entry.summary),
+    };
+  }
+  if (entry.type === 'branch_summary' && typeof entry.summary === 'string') {
+    return {
+      kind: 'summary', id: summaryId(sessionId, entry.id, 'branch_summary'), session_id: sessionId,
+      timestamp: normalizeTimestamp(entry.timestamp), source: 'branch_summary', content: trunc(entry.summary),
+    };
+  }
+  if (entry.type === 'message') {
+    const message = entry.message as JsonRecord | undefined;
+    if (message?.role === 'compactionSummary' && typeof message.summary === 'string') {
+      return {
+        kind: 'summary', id: summaryId(sessionId, entry.id, 'compaction'), session_id: sessionId,
+        timestamp: normalizeTimestamp(entry.timestamp ?? message.timestamp), source: 'compaction', content: trunc(message.summary),
+      };
+    }
+    if (message?.role === 'branchSummary' && typeof message.summary === 'string') {
+      return {
+        kind: 'summary', id: summaryId(sessionId, entry.id, 'branch_summary'), session_id: sessionId,
+        timestamp: normalizeTimestamp(entry.timestamp ?? message.timestamp), source: 'branch_summary', content: trunc(message.summary),
+      };
+    }
+  }
+  return null;
+}
+
+export function* parse(unit: IndexUnit, _cursor: Cursor): Generator<TranscriptRecord, Cursor> {
+  const source = readPiLines(unit.key);
+  const header = source.records[0]?.entry;
+  if (
+    header?.type !== 'session'
+    || header.version !== 3
+    || typeof header.id !== 'string'
+    || header.id.length === 0
+  ) return source.cursor;
+
+  const sessionId = namespacedSessionId(header.id);
+  const lineEntries = source.records.slice(1).filter(({ entry }) => (
+    entry && typeof entry === 'object' && typeof entry.id === 'string'
+  ));
+  const entries = lineEntries.map(({ entry }) => entry);
+  const entryById = new Map(entries.map((entry) => [entry.id as string, entry]));
+  const projectedById = new Map(entries.map((entry) => [entry.id as string, projectedMessages(entry, sessionId)]));
+  const finalMessageByEntry = new Map<string, string | null>();
+  const resolvingFinal = new Set<string>();
+  const finalMessage = (entryId: unknown): string | null => {
+    if (typeof entryId !== 'string') return null;
+    if (finalMessageByEntry.has(entryId)) return finalMessageByEntry.get(entryId) ?? null;
+    if (resolvingFinal.has(entryId)) return null;
+    resolvingFinal.add(entryId);
+    const own = projectedById.get(entryId)?.at(-1)?.id;
+    const entry = entryById.get(entryId);
+    const result = own ?? finalMessage(entry?.parentId);
+    resolvingFinal.delete(entryId);
+    finalMessageByEntry.set(entryId, result);
+    return result;
+  };
+
+  const leaf = entries.at(-1);
+  const activeEntryIds = new Set<string>();
+  let active: JsonRecord | undefined = leaf;
+  while (active && typeof active.id === 'string' && !activeEntryIds.has(active.id)) {
+    activeEntryIds.add(active.id);
+    active = typeof active.parentId === 'string' ? entryById.get(active.parentId) : undefined;
+  }
+
+  const modelByEntry = new Map<string, string | null>();
+  const resolvingModel = new Set<string>();
+  const modelAt = (entry: JsonRecord): string | null => {
+    if (modelByEntry.has(entry.id)) return modelByEntry.get(entry.id) ?? null;
+    if (resolvingModel.has(entry.id)) return null;
+    resolvingModel.add(entry.id);
+    const parent = typeof entry.parentId === 'string' ? entryById.get(entry.parentId) : undefined;
+    let model = parent ? modelAt(parent) : null;
+    if (entry.type === 'model_change' && typeof entry.modelId === 'string') model = entry.modelId;
+    if (entry.type === 'message' && entry.message?.role === 'assistant' && typeof entry.message.model === 'string') {
+      model = entry.message.model;
+    }
+    resolvingModel.delete(entry.id);
+    modelByEntry.set(entry.id, model);
+    return model;
+  };
+
+  const cwdByEntry = new Map<string, string | null>();
+  const resolvingCwd = new Set<string>();
+  const cwdAt = (entry: JsonRecord): string | null => {
+    if (cwdByEntry.has(entry.id)) return cwdByEntry.get(entry.id) ?? null;
+    if (resolvingCwd.has(entry.id)) {
+      throw new Error(`Pi session: corrupted cwd ancestry cycle involving entry ${String(entry.id)} in ${unit.key}`);
+    }
+    resolvingCwd.add(entry.id);
+    const parent = typeof entry.parentId === 'string' ? entryById.get(entry.parentId) : undefined;
+    let cwd = parent ? cwdAt(parent) : (typeof header.cwd === 'string' ? header.cwd : null);
+    if (typeof entry.cwd === 'string') cwd = entry.cwd;
+    if (typeof entry.message?.cwd === 'string') cwd = entry.message.cwd;
+    resolvingCwd.delete(entry.id);
+    cwdByEntry.set(entry.id, cwd);
+    return cwd;
+  };
+  for (const entry of entries) cwdAt(entry);
+
+  const records: TranscriptRecord[] = [];
+  const toolPaths = new Map<string, string | null>();
+  let startedAt = normalizeTimestamp(header.timestamp);
+  let endedAt = startedAt;
+  const updateBounds = (timestamp: string | null): void => {
+    if (timestamp === null) return;
+    if (startedAt === null || timestamp < startedAt) startedAt = timestamp;
+    if (endedAt === null || timestamp > endedAt) endedAt = timestamp;
+  };
+
+  for (const entry of entries) {
+    const timestamp = normalizeTimestamp(entry.timestamp ?? entry.message?.timestamp);
+    updateBounds(timestamp);
+    const summary = summaryRecord(entry, sessionId);
+    if (summary !== null) records.push(summary);
+
+    const projected = projectedById.get(entry.id as string) ?? [];
+    let parentUuid = finalMessage(entry.parentId);
+    const usage = entry.type === 'message' && entry.message?.role === 'assistant'
+      ? (entry.message.usage ?? {}) as JsonRecord
+      : {};
+    for (let index = 0; index < projected.length; index++) {
+      const item = projected[index]!;
+      const isLastAssistantPart = item.role === 'assistant' && index === projected.length - 1;
+      const message: MessageRecord = {
+        kind: 'message', uuid: item.id, session_id: sessionId, type: item.type,
+        parent_uuid: parentUuid, timestamp, role: item.role, text: trunc(item.text),
+        content_type: item.contentType, is_meta: item.isMeta, visibility: item.visibility,
+        model: modelAt(entry), is_sidechain: activeEntryIds.has(entry.id as string) ? 0 : 1,
+        agent_id: null,
+        input_tokens: isLastAssistantPart ? inputUsage(usage) : null,
+        output_tokens: isLastAssistantPart ? numeric(usage, 'output', 'output_tokens') : null,
+        cwd: cwdAt(entry), skill: null, source: SOURCE,
+      };
+      records.push(message);
+      parentUuid = item.id;
+
+      if (item.toolCall) {
+        const id = toolId(sessionId, item.toolCall.id);
+        const args = item.toolCall.arguments && typeof item.toolCall.arguments === 'object'
+          ? item.toolCall.arguments
+          : {};
+        const path = piFilePath(item.toolCall.name, args);
+        toolPaths.set(id, path);
+        records.push({
+          kind: 'tool_call', id, message_uuid: item.id, session_id: sessionId,
+          name: typeof item.toolCall.name === 'string' ? item.toolCall.name : 'tool',
+          presentation: item.toolCall.name === 'Skill' ? 'skill' : 'default',
+          input_json: truncJson(args) ?? '{}', file_path: path,
+        });
+      }
+      if (item.toolResult) {
+        const id = toolId(sessionId, item.toolResult.toolCallId);
+        records.push({
+          kind: 'tool_result', tool_use_id: id, message_uuid: item.id, session_id: sessionId,
+          content: trunc(joinedText(item.toolResult.content) ?? ''),
+          file_path: toolPaths.get(id) ?? null, is_error: item.toolResult.isError === true ? 1 : 0,
+        });
+      }
+    }
+  }
+
+  yield { kind: 'delete-session', sessionId };
+  yield* records;
+  yield {
+    kind: 'session', id: sessionId, title: titleFor(entries),
+    project: projectSlugFromPath(typeof header.cwd === 'string' ? header.cwd : null),
+    started_at: startedAt, ended_at: endedAt,
+    git_branch: structuralGitBranch(header, entries), version: String(header.version),
+    message_count: records.filter((record) => record.kind === 'message').length,
+    countMode: 'total', jsonl_path: unit.key, source: SOURCE,
+  };
+  return source.cursor;
+}
+
+function rawMessageText(entry: JsonRecord, part: number): string | null {
+  if (entry.type === 'custom_message') {
+    return textBlocks(entry.content).find((block) => block.part === part)?.text ?? null;
+  }
+  if (entry.type !== 'message') return null;
+  const message = entry.message as JsonRecord | undefined;
+  if (!message) return null;
+  if (message.role === 'assistant') {
+    const content = Array.isArray(message.content) ? message.content : [];
+    const block = content[part];
+    if (block?.type === 'text' && typeof block.text === 'string') return block.text;
+    if (block?.type === 'thinking' && typeof block.thinking === 'string') return block.thinking;
+    if (part === content.length && typeof message.errorMessage === 'string' && message.errorMessage.length > 0) {
+      return message.errorMessage;
+    }
+    return null;
+  }
+  if (message.role === 'toolResult') return joinedText(message.content) ?? '';
+  if (message.role === 'bashExecution') return bashText(message);
+  if (message.role === 'custom' || message.role === 'user') {
+    return textBlocks(message.content).find((block) => block.part === part)?.text ?? null;
+  }
+  return null;
+}
+
+function rawPi(input: RawLookup): RawRecord | null {
+  const match = /^pi:[^:]+:message:([^:]+):(\d+)$/.exec(input.messageUuid);
+  const path = typeof input.session?.jsonl_path === 'string' ? input.session.jsonl_path : null;
+  if (match === null || path === null || !existsSync(path)) return null;
+  const entryId = match[1]!;
+  const part = Number(match[2]);
+  let found: RawRecord | null = null;
+  readLines(path, (line) => {
+    const source = line.endsWith('\r') ? line.slice(0, -1) : line;
+    if (!source.includes(entryId)) return;
+    try {
+      const entry = JSON.parse(source) as JsonRecord;
+      if (entry?.id !== entryId) return;
+      found = {
+        text: source, totalLength: source.length, offset: 0, limit: source.length,
+        hasMore: false, messageText: rawMessageText(entry, part),
+      };
+      return false;
+    } catch { /* malformed source line */ }
+  });
+  return found;
+}
+
+export function createPiProvider({ rootDir }: { rootDir?: string } = {}): ProviderAdapter {
+  const resolvedRoot = rootDir ?? defaultPiSessionsRoot();
+  return {
+    name: SOURCE,
+    descriptor: {
+      id: SOURCE, name: 'Pi', vendor: 'Pi', defaultRoot: resolvedRoot, color: '#e2b714',
+    },
+    indexVersionMarker: PI_CANONICAL_TRANSCRIPT_MARKER,
+    watchRoots: (configuredRoot) => [configuredRoot],
+    discover: (ctx) => discoverAt(resolvedRoot, ctx),
+    parse,
+    raw: rawPi,
+  };
+}
+
+export const piProvider = createPiProvider();

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -1,8 +1,8 @@
 // Core provider contract (see docs/adr/0001).
 //
 // The indexing layer splits along two orthogonal axes:
-//   - Provider axis: pure per-source adapters (claude, codex, later opencode,
-//     pi, …) that discover their own work and parse it into records. A source is
+//   - Provider axis: pure per-source adapters (claude, codex, kimi, pi,
+//     later opencode, …) that discover their own work and parse it into records. A source is
 //     NOT assumed to be a single JSONL file — an adapter may read a SQLite store,
 //     a directory tree, etc. So discovery, change-detection, and resume cursoring
 //     are all adapter-owned and format-specific.

--- a/packaging/skill-README.md
+++ b/packaging/skill-README.md
@@ -1,7 +1,7 @@
 # Obelisk Skill
 
 Explicit memory infrastructure for coding agents — a queryable SQLite evidence
-layer over local Claude Code and Codex session history.
+layer over local Claude Code, Codex, Kimi Code, and Pi session history.
 
 ## Install with your agent (recommended)
 

--- a/skill-doc/SKILL.md
+++ b/skill-doc/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: obelisk
 description: >
-  Search and query past Claude Code and Codex session history.
+  Search and query past Claude Code, Codex, Kimi Code, and Pi session history.
   Reactive: when the user asks "how did I fix X", "what did we do last time", "find the session where", "上次怎么修的", "之前的session", "历史记录".
   Proactive: when the user references past work you lack context for, when you're about to modify a file with complex edit history, when the user says "继续之前的" or "continue where we left off", or when understanding prior decisions would improve your current response.
   Memory: when the user says "记住这个", "remember this", "写入记忆", "save this conclusion", or when you determine a retrieval result contains a conclusion worth persisting.
@@ -13,18 +13,20 @@ allowed-tools:
 
 # obelisk
 
-Search and query Claude Code and Codex session history stored in `~/.claude/`
-and `~/.codex/`.
+Search and query Claude Code, Codex, Kimi Code, and Pi session history from
+their configured local transcript roots. Defaults are `~/.claude/`, `~/.codex/`,
+`~/.kimi-code/`, and Pi's resolved sessions directory.
 Obelisk indexes sessions, messages, tool calls, tool results, summaries,
 subagents, workflows, workflow agents, parent chains, and raw JSONL lines into
 SQLite + FTS5.
 
-Obelisk has two transcript sources. Treat both as ordinary sessions by default:
-Claude rows use `source='claude'`; Codex rows use `source='codex'` and IDs
-prefixed with `codex:`. Use `source` only when provenance matters or the user
-asks to scope to one provider. Codex subagent child threads are mapped to the
-same `subagents` table; Codex workflow rows may be absent because Codex does not
-emit Claude-style workflow metadata.
+Obelisk has four transcript sources. Treat all as ordinary sessions by default:
+Claude rows use `source='claude'`; Codex, Kimi Code, and Pi rows use
+`source='codex'`, `source='kimi'`, and `source='pi'`, with provider-prefixed IDs.
+Use `source` only when provenance matters or the user asks to scope to one
+provider. Codex and Kimi can project child agents into `subagents`. Pi v1 support
+covers standard top-level v3 session files only and does not index deeper nested
+subagent run transcripts.
 
 Obelisk is a CodeAct memory layer: write a small JS query, run it locally, read
 the JSON, then answer. Do not turn history into a flat document or browse entire
@@ -180,8 +182,8 @@ identity. Results are already ordered by FTS5 rank; lower rank sorts earlier.
 Prefer returned order over manually interpreting numeric rank unless you are
 deliberately using FTS5 semantics.
 
-`source` can be `'claude'`, `'codex'`, or omitted. Omitted means search all
-indexed sources.
+`source` can be `'claude'`, `'codex'`, `'kimi'`, `'pi'`, or omitted. Omitted
+means search all indexed sources.
 
 ### `context(uuid)`
 

--- a/skill-doc/references/api-reference.md
+++ b/skill-doc/references/api-reference.md
@@ -57,7 +57,7 @@ Full-text search across all indexed message text using FTS5.
 | `opts.after` | `string` | ISO lower bound on message timestamp |
 | `opts.before` | `string` | ISO upper bound on message timestamp |
 | `opts.cwd` | `string` | SQL `LIKE` filter over `messages.cwd` |
-| `opts.source` | `string` | `"claude"`, `"codex"`, or omitted/all |
+| `opts.source` | `string` | `"claude"`, `"codex"`, `"kimi"`, `"pi"`, or omitted/all |
 | `opts.includeMeta` | `boolean` | Include `is_meta=1` rows, default false |
 
 Returns:
@@ -176,7 +176,7 @@ Returns:
     projects,
     sessions,
     memories,
-    sources: [{ source: 'claude' | 'codex', session_count, last_session_at }]
+    sources: [{ source: 'claude' | 'codex' | 'kimi' | 'pi', session_count, last_session_at }]
   }
 }
 ```
@@ -195,7 +195,7 @@ Session rows ordered by `ended_at` descending. Passing a number is treated as
 | `opts.before` | `string` | ISO upper bound on `started_at` |
 | `opts.limit` | `number` | Max rows, default 50 |
 | `opts.branch` | `string` | Exact git branch |
-| `opts.source` | `string` | `"claude"`, `"codex"`, or omitted/all |
+| `opts.source` | `string` | `"claude"`, `"codex"`, `"kimi"`, `"pi"`, or omitted/all |
 | `opts.sessionId` | `string` | Exact session ID |
 | `opts.sessions` | `string[]` | Restrict to session IDs |
 

--- a/skill-doc/references/retrieval-semantics.md
+++ b/skill-doc/references/retrieval-semantics.md
@@ -37,7 +37,7 @@ Project-like fields are distinct:
 - `memories.project`: stored project slug copied onto registered memory records.
 - `sessions.project_path`: absolute session path derived from message `cwd` when available; slug decoding is only a fallback.
 - `messages.cwd`: working directory at message time.
-- `sessions.source` / `messages.source`: transcript provider, currently `claude` or `codex`.
+- `sessions.source` / `messages.source`: transcript provider (`claude`, `codex`, `kimi`, or `pi`).
 - helper `project`: SQL `LIKE` over `sessions.project`, not exact membership.
 - helper `source`: optional provider filter. Omit it unless provenance matters.
 

--- a/skill-doc/references/schema.md
+++ b/skill-doc/references/schema.md
@@ -14,14 +14,17 @@ exist.
 
 ## Source Model
 
-Obelisk stores Claude Code and Codex transcripts in the same schema.
+Obelisk stores Claude Code, Codex, Kimi Code, and Pi transcripts in the same schema.
 
 - Claude rows use `source='claude'`.
 - Codex rows use `source='codex'`; root session and message IDs are prefixed
   with `codex:`.
+- Kimi Code rows use `source='kimi'` and `kimi:`-prefixed IDs.
+- Pi rows use `source='pi'` and `pi:`-prefixed IDs. Pi support currently covers
+  standard top-level v3 sessions, not deeper nested subagent run transcripts.
 - Omit `source` filters unless provider provenance matters.
-- Codex child threads are represented through `subagents`; Codex may not have
-  Claude-style workflow rows.
+- Codex and Kimi child agents are represented through `subagents`; provider
+  workflow rows may be absent when the source has no compatible metadata.
 
 ## Scope Fields
 
@@ -52,7 +55,7 @@ One row per root session.
 
 | Column | Meaning |
 | --- | --- |
-| `id` | Session ID (`codex:<thread-id>` for Codex roots) |
+| `id` | Provider-native session ID; Codex, Kimi, and Pi IDs are provider-prefixed |
 | `title` | AI/session title |
 | `project` | Provider-normalized project slug |
 | `project_path` | Absolute project path when known |
@@ -61,7 +64,7 @@ One row per root session.
 | `version` | Provider CLI/app version |
 | `message_count` | Indexed user + assistant messages |
 | `jsonl_path` | Source JSONL path |
-| `source` | `claude` or `codex` |
+| `source` | `claude`, `codex`, `kimi`, or `pi` |
 
 ### `messages`
 
@@ -84,7 +87,7 @@ Core evidence table.
 | `cwd` | Working directory at message time |
 | `skill` | Skill that generated the response, if known |
 | `turn_duration_ms` | Wall-clock duration for the turn |
-| `source` | `claude` or `codex` |
+| `source` | `claude`, `codex`, `kimi`, or `pi` |
 
 `content_type='tool_use'` is only a marker. Tool-call details live in
 `tool_calls`. `content_type='tool_result'` marks provider-emitted tool-result

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -263,6 +263,7 @@ test('main process watches every root declared by the built-in provider registry
       join(codexDir, 'session_index.jsonl'),
       join(home, '.kimi-code', 'sessions'),
       join(home, '.kimi-code', 'session_index.jsonl'),
+      join(home, '.pi', 'agent', 'sessions'),
     ]);
     assert.equal(serviceOptions[0].watchDirs.includes(codexDir), false);
   } finally {

--- a/tests/app-pi-index.test.mjs
+++ b/tests/app-pi-index.test.mjs
@@ -1,0 +1,62 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { buildIndex } from '../app/src/main/indexer.ts';
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require('node:sqlite');
+
+class TestDatabase {
+  constructor(dbPath) { this.db = new DatabaseSync(dbPath); }
+  pragma(statement) { this.db.exec(`PRAGMA ${statement}`); }
+  exec(sql) { return this.db.exec(sql); }
+  prepare(sql) { return this.db.prepare(sql); }
+  close() { return this.db.close(); }
+}
+
+test('app indexes configured Pi root sessions through the provider registry', () => {
+  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-pi-'));
+  const piRoot = join(home, 'pi-sessions');
+  const sessionPath = join(piRoot, '--tmp-app-pi--', 'fixture.jsonl');
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  mkdirSync(join(piRoot, '--tmp-app-pi--'), { recursive: true });
+  writeFileSync(sessionPath, [
+    { type: 'session', version: 3, id: 'app-pi-session', timestamp: '2026-07-20T10:00:00.000Z', cwd: '/tmp/app-pi' },
+    { type: 'message', id: 'user1', parentId: null, timestamp: '2026-07-20T10:00:01.000Z', message: { role: 'user', content: 'app Pi index needle' } },
+  ].map((entry) => JSON.stringify(entry)).join('\n') + '\n');
+
+  const first = buildIndex({
+    claudeDir: join(home, 'empty-claude'),
+    codexDir: join(home, 'empty-codex'),
+    providerRoots: {
+      kimi: join(home, 'empty-kimi'),
+      pi: piRoot,
+    },
+    dbPath,
+    DatabaseImpl: TestDatabase,
+  });
+  assert.deepEqual(first.affectedSessionIds, ['pi:app-pi-session']);
+
+  const db = new TestDatabase(dbPath);
+  assert.deepEqual(
+    db.prepare('SELECT id,title,source,message_count FROM sessions').all().map((row) => ({ ...row })),
+    [{ id: 'pi:app-pi-session', title: 'app Pi index needle', source: 'pi', message_count: 1 }],
+  );
+  assert.equal(db.prepare('SELECT text FROM messages').get().text, 'app Pi index needle');
+  const schema = db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='messages'").get().sql;
+  assert.doesNotMatch(schema, /\bpi\b/i);
+  db.close();
+
+  const second = buildIndex({
+    claudeDir: join(home, 'empty-claude'),
+    codexDir: join(home, 'empty-codex'),
+    providerRoots: { kimi: join(home, 'empty-kimi'), pi: piRoot },
+    dbPath,
+    DatabaseImpl: TestDatabase,
+  });
+  assert.deepEqual(second.affectedSessionIds, []);
+});

--- a/tests/pi-parse.test.mjs
+++ b/tests/pi-parse.test.mjs
@@ -1,0 +1,372 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import {
+  createPiProvider,
+  defaultPiSessionsRoot,
+} from '../packages/core/src/providers/pi.ts';
+import { persist } from '../packages/core/src/persist.ts';
+import { createQueryApi } from '../packages/core/src/query.ts';
+import { createProviderRegistry } from '../packages/core/src/providers/registry.ts';
+import { assembleSessionDetail } from '../packages/core/src/session-detail.ts';
+
+const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+
+function drain(generator) {
+  const values = [];
+  let step = generator.next();
+  while (!step.done) {
+    values.push(step.value);
+    step = generator.next();
+  }
+  return { values, cursor: step.value };
+}
+
+function coreFixture({ explicitTitle = true, torn = false, firstUserText = 'Inspect the Pi fixture' } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'obelisk-pi-'));
+  const projectDir = join(root, '--tmp-pi-project--');
+  const path = join(projectDir, '2026-07-20T10-00-00_session-native.jsonl');
+  mkdirSync(projectDir, { recursive: true });
+  const entries = [
+    { type: 'session', version: 3, id: 'session-native', timestamp: '2026-07-20T10:00:00.000Z', cwd: '/tmp/pi-project' },
+    { type: 'message', id: 'u1', parentId: null, timestamp: '2026-07-20T10:00:01.000Z', message: {
+      role: 'user', content: [
+        { type: 'text', text: firstUserText },
+        { type: 'image', data: 'BASE64_SHOULD_NOT_BE_INDEXED', mimeType: 'image/png' },
+      ], timestamp: 1784541601000,
+    } },
+    { type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-07-20T10:00:02.000Z', message: {
+      role: 'assistant', model: 'model-one', provider: 'test', api: 'messages',
+      content: [
+        { type: 'thinking', thinking: 'I should read it' },
+        { type: 'toolCall', id: 'call-read', name: 'read', arguments: { path: '/tmp/pi-project/source.ts' } },
+        { type: 'text', text: 'Read complete' },
+      ],
+      usage: { input: 10, output: 4, cacheRead: 2, cacheWrite: 3, totalTokens: 19 },
+      stopReason: 'stop', timestamp: 1784541602000,
+    } },
+    { type: 'message', id: 'r1', parentId: 'a1', timestamp: '2026-07-20T10:00:03.000Z', message: {
+      role: 'toolResult', toolCallId: 'call-read', toolName: 'read',
+      content: [{ type: 'text', text: 'export const value = 1;' }, { type: 'image', data: 'RESULT_BASE64', mimeType: 'image/png' }],
+      isError: true, timestamp: 1784541603000,
+    } },
+    { type: 'model_change', id: 'model2', parentId: 'r1', timestamp: '2026-07-20T10:00:04.000Z', provider: 'test', modelId: 'model-two' },
+    { type: 'message', id: 'side-u', parentId: 'u1', timestamp: '2026-07-20T10:00:05.000Z', message: { role: 'user', content: 'abandoned branch' } },
+    { type: 'message', id: 'side-a', parentId: 'side-u', timestamp: '2026-07-20T10:00:06.000Z', message: { role: 'assistant', model: 'side-model', content: [{ type: 'text', text: 'side answer' }], usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 } } },
+    { type: 'branch_summary', id: 'branch-sum', parentId: 'side-a', timestamp: '2026-07-20T10:00:07.000Z', fromId: 'side-a', summary: 'The abandoned branch tried another approach.' },
+    { type: 'compaction', id: 'compact', parentId: 'model2', timestamp: '2026-07-20T10:00:08.000Z', summary: 'Earlier active work was compacted.', firstKeptEntryId: 'r1', tokensBefore: 50000 },
+    { type: 'custom_message', id: 'hidden-custom', parentId: 'compact', timestamp: '2026-07-20T10:00:09.000Z', customType: 'fixture-extension', content: [
+      { type: 'text', text: 'extension-only context' },
+      { type: 'image', data: 'CUSTOM_BASE64', mimeType: 'image/png' },
+    ], display: false },
+    { type: 'message', id: 'bash1', parentId: 'hidden-custom', timestamp: '2026-07-20T10:00:10.000Z', message: {
+      role: 'bashExecution', command: 'pwd', output: '/tmp/pi-project', exitCode: 0, cancelled: false, truncated: false,
+    } },
+    { type: 'message', id: 'u2', parentId: 'bash1', timestamp: '2026-07-20T10:00:11.000Z', message: { role: 'user', content: 'Continue on the active branch' } },
+    ...(explicitTitle ? [{ type: 'session_info', id: 'info1', parentId: 'u2', timestamp: '2026-07-20T10:00:12.000Z', name: 'Explicit Pi fixture title' }] : []),
+  ];
+  const complete = `${entries.map((entry) => JSON.stringify(entry)).join('\n')}\n`;
+  writeFileSync(path, torn ? `${complete}{"type":"message","id":"torn"` : complete);
+
+  const nestedDir = join(projectDir, 'session-native', 'subagents', 'run-1');
+  mkdirSync(nestedDir, { recursive: true });
+  writeFileSync(join(nestedDir, 'session.jsonl'), `${JSON.stringify({
+    type: 'session', version: 3, id: 'nested-run', timestamp: '2026-07-20T10:00:00.000Z', cwd: '/tmp/pi-project',
+  })}\n`);
+  return { root, path, entries };
+}
+
+test('Pi default session root follows documented environment and global-setting precedence', () => {
+  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-home-'));
+  const cwd = join(home, 'work');
+  const agentDir = join(home, 'agent-home');
+  mkdirSync(agentDir, { recursive: true });
+  writeFileSync(join(agentDir, 'settings.json'), JSON.stringify({ sessionDir: '~/custom-pi-sessions' }));
+
+  assert.equal(defaultPiSessionsRoot({
+    env: { PI_CODING_AGENT_SESSION_DIR: './env-sessions', PI_CODING_AGENT_DIR: agentDir }, home, cwd,
+  }), join(cwd, 'env-sessions'));
+  assert.equal(defaultPiSessionsRoot({ env: { PI_CODING_AGENT_DIR: agentDir }, home, cwd }), join(home, 'custom-pi-sessions'));
+  assert.equal(defaultPiSessionsRoot({ env: {}, home, cwd }), join(home, '.pi', 'agent', 'sessions'));
+  assert.equal(createPiProvider({ rootDir: '/configured/pi/sessions' }).descriptor.defaultRoot, '/configured/pi/sessions');
+});
+
+test('Pi discovery includes only root session JSONL, honors changedPaths, and uses a stable numeric cursor', () => {
+  const { root, path } = coreFixture();
+  const provider = createPiProvider({ rootDir: root });
+  const initial = provider.discover({ lastCursor: () => null });
+
+  assert.equal(initial.length, 1, 'nested subagent run session.jsonl is excluded in v1');
+  assert.equal(initial[0].key, path);
+  assert.equal(initial[0].sessionId, 'pi:session-native');
+  assert.equal(initial[0].project, '-tmp-pi-project');
+
+  const observedMtime = statSync(path).mtimeMs;
+  const storedCursorWithDifferentLineCount = `${observedMtime}:999999`;
+  assert.deepEqual(provider.discover({ lastCursor: () => storedCursorWithDifferentLineCount }), [],
+    'unchanged discovery compares mtime before reading or counting transcript lines');
+  assert.deepEqual(provider.discover({
+    lastCursor: () => storedCursorWithDifferentLineCount,
+    changedPaths: [path],
+  }).map((unit) => unit.key), [path], 'explicit changed paths force replay even when mtime matches');
+  assert.deepEqual(provider.discover({
+    lastCursor: () => null,
+    changedPaths: [join(root, '--tmp-pi-project--', 'session-native', 'subagents', 'run-1', 'session.jsonl')],
+  }), []);
+  assert.deepEqual(provider.watchRoots('/configured/root'), ['/configured/root']);
+});
+
+test('Pi full replay emits canonical namespaced tree, block, model, usage, tool, summary, and metadata records', () => {
+  const { root } = coreFixture({ torn: true });
+  const provider = createPiProvider({ rootDir: root });
+  const unit = provider.discover({ lastCursor: () => null })[0];
+  const { values, cursor } = drain(provider.parse(unit, '0:999'));
+  const byKind = (kind) => values.filter((record) => record.kind === kind);
+
+  assert.deepEqual(values[0], { kind: 'delete-session', sessionId: 'pi:session-native' });
+  assert.equal(values.at(-1).kind, 'session');
+  assert.match(cursor, /^\d+(?:\.\d+)?:\d+$/);
+  assert.equal(cursor.split(':')[1], '14', 'cursor counts the ignored torn physical line');
+
+  const session = byKind('session')[0];
+  assert.deepEqual({
+    id: session.id, title: session.title, project: session.project, version: session.version,
+    git_branch: session.git_branch, source: session.source, countMode: session.countMode,
+  }, {
+    id: 'pi:session-native', title: 'Explicit Pi fixture title', project: '-tmp-pi-project',
+    version: '3', git_branch: null, source: 'pi', countMode: 'total',
+  });
+
+  const messages = byKind('message');
+  assert.ok(messages.every((message) => message.uuid.startsWith('pi:')));
+  assert.equal(new Set(messages.map((message) => message.uuid)).size, messages.length);
+  assert.deepEqual(
+    messages.filter((message) => ['I should read it', null, 'Read complete'].includes(message.text))
+      .map((message) => [message.content_type, message.text]),
+    [['thinking', 'I should read it'], ['tool_use', null], ['text', 'Read complete']],
+  );
+  const assistantParts = messages.filter((message) => message.uuid.includes(':message:a1:'));
+  assert.deepEqual(assistantParts.map((message) => [message.input_tokens, message.output_tokens]), [
+    [null, null], [null, null], [15, 4],
+  ]);
+  assert.equal(messages.find((message) => message.text === 'Continue on the active branch').model, 'model-two');
+  assert.equal(messages.find((message) => message.text === 'abandoned branch').is_sidechain, 1);
+  assert.equal(messages.find((message) => message.text === 'side answer').is_sidechain, 1);
+  assert.equal(messages.find((message) => message.text === 'Continue on the active branch').is_sidechain, 0);
+  assert.equal(
+    messages.find((message) => message.text === 'export const value = 1;').parent_uuid,
+    'pi:session-native:message:a1:2',
+    'entry parent maps to the final canonical message emitted by its ancestor',
+  );
+  const bash = messages.find((message) => message.type === 'bashExecution');
+  assert.equal(bash.text, '$ pwd\n/tmp/pi-project');
+  assert.equal(bash.parent_uuid, 'pi:session-native:message:hidden-custom:0');
+
+  const hidden = messages.find((message) => message.text === 'extension-only context');
+  assert.equal(hidden.is_meta, 1);
+  assert.equal(hidden.visibility, 'hidden');
+  assert.equal(JSON.stringify(messages).includes('BASE64'), false);
+
+  assert.deepEqual(byKind('tool_call').map((record) => ({
+    id: record.id, name: record.name, path: record.file_path,
+  })), [{ id: 'pi:session-native:tool:call-read', name: 'read', path: '/tmp/pi-project/source.ts' }]);
+  assert.deepEqual(byKind('tool_result').map((record) => ({
+    id: record.tool_use_id, content: record.content, path: record.file_path, error: record.is_error,
+  })), [{
+    id: 'pi:session-native:tool:call-read', content: 'export const value = 1;',
+    path: '/tmp/pi-project/source.ts', error: 1,
+  }]);
+  assert.deepEqual(byKind('summary').map((record) => [record.id, record.source, record.content]), [
+    ['pi:session-native:summary:branch-sum:branch_summary', 'branch_summary', 'The abandoned branch tried another approach.'],
+    ['pi:session-native:summary:compact:compaction', 'compaction', 'Earlier active work was compacted.'],
+  ]);
+
+  const detail = assembleSessionDetail(values);
+  assert.equal(detail.session.id, 'pi:session-native');
+  assert.equal(detail.messages.some((message) => message.text === 'extension-only context'), false);
+  const toolMessage = detail.messages.find((message) => message.tool_calls?.length);
+  assert.equal(toolMessage.tool_calls[0].result.content, 'export const value = 1;');
+});
+
+test('Pi title falls back to bounded first real user text and raw lookup projects no image data', () => {
+  const firstUserText = 'Inspect the Pi fixture ' + 'x'.repeat(220);
+  const { root, path } = coreFixture({ explicitTitle: false, firstUserText });
+  const provider = createPiProvider({ rootDir: root });
+  const unit = provider.discover({ lastCursor: () => null })[0];
+  const { values } = drain(provider.parse(unit, null));
+  const session = values.find((record) => record.kind === 'session');
+  const firstUser = values.find((record) => record.kind === 'message' && record.text === firstUserText);
+
+  assert.equal(session.title, firstUserText.slice(0, 200));
+  const raw = provider.raw({
+    source: 'pi', messageUuid: firstUser.uuid, session: { jsonl_path: path }, agentId: null,
+  });
+  assert.equal(raw.messageText, firstUserText);
+  assert.ok(raw.text.includes('BASE64_SHOULD_NOT_BE_INDEXED'), 'raw returns the original source line');
+  assert.equal(raw.messageText.includes('BASE64'), false, 'projected expansion omits image payloads');
+});
+
+test('Pi full replay deletes stale persisted rows and round-trips through canonical session detail', () => {
+  const { root, path, entries } = coreFixture();
+  const provider = createPiProvider({ rootDir: root });
+  const unit = provider.discover({ lastCursor: () => null })[0];
+  const firstRecords = drain(provider.parse(unit, null)).values;
+  const direct = assembleSessionDetail(firstRecords);
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  persist(db, unit, provider.parse(unit, null));
+
+  const persisted = assembleSessionDetail({
+    session: db.prepare('SELECT * FROM sessions').get(),
+    messages: db.prepare('SELECT * FROM messages ORDER BY timestamp, uuid').all(),
+    toolCalls: db.prepare('SELECT * FROM tool_calls').all(),
+    toolResults: db.prepare('SELECT * FROM tool_results').all(),
+    summaries: db.prepare('SELECT * FROM summaries').all(),
+  });
+  assert.deepEqual(persisted, direct);
+  assert.equal(db.prepare("SELECT COUNT(*) AS c FROM messages WHERE text = 'side answer'").get().c, 1);
+  const userUuid = firstRecords.find((record) => record.kind === 'message' && record.text === 'Inspect the Pi fixture').uuid;
+  const boundedRaw = createQueryApi(db, {
+    providerRegistry: createProviderRegistry([provider]),
+  }).raw(userUuid, { offset: 0, limit: 40 });
+  assert.equal(boundedRaw.text.length, 40);
+  assert.equal(boundedRaw.hasMore, true);
+
+  const retained = entries.filter((entry) => !['side-u', 'side-a', 'branch-sum'].includes(entry.id));
+  writeFileSync(path, `${retained.map((entry) => JSON.stringify(entry)).join('\n')}\n`);
+  persist(db, unit, provider.parse(unit, '1:1'));
+
+  assert.equal(db.prepare("SELECT COUNT(*) AS c FROM messages WHERE text = 'side answer'").get().c, 0);
+  assert.equal(db.prepare("SELECT COUNT(*) AS c FROM summaries WHERE source = 'branch_summary'").get().c, 0);
+  assert.equal(db.prepare('SELECT message_count FROM sessions WHERE id = ?').get('pi:session-native').message_count,
+    retained.filter((entry) => entry.type === 'message' || entry.type === 'custom_message').reduce((count, entry) => {
+      if (entry.type === 'custom_message') return count + 1;
+      if (entry.message.role === 'assistant') return count + entry.message.content.length;
+      return count + 1;
+    }, 0));
+  db.close();
+});
+
+test('Pi assistant errorMessage is always a stable trailing canonical part and supports raw expansion', () => {
+  const { root, path } = coreFixture();
+  const entries = readFileSync(path, 'utf8').trimEnd().split('\n').map((line) => JSON.parse(line));
+  entries.push({
+    type: 'message', id: 'assistant-error', parentId: 'info1', timestamp: '2026-07-20T10:00:13.000Z',
+    message: {
+      role: 'assistant', model: 'model-two',
+      content: [
+        { type: 'thinking', thinking: 'partial reasoning' },
+        { type: 'text', text: 'partial answer' },
+        { type: 'toolCall', id: 'call-before-error', name: 'read', arguments: { path: '/tmp/pi-project/missing.ts' } },
+      ],
+      errorMessage: 'provider failed after partial output',
+      usage: { input: 7, output: 2 },
+    },
+  });
+  writeFileSync(path, `${entries.map((entry) => JSON.stringify(entry)).join('\n')}\n`);
+
+  const provider = createPiProvider({ rootDir: root });
+  const unit = provider.discover({ lastCursor: () => null })[0];
+  const { values } = drain(provider.parse(unit, null));
+  const parts = values.filter((record) => record.kind === 'message' && record.uuid.includes(':message:assistant-error:'));
+  assert.deepEqual(parts.map(({ uuid, content_type, text }) => ({ uuid, content_type, text })), [
+    { uuid: 'pi:session-native:message:assistant-error:0', content_type: 'thinking', text: 'partial reasoning' },
+    { uuid: 'pi:session-native:message:assistant-error:1', content_type: 'text', text: 'partial answer' },
+    { uuid: 'pi:session-native:message:assistant-error:2', content_type: 'tool_use', text: null },
+    { uuid: 'pi:session-native:message:assistant-error:3', content_type: 'text', text: 'provider failed after partial output' },
+  ]);
+  assert.deepEqual(parts.map(({ input_tokens, output_tokens }) => [input_tokens, output_tokens]), [
+    [null, null], [null, null], [null, null], [7, 2],
+  ]);
+
+  const raw = provider.raw({
+    source: 'pi', messageUuid: parts.at(-1).uuid, session: { jsonl_path: path }, agentId: null,
+  });
+  assert.equal(raw.messageText, 'provider failed after partial output');
+  assert.equal(JSON.parse(raw.text).id, 'assistant-error');
+});
+
+test('Pi latest session_info explicitly sets or clears replay title', () => {
+  const { root, path } = coreFixture({ explicitTitle: false });
+  const base = readFileSync(path, 'utf8').trimEnd().split('\n').map((line) => JSON.parse(line));
+  base.push(
+    { type: 'session_info', id: 'old-info', parentId: 'u2', name: 'Older title' },
+    { type: 'session_info', id: 'clear-info', parentId: 'old-info', name: '   \t ' },
+  );
+  writeFileSync(path, `${base.map((entry) => JSON.stringify(entry)).join('\n')}\n`);
+  const provider = createPiProvider({ rootDir: root });
+  const unit = provider.discover({ lastCursor: () => null })[0];
+  let replay = drain(provider.parse(unit, null)).values;
+  assert.equal(replay.find((record) => record.kind === 'session').title, null,
+    'latest whitespace name clears both an older name and first-prompt fallback');
+
+  base.push({ type: 'session_info', id: 'new-info', parentId: 'clear-info', name: '  Latest title  ' });
+  writeFileSync(path, `${base.map((entry) => JSON.stringify(entry)).join('\n')}\n`);
+  replay = drain(provider.parse(unit, null)).values;
+  assert.equal(replay.find((record) => record.kind === 'session').title, 'Latest title');
+});
+
+test('Pi bash execution text preserves failure, cancellation, and truncation status without noisy success metadata', () => {
+  const { root, path } = coreFixture();
+  const entries = readFileSync(path, 'utf8').trimEnd().split('\n').map((line) => JSON.parse(line));
+  entries.push(
+    { type: 'message', id: 'bash-failed', parentId: 'info1', message: {
+      role: 'bashExecution', command: 'false', output: '', exitCode: 17, cancelled: false, truncated: false,
+    } },
+    { type: 'message', id: 'bash-signals', parentId: 'bash-failed', message: {
+      role: 'bashExecution', command: 'long-job', output: 'partial', exitCode: 130, cancelled: true, truncated: true,
+    } },
+  );
+  writeFileSync(path, `${entries.map((entry) => JSON.stringify(entry)).join('\n')}\n`);
+  const provider = createPiProvider({ rootDir: root });
+  const values = drain(provider.parse(provider.discover({ lastCursor: () => null })[0], null)).values;
+  const bash = new Map(values.filter((record) => record.kind === 'message' && record.type === 'bashExecution')
+    .map((record) => [record.uuid, record.text]));
+  assert.equal(bash.get('pi:session-native:message:bash1:0'), '$ pwd\n/tmp/pi-project');
+  assert.equal(bash.get('pi:session-native:message:bash-failed:0'), '$ false\n[exit code: 17]');
+  assert.equal(bash.get('pi:session-native:message:bash-signals:0'),
+    '$ long-job\npartial\n[exit code: 130]\n[cancelled]\n[output truncated]');
+});
+
+test('Pi parser rejects self and cyclic cwd ancestry before yielding delete-session', () => {
+  for (const { label, entries } of [
+    {
+      label: 'self parent',
+      entries: [{ type: 'message', id: 'self', parentId: 'self', message: { role: 'user', content: 'self' } }],
+    },
+    {
+      label: 'two-entry cycle',
+      entries: [
+        { type: 'message', id: 'cycle-a', parentId: 'cycle-b', message: { role: 'user', content: 'a' } },
+        { type: 'message', id: 'cycle-b', parentId: 'cycle-a', message: { role: 'assistant', content: [{ type: 'text', text: 'b' }] } },
+      ],
+    },
+  ]) {
+    const root = mkdtempSync(join(tmpdir(), 'obelisk-pi-cycle-'));
+    const projectDir = join(root, 'project');
+    const path = join(projectDir, 'cycle.jsonl');
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(path, [
+      { type: 'session', version: 3, id: `cycle-${label}`, cwd: '/tmp/pi-cycle' },
+      ...entries,
+    ].map((entry) => JSON.stringify(entry)).join('\n') + '\n');
+    const provider = createPiProvider({ rootDir: root });
+    const generator = provider.parse(provider.discover({ lastCursor: () => null })[0], null);
+    assert.throws(() => generator.next(), /Pi session: corrupted cwd ancestry cycle involving entry .*cycle\.jsonl/, label);
+  }
+});
+
+test('Pi parser rejects malformed complete interior lines but ignores only a torn final line', () => {
+  const { root, path } = coreFixture();
+  writeFileSync(path, `${readFileSync(path, 'utf8')}{bad json}\n${JSON.stringify({
+    type: 'message', id: 'after-bad', parentId: null, timestamp: '2026-07-20T11:00:00.000Z', message: { role: 'user', content: 'after' },
+  })}\n`);
+  const provider = createPiProvider({ rootDir: root });
+  const unit = { key: path, sessionId: 'pi:session-native' };
+
+  assert.throws(() => drain(provider.parse(unit, null)), /corrupted line/);
+});

--- a/tests/pi-runtime.test.mjs
+++ b/tests/pi-runtime.test.mjs
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runCli } from './cli-test-helpers.mjs';
+
+test('passive-pull runtime indexes Pi sessions from the default home', () => {
+  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-runtime-'));
+  const sessionDir = join(home, '.pi', 'agent', 'sessions', '--tmp-runtime-pi--');
+  const sessionPath = join(sessionDir, '2026-07-20T10-00-00_runtime-pi.jsonl');
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(sessionPath, [
+    { type: 'session', version: 3, id: 'runtime-pi', timestamp: '2026-07-20T10:00:00.000Z', cwd: '/tmp/runtime-pi' },
+    { type: 'message', id: 'runtime-user', parentId: null, timestamp: '2026-07-20T10:00:01.000Z', message: { role: 'user', content: 'runtime pi needle' } },
+    { type: 'session_info', id: 'runtime-info', parentId: 'runtime-user', timestamp: '2026-07-20T10:00:02.000Z', name: 'Runtime Pi session' },
+    '',
+  ].map((entry) => typeof entry === 'string' ? entry : JSON.stringify(entry)).join('\n'));
+
+  const queryPath = join(home, 'query.mjs');
+  writeFileSync(queryPath, "return sessions({ source: 'pi', limit: 5 });");
+  const run = runCli(['--query', queryPath], {
+    home,
+    env: {
+      PI_CODING_AGENT_DIR: '',
+      PI_CODING_AGENT_SESSION_DIR: '',
+    },
+  });
+
+  assert.equal(run.status, 0, run.stderr);
+  const sessions = JSON.parse(run.stdout);
+  assert.deepEqual(sessions.map(({ id, title, source }) => ({ id, title, source })), [{
+    id: 'pi:runtime-pi',
+    title: 'Runtime Pi session',
+    source: 'pi',
+  }]);
+});

--- a/tests/provider-registry.test.mjs
+++ b/tests/provider-registry.test.mjs
@@ -61,12 +61,14 @@ test('built-in provider registry exposes every source without caller-side branch
     claude: '/sources/claude',
     codex: '/sources/codex',
     kimi: '/sources/kimi',
+    pi: '/sources/pi-sessions',
   });
 
   assert.deepEqual(registry.catalog().map(({ id, name }) => ({ id, name })), [
     { id: 'claude', name: 'Claude Code' },
     { id: 'codex', name: 'Codex' },
     { id: 'kimi', name: 'Kimi Code' },
+    { id: 'pi', name: 'Pi' },
   ]);
   assert.deepEqual(registry.watchRoots(), [
     '/sources/claude/projects',
@@ -75,5 +77,6 @@ test('built-in provider registry exposes every source without caller-side branch
     '/sources/codex/session_index.jsonl',
     '/sources/kimi/sessions',
     '/sources/kimi/session_index.jsonl',
+    '/sources/pi-sessions',
   ]);
 });


### PR DESCRIPTION
## Summary

- add a registry-driven `pi` provider for standard Pi coding-agent v3 session JSONL
- project Pi trees into canonical messages, thinking, tool calls/results, summaries, metadata, usage, and sidechains
- resolve Pi session roots from `PI_CODING_AGENT_SESSION_DIR`, `PI_CODING_AGENT_DIR`, global `settings.json`, or the default `~/.pi/agent/sessions`
- add app and passive-pull CLI integration coverage
- update provider catalogs, package exports, skill references, and user documentation

## Implementation notes

- Pi IDs are provider-namespaced to avoid cross-source collisions.
- Modified sessions use tree-aware full replay with transactional `delete-session` cleanup and `countMode: 'total'`.
- Unchanged discovery checks file metadata before reading transcript contents.
- Image payloads are omitted from indexed/projected text; raw lookup remains bounded by the existing query API.
- Synthetic fixtures cover branching, parent causality, model state, mixed thinking/text/tool content, tool errors and file paths, usage, compaction and branch summaries, custom metadata, title fallback/clear semantics, bash status, torn writes, corrupt ancestry, replay cleanup, and raw lookup.

## Scope

This first version intentionally indexes only standard top-level files shaped `<project-dir>/<session>.jsonl`. Deeper nested Pi subagent run `session.jsonl` transcripts are excluded and documented for a follow-up.

Deleted-source reconciliation and recovery of provider roots created after app startup retain the current cross-provider behavior and are not patched with Pi-specific workarounds here.

## Validation

- `npm run typecheck`
- `npm run lint` — 0 errors; 4 pre-existing warnings
- `npm test` — 287/287 passing
- `npm run build:core`
- `npm run build:cli`
- focused Pi parser, app indexer, registry, session-detail, raw-query, and packaged CLI tests
- `git diff --check`
