### PR TITLE
feat(app): preview and safely open local Markdown file links 预览并安全打开本地 Markdown 文件链接

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,8 @@
     "verify:icons": "node scripts/verify-icons.mjs",
     "test:electron": "electron-vite build && electron --no-sandbox tests/electron-concurrency.mjs",
     "test:electron:timeline": "electron-vite build && electron --no-sandbox tests/electron-session-virtualization.mjs",
-    "test:electron:reader-state": "electron-vite build && electron --no-sandbox tests/electron-session-reader-state.mjs"
+    "test:electron:reader-state": "electron-vite build && electron --no-sandbox tests/electron-session-reader-state.mjs",
+    "test:local-links": "node --test tests/local-markdown-link.test.mjs"
   },
   "build": {
     "appId": "com.obelisk.app",

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -9,6 +9,7 @@ import { writeHeartbeat } from './indexer.ts';
 import { createIndexerService } from './indexer-service.ts';
 import { createWorkerBuildIndex } from './indexer-worker-client.ts';
 import { buildRecapExportQuery } from './recap-capture-query.ts';
+import { previewLocalMarkdownLink, resolveExistingLocalMarkdownFile } from './local-markdown-link.mjs';
 import { acquireWriterLease, writerLockPathFor } from '../../../packages/core/src/writer-lease.ts';
 import { migrateCoreSchemaColumns } from '../../../packages/core/src/schema-migrations.ts';
 import { createBuiltinProviderRegistry } from '../../../packages/core/src/providers/builtins.ts';
@@ -325,6 +326,10 @@ function createWindow() {
     }
   });
 
+  win.webContents.on('will-navigate', (event, url) => {
+    if (url.startsWith('file:')) event.preventDefault();
+  });
+
   if (isDev) {
     win.loadURL(process.env.ELECTRON_RENDERER_URL || process.env.OBELISK_DEV_SERVER_URL || 'http://localhost:5173');
     if (shouldOpenDevTools) {
@@ -587,6 +592,26 @@ ipcMain.handle('db:readMemoryFile', (_, filePath) => {
     if (fs.existsSync(filePath)) return fs.readFileSync(filePath, 'utf-8');
     return null;
   } catch { return null; }
+});
+
+ipcMain.handle('local-link:preview', (_, href) => previewLocalMarkdownLink(href));
+
+ipcMain.handle('local-link:open', async (event, href) => {
+  const filePath = resolveExistingLocalMarkdownFile(href);
+  if (!filePath) return { exists: false };
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win) return { exists: true, opened: false };
+  const { response } = await dialog.showMessageBox(win, {
+    type: 'question',
+    buttons: ['Cancel', 'Open'],
+    defaultId: 1,
+    cancelId: 0,
+    message: '是否用默认应用打开此文件？',
+    detail: filePath,
+  });
+  if (response !== 1) return { exists: true, opened: false };
+  const error = await shell.openPath(filePath);
+  return { exists: true, opened: !error, error: error || undefined };
 });
 
 ipcMain.handle('db:archiveMemory', (_, id, reason) => {

--- a/app/src/main/local-markdown-link.mjs
+++ b/app/src/main/local-markdown-link.mjs
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const LOCAL_LINK_PREVIEW_BYTES = 12 * 1024;
+
+function withoutLineSuffix(filePath) {
+  return filePath.replace(/:\d+(?::\d+)?$/, '');
+}
+
+export function localMarkdownLinkCandidates(href) {
+  if (typeof href !== 'string' || !href.trim()) return [];
+  const rawHref = href.trim();
+  let filePath;
+  try {
+    if (rawHref.startsWith('file:')) {
+      filePath = fileURLToPath(rawHref);
+    } else {
+      filePath = decodeURIComponent(rawHref);
+    }
+  } catch {
+    return [];
+  }
+  if (!path.isAbsolute(filePath)) return [];
+  const withoutSuffix = withoutLineSuffix(filePath);
+  return withoutSuffix === filePath ? [filePath] : [filePath, withoutSuffix];
+}
+
+export function resolveExistingLocalMarkdownFile(href) {
+  for (const filePath of localMarkdownLinkCandidates(href)) {
+    try {
+      if (fs.statSync(filePath).isFile()) return filePath;
+    } catch {}
+  }
+  return null;
+}
+
+export function previewLocalMarkdownLink(href) {
+  const filePath = resolveExistingLocalMarkdownFile(href);
+  if (!filePath) return { exists: false };
+  let fd;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const buffer = Buffer.alloc(LOCAL_LINK_PREVIEW_BYTES);
+    const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
+    const content = buffer.subarray(0, bytesRead);
+    if (content.includes(0)) return { exists: true, path: filePath, preview: null, truncated: false };
+    return {
+      exists: true,
+      path: filePath,
+      preview: content.toString('utf8'),
+      truncated: bytesRead === LOCAL_LINK_PREVIEW_BYTES,
+    };
+  } catch {
+    return { exists: false };
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -22,6 +22,8 @@ contextBridge.exposeInMainWorld('obelisk', {
   getMessageFullText: (uuid: string) => ipcRenderer.invoke('db:getMessageFullText', uuid),
   getMemories: () => ipcRenderer.invoke('db:getMemories'),
   readMemoryFile: (path: string) => ipcRenderer.invoke('db:readMemoryFile', path),
+  previewLocalMarkdownLink: (href: string) => ipcRenderer.invoke('local-link:preview', href),
+  openLocalMarkdownLink: (href: string) => ipcRenderer.invoke('local-link:open', href),
   archiveMemory: (id: string, reason?: string) => ipcRenderer.invoke('db:archiveMemory', id, reason),
   restoreMemory: (id: string) => ipcRenderer.invoke('db:restoreMemory', id),
   getProjects: () => ipcRenderer.invoke('db:getProjects'),

--- a/app/src/renderer/src/local-markdown-links.js
+++ b/app/src/renderer/src/local-markdown-links.js
@@ -1,0 +1,91 @@
+const HOVER_DELAY_MS = 300;
+const HIDE_DELAY_MS = 120;
+const cache = new Map();
+let hoverTimer = null;
+let hideTimer = null;
+let activeLink = null;
+let previewEl = null;
+
+function isLocalHref(href) {
+  return typeof href === 'string' && (/^(?:file:|\/|[A-Za-z]:[\\/]|\\\\)/.test(href.trim()));
+}
+
+function markdownLink(target) {
+  const link = target instanceof Element ? target.closest('.markdown-msg a, .markdown-body a, .markdown-compact a') : null;
+  return link && isLocalHref(link.getAttribute('href')) ? link : null;
+}
+
+function hidePreview() {
+  clearTimeout(hoverTimer);
+  clearTimeout(hideTimer);
+  hoverTimer = null;
+  hideTimer = null;
+  activeLink = null;
+  previewEl?.remove();
+  previewEl = null;
+}
+
+function showPreview(link, result) {
+  if (!result?.preview || activeLink !== link) return;
+  previewEl?.remove();
+  previewEl = document.createElement('aside');
+  previewEl.className = 'local-file-preview';
+  const pathEl = document.createElement('div');
+  pathEl.className = 'local-file-preview-path';
+  pathEl.textContent = result.path;
+  const contentEl = document.createElement('pre');
+  contentEl.textContent = `${result.preview}${result.truncated ? '\n…' : ''}`;
+  previewEl.append(pathEl, contentEl);
+  document.body.append(previewEl);
+}
+
+async function previewLink(link) {
+  const href = link.getAttribute('href');
+  if (!href || !window.obelisk?.previewLocalMarkdownLink) return;
+  let result = cache.get(href);
+  if (!result) {
+    result = await window.obelisk.previewLocalMarkdownLink(href);
+    cache.set(href, result);
+  }
+  showPreview(link, result);
+}
+
+function onPointerOver(event) {
+  const link = markdownLink(event.target);
+  if (!link || link.contains(event.relatedTarget)) return;
+  clearTimeout(hideTimer);
+  hideTimer = null;
+  clearTimeout(hoverTimer);
+  activeLink = link;
+  hoverTimer = setTimeout(() => void previewLink(link), HOVER_DELAY_MS);
+}
+
+function onPointerOut(event) {
+  const link = markdownLink(event.target);
+  if (link && !link.contains(event.relatedTarget)) {
+    clearTimeout(hideTimer);
+    hideTimer = setTimeout(hidePreview, HIDE_DELAY_MS);
+  }
+}
+
+function onClick(event) {
+  const link = markdownLink(event.target);
+  if (!link) return;
+  event.preventDefault();
+  const href = link.getAttribute('href');
+  if (href) void window.obelisk?.openLocalMarkdownLink?.(href);
+}
+
+export function installLocalMarkdownLinkHandlers() {
+  document.addEventListener('pointerover', onPointerOver);
+  document.addEventListener('pointerout', onPointerOut);
+  document.addEventListener('click', onClick);
+  document.addEventListener('scroll', hidePreview, true);
+  return () => {
+    document.removeEventListener('pointerover', onPointerOver);
+    document.removeEventListener('pointerout', onPointerOut);
+    document.removeEventListener('click', onClick);
+    document.removeEventListener('scroll', hidePreview, true);
+    hidePreview();
+  };
+}

--- a/app/src/renderer/src/main.js
+++ b/app/src/renderer/src/main.js
@@ -6,6 +6,7 @@ import router from './router.js';
 import { commitInitialData, fetchInitialData } from './data.js';
 import { noteSessionUpdated, sessionLiveState } from './session-live.mjs';
 import { createGlobalDataRefreshCoordinator } from './session-global-refresh.mjs';
+import { installLocalMarkdownLinkHandlers } from './local-markdown-links.js';
 
 // Import shared renderer CSS globally
 import '../styles/base.css';
@@ -58,5 +59,7 @@ window.obelisk?.onSessionUpdated?.(({ sessionId } = {}) => {
   const currentSessionId = route.name === 'SessionDetail' ? String(route.params.id || '') : null;
   noteSessionUpdated(sessionLiveState, sessionId, currentSessionId);
 });
+
+installLocalMarkdownLinkHandlers();
 
 app.mount('#app');

--- a/app/src/renderer/styles/base.css
+++ b/app/src/renderer/styles/base.css
@@ -109,14 +109,15 @@ button, input, .row, .sidebar-item, .toolbar-btn,
 .local-file-preview {
   position: fixed; right: 16px; bottom: 16px; z-index: 600;
   width: min(520px, calc(100vw - 32px)); max-height: min(360px, calc(100vh - 32px));
-  overflow: hidden; border: 1px solid var(--hairline-strong); border-radius: 8px;
-  background: var(--surface); box-shadow: 0 16px 42px rgba(0,0,0,0.24); pointer-events: none;
+  overflow: hidden; border: 1px solid rgba(255,255,255,0.16); border-radius: 8px;
+  background: #181923; box-shadow: 0 18px 48px rgba(0,0,0,0.52); pointer-events: none;
 }
 .local-file-preview-path {
-  padding: 8px 10px; border-bottom: 1px solid var(--hairline); color: var(--muted);
+  padding: 8px 10px; border-bottom: 1px solid rgba(255,255,255,0.10); color: rgba(255,255,255,0.62);
+  background: #20212d;
   font: var(--text-xs)/1.35 var(--font-mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .local-file-preview pre {
-  max-height: 304px; overflow: hidden; padding: 10px; color: var(--fg-2);
+  max-height: 304px; overflow: hidden; padding: 10px; color: rgba(255,255,255,0.78);
   font: var(--text-xs)/1.55 var(--font-mono); white-space: pre-wrap; overflow-wrap: anywhere;
 }

--- a/app/src/renderer/styles/base.css
+++ b/app/src/renderer/styles/base.css
@@ -105,3 +105,18 @@ button, input, .row, .sidebar-item, .toolbar-btn,
 
 .app { position: relative; z-index: 2; height: 100vh; display: flex; flex-direction: column; }
 .columns { flex: 1; display: grid; grid-template-columns: var(--col-sidebar) 1fr; min-height: 0; }
+
+.local-file-preview {
+  position: fixed; right: 16px; bottom: 16px; z-index: 600;
+  width: min(520px, calc(100vw - 32px)); max-height: min(360px, calc(100vh - 32px));
+  overflow: hidden; border: 1px solid var(--hairline-strong); border-radius: 8px;
+  background: var(--surface); box-shadow: 0 16px 42px rgba(0,0,0,0.24); pointer-events: none;
+}
+.local-file-preview-path {
+  padding: 8px 10px; border-bottom: 1px solid var(--hairline); color: var(--muted);
+  font: var(--text-xs)/1.35 var(--font-mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.local-file-preview pre {
+  max-height: 304px; overflow: hidden; padding: 10px; color: var(--fg-2);
+  font: var(--text-xs)/1.55 var(--font-mono); white-space: pre-wrap; overflow-wrap: anywhere;
+}

--- a/app/tests/local-markdown-link.test.mjs
+++ b/app/tests/local-markdown-link.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { localMarkdownLinkCandidates } from '../src/main/local-markdown-link.mjs';
+
+test('parses local paths and strips Codex line suffixes', () => {
+  assert.deepEqual(localMarkdownLinkCandidates('/tmp/a%20file.ts:42:7'), ['/tmp/a file.ts:42:7', '/tmp/a file.ts']);
+  assert.deepEqual(localMarkdownLinkCandidates('file:///tmp/a%20file.ts:42'), ['/tmp/a file.ts:42', '/tmp/a file.ts']);
+});
+
+test('rejects non-local Markdown links', () => {
+  assert.deepEqual(localMarkdownLinkCandidates('https://example.com/a.ts'), []);
+  assert.deepEqual(localMarkdownLinkCandidates('./a.ts'), []);
+});


### PR DESCRIPTION
鼠标悬停在 [toolbar.css](./toolbar.css) 的效果：

<img width="1195" height="798" alt="image" src="https://github.com/user-attachments/assets/bc9b6d6b-1cbf-4567-9f1b-6c596b96261d" />

鼠标点击在 [toolbar.css](./toolbar.css) 的效果：

<img width="1200" height="800" alt="PixPin_2026-07-30_04-46-15" src="https://github.com/user-attachments/assets/5ae66529-d33a-4ef2-b8d0-e225306b24d8" />

## 概要

- 拦截 Markdown 渲染出的本地文件链接，避免 Electron 窗口跳转离开 Obelisk。
- 悬浮存在的本地文本文件时，在右下角显示固定位置的文本预览。
- 点击存在的文件后先请求确认，再通过系统默认应用打开（边界：没有实现具体行号的跳转）。
- 支持绝对路径、`file://` URL、URL 编码路径，以及 Codex 风格的 `:行号[:列号]` 后缀。
- 文件不存在、不可读、二进制文件或目录时保持静默，无预览、无弹窗。
- 改善预览卡片对比度：使用不透明深色背景、独立标题栏、更清晰的边框与阴影。

## 实现

- 文件路径解析、存在性检查、限量预览读取与 `shell.openPath()` 全部保留在 Electron 主进程。
- Renderer 仅负责事件委托、悬浮延迟、结果缓存与固定预览 UI。
- 预览内容最多读取 12 KiB。
- 在多个链接间连续悬浮时，预览卡片保持原位，只更新内容，不会跳动。

## 验证

- `npm run test:local-links --prefix app`
- 覆盖 `file://`、URL 解码、`:行号[:列号]` 剥离，以及非本地链接拒绝。