### PR TITLE
[Sessions] Render Markdown images within message bounds

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -20,6 +20,7 @@
     "generate:session-share": "node scripts/generate-session-share.mjs",
     "verify:icons": "node scripts/verify-icons.mjs",
     "test:electron": "electron-vite build && electron --no-sandbox tests/electron-concurrency.mjs",
+    "test:electron:images": "electron-vite build && electron --no-sandbox tests/electron-session-images.mjs",
     "test:electron:timeline": "electron-vite build && electron --no-sandbox tests/electron-session-virtualization.mjs",
     "test:electron:reader-state": "electron-vite build && electron --no-sandbox tests/electron-session-reader-state.mjs"
   },

--- a/app/src/renderer/src/components/SessionImage.ce.vue
+++ b/app/src/renderer/src/components/SessionImage.ce.vue
@@ -1,0 +1,94 @@
+<script setup>
+import { computed, ref } from 'vue';
+
+defineOptions({ name: 'SessionImage' });
+
+const props = defineProps({
+  src: { type: String, required: true },
+  alt: { type: String, default: '' },
+  title: { type: String, default: '' },
+});
+
+const status = ref('loading');
+const accessibleLabel = computed(() => props.alt || props.title || 'Session image');
+
+function handleLoad() {
+  status.value = 'loaded';
+}
+
+function handleError() {
+  status.value = 'error';
+}
+</script>
+
+<template>
+  <figure
+    class="session-image"
+    :class="`is-${status}`"
+    :aria-busy="status === 'loading' ? 'true' : undefined"
+  >
+    <img
+      v-if="status !== 'error'"
+      :src="src"
+      :alt="alt"
+      :title="title || undefined"
+      loading="lazy"
+      decoding="async"
+      @load="handleLoad"
+      @error="handleError"
+    >
+    <figcaption v-else role="status">
+      <span>Image unavailable</span>
+      <span v-if="accessibleLabel" class="image-label">{{ accessibleLabel }}</span>
+    </figcaption>
+  </figure>
+</template>
+
+<style>
+:host {
+  display: block;
+  max-inline-size: 100%;
+  min-inline-size: 0;
+  margin: 0.7em 0;
+  contain: inline-size;
+}
+
+.session-image {
+  max-inline-size: 100%;
+  min-inline-size: 0;
+  margin: 0;
+  overflow: clip;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.22);
+}
+
+img {
+  display: block;
+  inline-size: auto;
+  max-inline-size: 100%;
+  block-size: auto;
+  max-block-size: min(70vh, 720px);
+  object-fit: contain;
+  color: rgba(255, 255, 255, 0.48);
+}
+
+.is-loading {
+  min-block-size: 48px;
+}
+
+figcaption {
+  display: flex;
+  min-block-size: 48px;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 12px;
+  color: rgba(255, 255, 255, 0.48);
+  font: 12px/1.5 ui-monospace, 'SF Mono', Menlo, monospace;
+}
+
+.image-label::before {
+  content: '·';
+  margin-inline-end: 6px;
+}
+</style>

--- a/app/src/renderer/src/main.js
+++ b/app/src/renderer/src/main.js
@@ -6,6 +6,7 @@ import router from './router.js';
 import { commitInitialData, fetchInitialData } from './data.js';
 import { noteSessionUpdated, sessionLiveState } from './session-live.mjs';
 import { createGlobalDataRefreshCoordinator } from './session-global-refresh.mjs';
+import { registerSessionImageElement } from './session-image-element.js';
 
 // Import shared renderer CSS globally
 import '../styles/base.css';
@@ -13,6 +14,8 @@ import '../styles/sidebar.css';
 import '../styles/toolbar.css';
 import '../styles/list.css';
 import '../styles/detail.css';
+
+registerSessionImageElement();
 
 const app = createApp(App);
 

--- a/app/src/renderer/src/markdown-image-renderer.js
+++ b/app/src/renderer/src/markdown-image-renderer.js
@@ -1,0 +1,50 @@
+import { SESSION_IMAGE_TAG } from './session-image-element.js';
+
+const SAFE_IMAGE_PROTOCOLS = new Set(['blob:', 'file:', 'http:', 'https:']);
+let configuredMarked = null;
+
+function decodeMarkedAttribute(value) {
+  const decoder = document.createElement('textarea');
+  decoder.innerHTML = String(value ?? '');
+  return decoder.value;
+}
+
+function isSafeImageSource(source) {
+  try {
+    const url = new URL(source, document.baseURI);
+    return SAFE_IMAGE_PROTOCOLS.has(url.protocol)
+      || (url.protocol === 'data:' && /^data:image\//i.test(source));
+  } catch {
+    return false;
+  }
+}
+
+function imageFallback(alt) {
+  const fallback = document.createElement('span');
+  fallback.className = 'session-image-fallback';
+  fallback.textContent = alt || 'Image unavailable';
+  return fallback.outerHTML;
+}
+
+export function renderSessionMarkdownImage(href, title, text) {
+  const source = decodeMarkedAttribute(href).trim();
+  const alt = decodeMarkedAttribute(text);
+  const accessibleTitle = decodeMarkedAttribute(title);
+  if (!source || !isSafeImageSource(source)) return imageFallback(alt);
+
+  const image = document.createElement(SESSION_IMAGE_TAG);
+  image.setAttribute('src', source);
+  image.setAttribute('alt', alt);
+  if (accessibleTitle) image.setAttribute('title', accessibleTitle);
+  return image.outerHTML;
+}
+
+export function configureMarkdownImages(marked) {
+  if (!marked || configuredMarked === marked) return;
+  marked.use({
+    renderer: {
+      image: renderSessionMarkdownImage,
+    },
+  });
+  configuredMarked = marked;
+}

--- a/app/src/renderer/src/session-image-element.js
+++ b/app/src/renderer/src/session-image-element.js
@@ -1,0 +1,9 @@
+import { defineCustomElement } from 'vue';
+import SessionImage from './components/SessionImage.ce.vue';
+
+export const SESSION_IMAGE_TAG = 'obelisk-session-image';
+
+export function registerSessionImageElement() {
+  if (customElements.get(SESSION_IMAGE_TAG)) return;
+  customElements.define(SESSION_IMAGE_TAG, defineCustomElement(SessionImage));
+}

--- a/app/src/renderer/src/utils.js
+++ b/app/src/renderer/src/utils.js
@@ -2,6 +2,7 @@
 // Pure helpers with no side-effects on global state (except formatProjectLabel which reads store).
 
 import { state } from './store.js';
+import { configureMarkdownImages } from './markdown-image-renderer.js';
 
 // --- Time / formatting ---
 
@@ -95,6 +96,7 @@ export function highlightTextNodes(rootEl, query) {
 export function renderMarkdown(text, opts = {}) {
   if (text == null) return '';
   // marked is loaded globally via CDN in index.html
+  configureMarkdownImages(window.marked);
   const html = sanitizeMarkdown(window.marked.parse(text));
   const cls = opts.variant === 'msg' ? 'markdown-msg'
             : opts.variant === 'compact' ? 'markdown-compact'

--- a/app/src/renderer/styles/detail.css
+++ b/app/src/renderer/styles/detail.css
@@ -363,6 +363,20 @@
 .markdown-msg th, .markdown-msg td { border: 1px solid var(--hairline); padding: 5px 9px; text-align: left; }
 .markdown-msg th { background: rgba(255,255,255,0.04); font-weight: 600; }
 .markdown-msg mark { background: var(--accent-soft); color: var(--accent-2); padding: 0 2px; border-radius: 2px; }
+.session-image-fallback {
+  display: block;
+  max-width: 100%;
+  margin: 0.7em 0;
+  padding: 10px 12px;
+  overflow: hidden;
+  border: 1px solid var(--hairline-strong);
+  border-radius: 6px;
+  color: var(--muted);
+  background: rgba(0,0,0,0.22);
+  font: 12px/1.5 var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 .detail-section-divider {
   display: flex; align-items: center; gap: 10px;

--- a/app/tests/electron-session-images.mjs
+++ b/app/tests/electron-session-images.mjs
@@ -1,0 +1,290 @@
+import { app, BrowserWindow, ipcMain } from 'electron';
+import { createServer } from 'node:http';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appRoot = join(here, '..');
+const sessionId = 'session-image-test';
+const channels = [
+  'db:getSessions',
+  'db:getSessionMessages',
+  'db:getSessionToolCalls',
+  'db:getSessionToolResults',
+  'db:getSessionSubagents',
+  'db:getSessionWorkflows',
+  'db:getSessionSummaries',
+  'db:getMemories',
+  'db:getProjects',
+  'db:getStats',
+  'settings:get',
+];
+
+let failures = 0;
+let messages = [];
+
+function assert(condition, message) {
+  if (condition) console.log(`PASS: ${message}`);
+  else {
+    failures++;
+    console.error(`FAIL: ${message}`);
+  }
+}
+
+async function waitFor(webContents, expression, message, timeoutMs = 8_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await webContents.executeJavaScript(`Boolean(${expression})`, true)) return;
+    await delay(40);
+  }
+  throw new Error(`Timed out waiting for ${message}`);
+}
+
+function startImageServer() {
+  const wideSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="1176" height="768" viewBox="0 0 1176 768"><rect width="1176" height="768" fill="#7c3aed"/></svg>';
+  const smallSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80" viewBox="0 0 120 80"><rect width="120" height="80" fill="#22c55e"/></svg>';
+  const server = createServer((request, response) => {
+    const svg = request.url === '/wide.svg'
+      ? wideSvg
+      : request.url === '/small.svg'
+        ? smallSvg
+        : null;
+    if (!svg) {
+      response.writeHead(404).end();
+      return;
+    }
+    const send = () => {
+      response.writeHead(200, {
+        'Content-Type': 'image/svg+xml',
+        'Cache-Control': 'no-store',
+      });
+      response.end(svg);
+    };
+    if (request.url === '/wide.svg') setTimeout(send, 300);
+    else send();
+  });
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve({
+        server,
+        baseUrl: `http://127.0.0.1:${address.port}`,
+      });
+    });
+  });
+}
+
+function sessionSummary() {
+  return {
+    id: sessionId,
+    title: 'Session image rendering',
+    project: 'image-fixture',
+    project_path: '/tmp/image-fixture',
+    source: 'codex',
+    started_at: '2026-07-30T00:00:00.000Z',
+    ended_at: '2026-07-30T00:05:00.000Z',
+    message_count: messages.length,
+    git_branch: 'main',
+  };
+}
+
+function registerHandlers() {
+  ipcMain.handle('db:getSessions', () => [sessionSummary()]);
+  ipcMain.handle('db:getSessionMessages', () => messages);
+  ipcMain.handle('db:getSessionToolCalls', () => []);
+  ipcMain.handle('db:getSessionToolResults', () => []);
+  ipcMain.handle('db:getSessionSubagents', () => []);
+  ipcMain.handle('db:getSessionWorkflows', () => []);
+  ipcMain.handle('db:getSessionSummaries', () => []);
+  ipcMain.handle('db:getMemories', () => []);
+  ipcMain.handle('db:getProjects', () => [{ project: 'image-fixture', count: 1 }]);
+  ipcMain.handle('db:getStats', () => ({}));
+  ipcMain.handle('settings:get', () => ({}));
+}
+
+async function run() {
+  const { server, baseUrl } = await startImageServer();
+  let win = null;
+  try {
+    messages = [
+      {
+        uuid: 'message-0',
+        type: 'user',
+        timestamp: '2026-07-30T00:00:00.000Z',
+        text: 'Image rendering fixtures',
+        content_type: 'text',
+        is_meta: 0,
+      },
+      {
+        uuid: 'message-1',
+        type: 'assistant',
+        timestamp: '2026-07-30T00:01:00.000Z',
+        text: `Wide image\n\n![Wide timeline fixture](${baseUrl}/wide.svg "Wide fixture")`,
+        content_type: 'text',
+        is_meta: 0,
+      },
+      {
+        uuid: 'message-2',
+        type: 'assistant',
+        timestamp: '2026-07-30T00:02:00.000Z',
+        text: `Small image\n\n![Small timeline fixture](${baseUrl}/small.svg)`,
+        content_type: 'text',
+        is_meta: 0,
+      },
+      {
+        uuid: 'message-3',
+        type: 'assistant',
+        timestamp: '2026-07-30T00:03:00.000Z',
+        text: 'Broken image\n\n![Missing timeline fixture](file:///obelisk-fixtures/missing-session-image.png)',
+        content_type: 'text',
+        is_meta: 0,
+      },
+      {
+        uuid: 'message-4',
+        type: 'user',
+        timestamp: '2026-07-30T00:04:00.000Z',
+        text: 'Following message',
+        content_type: 'text',
+        is_meta: 0,
+      },
+    ];
+    registerHandlers();
+    win = new BrowserWindow({
+      show: false,
+      width: 1200,
+      height: 800,
+      webPreferences: {
+        preload: join(appRoot, 'out', 'preload', 'index.js'),
+        contextIsolation: true,
+        nodeIntegration: false,
+      },
+    });
+
+    await win.loadFile(join(appRoot, 'out', 'renderer', 'index.html'), {
+      hash: '/sessions',
+    });
+    await waitFor(
+      win.webContents,
+      `document.body.textContent.includes('Session image rendering')`,
+      'session list',
+    );
+    await win.webContents.executeJavaScript(`(() => {
+      window.__wideImageLayout = new Promise(resolve => {
+        const observer = new MutationObserver(() => {
+          const message = document.querySelector('[data-uuid="message-1"]');
+          const host = message?.querySelector('obelisk-session-image');
+          const image = host?.shadowRoot?.querySelector('img');
+          const row = message?.closest('.virtual-timeline-row');
+          if (!image || !row) return;
+          observer.disconnect();
+          const before = row.getBoundingClientRect().height;
+          image.addEventListener('load', () => {
+            requestAnimationFrame(() => requestAnimationFrame(() => {
+              resolve({
+                before,
+                after: row.getBoundingClientRect().height,
+              });
+            }));
+          }, { once: true });
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+      });
+      window.location.hash = ${JSON.stringify(`/sessions/${sessionId}`)};
+    })()`, true);
+
+    await waitFor(
+      win.webContents,
+      `document.querySelector('.flap-number')?.getAttribute('aria-label') === '${messages.length}'`,
+      'image fixture timeline',
+    );
+    const resize = await win.webContents.executeJavaScript('window.__wideImageLayout', true);
+    await waitFor(
+      win.webContents,
+      `document.querySelector('[data-uuid="message-2"] obelisk-session-image')?.shadowRoot?.querySelector('.is-loaded')`,
+      'small image load',
+    );
+    await waitFor(
+      win.webContents,
+      `document.querySelector('[data-uuid="message-3"] obelisk-session-image')?.shadowRoot?.querySelector('.is-error')`,
+      'failed image state',
+    );
+    await delay(100);
+
+    const layout = await win.webContents.executeJavaScript(`(() => {
+      const wrap = document.querySelector('.detail-wrap');
+      const wideMessage = document.querySelector('[data-uuid="message-1"]');
+      const wideRow = wideMessage.closest('.virtual-timeline-row');
+      const nextRow = document.querySelector('[data-uuid="message-2"]').closest('.virtual-timeline-row');
+      const wideHost = wideMessage.querySelector('obelisk-session-image');
+      const wideImage = wideHost.shadowRoot.querySelector('img');
+      const smallHost = document.querySelector('[data-uuid="message-2"] obelisk-session-image');
+      const smallImage = smallHost.shadowRoot.querySelector('img');
+      const brokenHost = document.querySelector('[data-uuid="message-3"] obelisk-session-image');
+      const wideHostRect = wideHost.getBoundingClientRect();
+      const wideImageRect = wideImage.getBoundingClientRect();
+      const smallImageRect = smallImage.getBoundingClientRect();
+      const wideRowRect = wideRow.getBoundingClientRect();
+      const nextRowRect = nextRow.getBoundingClientRect();
+      return {
+        wrapClientWidth: wrap.clientWidth,
+        wrapScrollWidth: wrap.scrollWidth,
+        wideHostWidth: wideHostRect.width,
+        wideImageWidth: wideImageRect.width,
+        wideImageHeight: wideImageRect.height,
+        wideNaturalWidth: wideImage.naturalWidth,
+        wideNaturalHeight: wideImage.naturalHeight,
+        smallImageWidth: smallImageRect.width,
+        smallNaturalWidth: smallImage.naturalWidth,
+        rowHeight: wideRowRect.height,
+        rowGap: nextRowRect.top - wideRowRect.bottom,
+        brokenText: brokenHost.shadowRoot.querySelector('figcaption')?.textContent || '',
+      };
+    })()`, true);
+
+    assert(
+      resize.after > resize.before + 100,
+      `image load grows and remeasures its virtual row (${JSON.stringify(resize)})`,
+    );
+    assert(
+      layout.wrapScrollWidth <= layout.wrapClientWidth + 1,
+      `wide images do not add session-level horizontal overflow (${JSON.stringify(layout)})`,
+    );
+    assert(
+      layout.wideImageWidth <= layout.wideHostWidth + 1
+        && Math.abs(
+          layout.wideImageWidth / layout.wideImageHeight
+          - layout.wideNaturalWidth / layout.wideNaturalHeight
+        ) < 0.01,
+      `wide images fit their host and preserve aspect ratio (${JSON.stringify(layout)})`,
+    );
+    assert(
+      layout.smallImageWidth <= layout.smallNaturalWidth + 1,
+      `small images keep their intrinsic width (${JSON.stringify(layout)})`,
+    );
+    assert(
+      layout.rowHeight > layout.wideImageHeight && layout.rowGap >= 13,
+      `measured image rows do not overlap the following row (${JSON.stringify(layout)})`,
+    );
+    assert(
+      layout.brokenText.includes('Image unavailable')
+        && layout.brokenText.includes('Missing timeline fixture'),
+      `failed images remain contained with fallback text (${JSON.stringify(layout)})`,
+    );
+  } finally {
+    win?.destroy();
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+app.whenReady()
+  .then(run)
+  .catch(error => {
+    failures++;
+    console.error(error.stack || error);
+  })
+  .finally(() => {
+    for (const channel of channels) ipcMain.removeHandler(channel);
+    app.exit(failures ? 1 : 0);
+  });


### PR DESCRIPTION
## Summary
- add a dedicated Vue custom element for session images with bounded intrinsic sizing and load/error states
- route Marked image tokens through the element while validating source protocols
- add a production Electron regression test for wide, small, and failed images plus virtual-row remeasurement

## Commit structure
1. `feat(renderer): add bounded session image element`
2. `fix(renderer): route markdown images through media element`
3. `test(renderer): cover session image layout`

## Verification
- `npm run lint` (0 errors; 4 existing warnings)
- `npm run typecheck`
- `npm test` (275 passing)
- `cd app && npm run test:electron`
- `cd app && npm run test:electron:images`
- `cd app && npx electron-vite build`

## Known baseline limitation
- `npm run test:electron:timeline` currently stops before test execution because Electron’s Node 20 runtime cannot import `packages/core/src/session-detail.ts` from the existing source-level test harness. This is also reproducible on `main`; the new image regression test avoids that unrelated harness path.

Closes #6