### PR TITLE
feat(memory): open existing inline session references

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,8 @@
     "verify:icons": "node scripts/verify-icons.mjs",
     "test:electron": "electron-vite build && electron --no-sandbox tests/electron-concurrency.mjs",
     "test:electron:timeline": "electron-vite build && electron --no-sandbox tests/electron-session-virtualization.mjs",
-    "test:electron:reader-state": "electron-vite build && electron --no-sandbox tests/electron-session-reader-state.mjs"
+    "test:electron:reader-state": "electron-vite build && electron --no-sandbox tests/electron-session-reader-state.mjs",
+    "test:electron:memory-links": "electron-vite build && electron --no-sandbox tests/electron-memory-session-links.mjs"
   },
   "build": {
     "appId": "com.obelisk.app",

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -325,6 +325,12 @@ function createWindow() {
     }
   });
 
+  win.webContents.on('will-navigate', (event, url) => {
+    try {
+      if (new URL(url).protocol === 'obelisk:') event.preventDefault();
+    } catch {}
+  });
+
   if (isDev) {
     win.loadURL(process.env.ELECTRON_RENDERER_URL || process.env.OBELISK_DEV_SERVER_URL || 'http://localhost:5173');
     if (shouldOpenDevTools) {
@@ -474,6 +480,10 @@ function querySessionMetadata(sessionId: string): SessionMetadata | null {
 ipcMain.handle('db:getSessions', (_, opts = {}) => {
   if (!db) return [];
   const { project, limit = 200 } = opts;
+  const sessionIds = Array.isArray(opts.ids)
+    ? [...new Set(opts.ids.filter((id: unknown): id is string => typeof id === 'string' && id.length > 0))].slice(0, 100)
+    : null;
+  if (sessionIds && sessionIds.length === 0) return [];
   let sql = `SELECT ${SESSION_METADATA_COLUMNS} FROM sessions`;
   const params: unknown[] = [];
   const sourceFilter = sourceWhereClause(opts);
@@ -482,8 +492,12 @@ ipcMain.handle('db:getSessions', (_, opts = {}) => {
     params.push(...sourceFilter.params);
   }
   if (project) { sql = appendWhere(sql, params, `project LIKE ?`); params.push(project); }
+  if (sessionIds) {
+    sql = appendWhere(sql, params, `id IN (${sessionIds.map(() => '?').join(',')})`);
+    params.push(...sessionIds);
+  }
   sql += ` ORDER BY COALESCE(ended_at, started_at) DESC LIMIT ?`;
-  params.push(limit);
+  params.push(sessionIds ? Math.min(limit, sessionIds.length) : limit);
   return db.prepare(sql).all(...params);
 });
 

--- a/app/src/renderer/src/data.js
+++ b/app/src/renderer/src/data.js
@@ -228,6 +228,16 @@ export async function loadMemoryMarkdown(memoryPath) {
   }
 }
 
+export async function loadSessionsByIds(sessionIds) {
+  const ids = [...new Set((sessionIds || []).filter(id => typeof id === 'string' && id))].slice(0, 100);
+  if (!ids.length) return [];
+  try {
+    return await window.obelisk.getSessions({ source: 'all', ids, limit: ids.length });
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Archive a memory by id. Updates state after successful IPC call.
  */

--- a/app/src/renderer/src/memory-session-links.mjs
+++ b/app/src/renderer/src/memory-session-links.mjs
@@ -44,6 +44,11 @@ function sessionIcon(document) {
   return svg;
 }
 
+function sessionLabel(session, sessionId) {
+  const title = typeof session?.title === 'string' ? session.title.trim() : '';
+  return title || sessionId;
+}
+
 export function decorateResolvedInlineSessions(root, sessionsById) {
   if (!root?.querySelectorAll) return;
   const resolved = sessionsById instanceof Map ? sessionsById : new Map();
@@ -54,11 +59,13 @@ export function decorateResolvedInlineSessions(root, sessionsById) {
     if (!sessionId || !session) continue;
 
     const button = code.ownerDocument.createElement('button');
+    const label = sessionLabel(session, sessionId);
     button.type = 'button';
     button.classList.add('session-link', 'markdown-session-link');
     button.dataset.sessionId = sessionId;
-    button.title = session.title ? `Open session: ${session.title}` : `Open session: ${sessionId}`;
-    button.append(sessionIcon(code.ownerDocument), code.ownerDocument.createTextNode(sessionId));
+    button.title = `Session ID: ${sessionId}`;
+    button.setAttribute('aria-label', `Open session: ${label}`);
+    button.append(sessionIcon(code.ownerDocument), code.ownerDocument.createTextNode(label));
     code.replaceWith(button);
   }
 }

--- a/app/src/renderer/src/memory-session-links.mjs
+++ b/app/src/renderer/src/memory-session-links.mjs
@@ -1,0 +1,98 @@
+const OBELISK_PROTOCOL = 'obelisk:';
+const SESSION_HOST = 'session';
+
+function isObeliskHref(href) {
+  return typeof href === 'string' && href.trim().toLowerCase().startsWith(OBELISK_PROTOCOL);
+}
+
+export function parseObeliskSessionHref(href) {
+  if (typeof href !== 'string' || !href.trim()) return null;
+
+  let url;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+
+  if (
+    url.protocol !== OBELISK_PROTOCOL
+    || url.hostname !== SESSION_HOST
+    || url.username
+    || url.password
+    || url.port
+    || url.search
+    || url.hash
+  ) {
+    return null;
+  }
+
+  const encodedId = url.pathname.slice(1);
+  if (!encodedId || encodedId.includes('/')) return null;
+
+  try {
+    const sessionId = decodeURIComponent(encodedId);
+    if (!sessionId || sessionId.trim() !== sessionId || sessionId.includes('/')) return null;
+    return sessionId;
+  } catch {
+    return null;
+  }
+}
+
+export function collectObeliskSessionIds(root) {
+  if (!root?.querySelectorAll) return [];
+  const ids = new Set();
+  for (const link of root.querySelectorAll('a[href]')) {
+    const sessionId = parseObeliskSessionHref(link.getAttribute('href'));
+    if (sessionId) ids.add(sessionId);
+  }
+  return [...ids];
+}
+
+function replaceWithReadableText(link) {
+  const replacement = link.ownerDocument.createElement('span');
+  replacement.className = 'markdown-session-reference-unavailable';
+  while (link.firstChild) replacement.append(link.firstChild);
+  link.replaceWith(replacement);
+}
+
+function sessionIcon(document) {
+  const namespace = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(namespace, 'svg');
+  svg.setAttribute('viewBox', '0 0 16 16');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '1.5');
+  svg.setAttribute('stroke-linejoin', 'round');
+  svg.setAttribute('aria-hidden', 'true');
+
+  const frame = document.createElementNS(namespace, 'path');
+  frame.setAttribute('d', 'M3 4h10v8a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V4z');
+  const lines = document.createElementNS(namespace, 'path');
+  lines.setAttribute('d', 'M5.5 7h5M5.5 9.5h3');
+  lines.setAttribute('stroke-linecap', 'round');
+  svg.append(frame, lines);
+  return svg;
+}
+
+export function decorateObeliskSessionLinks(root, sessionsById) {
+  if (!root?.querySelectorAll) return;
+  const resolved = sessionsById instanceof Map ? sessionsById : new Map();
+
+  for (const link of root.querySelectorAll('a[href]')) {
+    const href = link.getAttribute('href');
+    if (!isObeliskHref(href)) continue;
+
+    const sessionId = parseObeliskSessionHref(href);
+    const session = sessionId ? resolved.get(sessionId) : null;
+    if (!sessionId || !session) {
+      replaceWithReadableText(link);
+      continue;
+    }
+
+    link.classList.add('session-link', 'markdown-session-link');
+    link.dataset.obeliskSessionId = sessionId;
+    link.title = session.title ? `Open session: ${session.title}` : `Open session: ${sessionId}`;
+    link.prepend(sessionIcon(link.ownerDocument));
+  }
+}

--- a/app/src/renderer/src/memory-session-links.mjs
+++ b/app/src/renderer/src/memory-session-links.mjs
@@ -1,59 +1,28 @@
-const OBELISK_PROTOCOL = 'obelisk:';
-const SESSION_HOST = 'session';
+const MAX_SESSION_CANDIDATES = 100;
+const MAX_SESSION_ID_LENGTH = 512;
 
-function isObeliskHref(href) {
-  return typeof href === 'string' && href.trim().toLowerCase().startsWith(OBELISK_PROTOCOL);
+export function inlineCodeSessionCandidate(code) {
+  if (!code || code.closest?.('pre')) return null;
+  const raw = code.textContent;
+  if (typeof raw !== 'string') return null;
+  const candidate = raw.trim();
+  if (!candidate || candidate.length > MAX_SESSION_ID_LENGTH) return null;
+  return candidate;
 }
 
-export function parseObeliskSessionHref(href) {
-  if (typeof href !== 'string' || !href.trim()) return null;
-
-  let url;
-  try {
-    url = new URL(href);
-  } catch {
-    return null;
-  }
-
-  if (
-    url.protocol !== OBELISK_PROTOCOL
-    || url.hostname !== SESSION_HOST
-    || url.username
-    || url.password
-    || url.port
-    || url.search
-    || url.hash
-  ) {
-    return null;
-  }
-
-  const encodedId = url.pathname.slice(1);
-  if (!encodedId || encodedId.includes('/')) return null;
-
-  try {
-    const sessionId = decodeURIComponent(encodedId);
-    if (!sessionId || sessionId.trim() !== sessionId || sessionId.includes('/')) return null;
-    return sessionId;
-  } catch {
-    return null;
-  }
-}
-
-export function collectObeliskSessionIds(root) {
+// Memory agents already expose session IDs as inline code. The renderer does not
+// interpret their shape: it collects bounded candidates and lets an exact DB lookup
+// decide whether any of them are real sessions.
+export function collectInlineSessionCandidates(root) {
   if (!root?.querySelectorAll) return [];
-  const ids = new Set();
-  for (const link of root.querySelectorAll('a[href]')) {
-    const sessionId = parseObeliskSessionHref(link.getAttribute('href'));
-    if (sessionId) ids.add(sessionId);
+  const candidates = new Set();
+  for (const code of root.querySelectorAll('code')) {
+    const candidate = inlineCodeSessionCandidate(code);
+    if (!candidate) continue;
+    candidates.add(candidate);
+    if (candidates.size >= MAX_SESSION_CANDIDATES) break;
   }
-  return [...ids];
-}
-
-function replaceWithReadableText(link) {
-  const replacement = link.ownerDocument.createElement('span');
-  replacement.className = 'markdown-session-reference-unavailable';
-  while (link.firstChild) replacement.append(link.firstChild);
-  link.replaceWith(replacement);
+  return [...candidates];
 }
 
 function sessionIcon(document) {
@@ -75,24 +44,21 @@ function sessionIcon(document) {
   return svg;
 }
 
-export function decorateObeliskSessionLinks(root, sessionsById) {
+export function decorateResolvedInlineSessions(root, sessionsById) {
   if (!root?.querySelectorAll) return;
   const resolved = sessionsById instanceof Map ? sessionsById : new Map();
 
-  for (const link of root.querySelectorAll('a[href]')) {
-    const href = link.getAttribute('href');
-    if (!isObeliskHref(href)) continue;
-
-    const sessionId = parseObeliskSessionHref(href);
+  for (const code of root.querySelectorAll('code')) {
+    const sessionId = inlineCodeSessionCandidate(code);
     const session = sessionId ? resolved.get(sessionId) : null;
-    if (!sessionId || !session) {
-      replaceWithReadableText(link);
-      continue;
-    }
+    if (!sessionId || !session) continue;
 
-    link.classList.add('session-link', 'markdown-session-link');
-    link.dataset.obeliskSessionId = sessionId;
-    link.title = session.title ? `Open session: ${session.title}` : `Open session: ${sessionId}`;
-    link.prepend(sessionIcon(link.ownerDocument));
+    const button = code.ownerDocument.createElement('button');
+    button.type = 'button';
+    button.classList.add('session-link', 'markdown-session-link');
+    button.dataset.sessionId = sessionId;
+    button.title = session.title ? `Open session: ${session.title}` : `Open session: ${sessionId}`;
+    button.append(sessionIcon(code.ownerDocument), code.ownerDocument.createTextNode(sessionId));
+    code.replaceWith(button);
   }
 }

--- a/app/src/renderer/src/utils.js
+++ b/app/src/renderer/src/utils.js
@@ -2,6 +2,10 @@
 // Pure helpers with no side-effects on global state (except formatProjectLabel which reads store).
 
 import { state } from './store.js';
+import {
+  collectObeliskSessionIds,
+  decorateObeliskSessionLinks,
+} from './memory-session-links.mjs';
 
 // --- Time / formatting ---
 
@@ -102,8 +106,18 @@ export function renderMarkdown(text, opts = {}) {
   const container = document.createElement('div');
   container.className = cls;
   container.innerHTML = html;
+  if (opts.sessionReferences) {
+    decorateObeliskSessionLinks(container, opts.sessionReferences);
+  }
   if (opts.query) highlightTextNodes(container, opts.query.trim());
   return container.outerHTML;
+}
+
+export function markdownSessionReferenceIds(text) {
+  if (text == null) return [];
+  const container = document.createElement('div');
+  container.innerHTML = sanitizeMarkdown(window.marked.parse(text));
+  return collectObeliskSessionIds(container);
 }
 
 // --- Duration / tokens / tooltip ---

--- a/app/src/renderer/src/utils.js
+++ b/app/src/renderer/src/utils.js
@@ -4,8 +4,8 @@
 import { state } from './store.js';
 import { markFileReferences, mayContainFileReference } from './file-references.mjs';
 import {
-  collectObeliskSessionIds,
-  decorateObeliskSessionLinks,
+  collectInlineSessionCandidates,
+  decorateResolvedInlineSessions,
 } from './memory-session-links.mjs';
 
 // --- Time / formatting ---
@@ -108,7 +108,7 @@ export function renderMarkdown(text, opts = {}) {
   container.className = cls;
   container.innerHTML = html;
   if (opts.sessionReferences) {
-    decorateObeliskSessionLinks(container, opts.sessionReferences);
+    decorateResolvedInlineSessions(container, opts.sessionReferences);
   }
   // Without a cwd or session to resolve against, a reference could never be opened — leaving it
   // unmarked keeps it from looking actionable.
@@ -119,11 +119,11 @@ export function renderMarkdown(text, opts = {}) {
   return container.outerHTML;
 }
 
-export function markdownSessionReferenceIds(text) {
+export function markdownSessionCandidates(text) {
   if (text == null) return [];
   const container = document.createElement('div');
   container.innerHTML = sanitizeMarkdown(window.marked.parse(text));
-  return collectObeliskSessionIds(container);
+  return collectInlineSessionCandidates(container);
 }
 
 // --- Duration / tokens / tooltip ---

--- a/app/src/renderer/src/views/MemoryList.vue
+++ b/app/src/renderer/src/views/MemoryList.vue
@@ -89,7 +89,7 @@ function summaryHTML(m) {
 function sourceSessionTitle(m) {
   if (!m.session_id) return '';
   const s = state.sessions.find(x => x.id === m.session_id);
-  return s?.title || m.session_id.slice(0, 8);
+  return s?.title?.trim() || m.session_id;
 }
 
 function openSourceSession(m) {
@@ -353,6 +353,8 @@ onUnmounted(() => {
           <button
             v-if="detailMemory.session_id"
             class="session-link"
+            :title="`Session ID: ${detailMemory.session_id}`"
+            :aria-label="`Open session: ${sourceSessionTitle(detailMemory)}`"
             @click="openSourceSession(detailMemory)"
           >
             <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round">

--- a/app/src/renderer/src/views/MemoryList.vue
+++ b/app/src/renderer/src/views/MemoryList.vue
@@ -8,7 +8,7 @@ import {
   formatProjectLabel,
   fmtListTime,
   fmtRelative,
-  markdownSessionReferenceIds,
+  markdownSessionCandidates,
   renderMarkdown,
 } from '../utils.js';
 import { loadMemoryMarkdown, loadSessionsByIds, archiveMemory, restoreMemory } from '../data.js';
@@ -181,7 +181,7 @@ async function loadDetail(memory) {
   }
   if (version !== detailLoadVersion) return;
   const markdown = memory?.markdown ?? null;
-  const referenceIds = markdownSessionReferenceIds(markdown);
+  const referenceIds = markdownSessionCandidates(markdown);
   const sessions = await loadSessionsByIds(referenceIds);
   if (version !== detailLoadVersion) return;
   detailSessionReferences.value = new Map(sessions.map(session => [session.id, session]));
@@ -292,11 +292,11 @@ const renderedMarkdown = computed(() => {
 
 function openMarkdownSession(event) {
   const link = event.target instanceof Element
-    ? event.target.closest('[data-obelisk-session-id]')
+    ? event.target.closest('[data-session-id]')
     : null;
   if (!link) return;
   event.preventDefault();
-  const sessionId = link.dataset.obeliskSessionId;
+  const sessionId = link.dataset.sessionId;
   if (sessionId) router.push({ name: 'SessionDetail', params: { id: sessionId } });
 }
 

--- a/app/src/renderer/src/views/MemoryList.vue
+++ b/app/src/renderer/src/views/MemoryList.vue
@@ -2,8 +2,16 @@
 import { computed, ref, nextTick, onMounted, onUnmounted, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { state, FOLDER_SVG, setSelection, clearSelection } from '../store.js';
-import { highlightPlain, escapeHTML, formatProjectLabel, fmtListTime, fmtRelative, renderMarkdown } from '../utils.js';
-import { loadMemoryMarkdown, archiveMemory, restoreMemory } from '../data.js';
+import {
+  highlightPlain,
+  escapeHTML,
+  formatProjectLabel,
+  fmtListTime,
+  fmtRelative,
+  markdownSessionReferenceIds,
+  renderMarkdown,
+} from '../utils.js';
+import { loadMemoryMarkdown, loadSessionsByIds, archiveMemory, restoreMemory } from '../data.js';
 import { resolveMemoryShortcut } from '../keyboard-shortcuts.mjs';
 
 defineOptions({ name: 'MemoryList' });
@@ -33,6 +41,7 @@ const showProjectPrefix = computed(() => state.projectFilter === 'all');
 
 const detailMemory = computed(() => props.id ? state.memories.find(memory => memory.id === props.id) : null);
 const detailMarkdown = ref(null);
+const detailSessionReferences = ref(new Map());
 const showSource = ref(false);
 const loadingMarkdown = ref(false);
 
@@ -164,13 +173,19 @@ async function loadDetail(memory) {
   const version = ++detailLoadVersion;
   showSource.value = false;
   detailMarkdown.value = null;
+  detailSessionReferences.value = new Map();
   loadingMarkdown.value = Boolean(memory);
 
   if (memory?.markdown == null && memory.path) {
     memory.markdown = await loadMemoryMarkdown(memory.path);
   }
   if (version !== detailLoadVersion) return;
-  detailMarkdown.value = memory?.markdown ?? null;
+  const markdown = memory?.markdown ?? null;
+  const referenceIds = markdownSessionReferenceIds(markdown);
+  const sessions = await loadSessionsByIds(referenceIds);
+  if (version !== detailLoadVersion) return;
+  detailSessionReferences.value = new Map(sessions.map(session => [session.id, session]));
+  detailMarkdown.value = markdown;
   loadingMarkdown.value = false;
 }
 
@@ -269,8 +284,21 @@ function detailArchiveRestore() {
 const renderedMarkdown = computed(() => {
   if (detailMarkdown.value == null) return null;
   if (showSource.value) return null; // handled by pre block in template
-  return renderMarkdown(detailMarkdown.value, { variant: 'body' });
+  return renderMarkdown(detailMarkdown.value, {
+    variant: 'body',
+    sessionReferences: detailSessionReferences.value,
+  });
 });
+
+function openMarkdownSession(event) {
+  const link = event.target instanceof Element
+    ? event.target.closest('[data-obelisk-session-id]')
+    : null;
+  if (!link) return;
+  event.preventDefault();
+  const sessionId = link.dataset.obeliskSessionId;
+  if (sessionId) router.push({ name: 'SessionDetail', params: { id: sessionId } });
+}
 
 // --- Keyboard handler ---
 
@@ -362,7 +390,7 @@ onUnmounted(() => {
           File not found or empty.
         </div>
         <pre v-else-if="showSource" class="markdown-source">{{ detailMarkdown }}</pre>
-        <div v-else class="markdown-body" v-html="renderedMarkdown"></div>
+        <div v-else class="markdown-body" @click="openMarkdownSession" v-html="renderedMarkdown"></div>
       </div>
 
       <div v-if="detailMemory.anchors?.length" class="detail-section-divider" id="anchors-section">

--- a/app/src/renderer/styles/detail.css
+++ b/app/src/renderer/styles/detail.css
@@ -272,6 +272,8 @@
   color: var(--fg-2); font-style: italic;
 }
 .markdown-body a { color: var(--accent-2); text-decoration: underline; text-underline-offset: 2px; }
+.markdown-body a.markdown-session-link { vertical-align: baseline; }
+.markdown-body a.markdown-session-link svg { flex-shrink: 0; }
 .markdown-body hr { border: 0; border-top: 1px solid var(--hairline); margin: 1.5em 0; }
 .markdown-body table { border-collapse: collapse; margin: 0.8em 0; font-size: 12.5px; }
 .markdown-body th, .markdown-body td { border: 1px solid var(--hairline); padding: 6px 10px; text-align: left; }

--- a/app/src/renderer/styles/detail.css
+++ b/app/src/renderer/styles/detail.css
@@ -272,8 +272,10 @@
   color: var(--fg-2); font-style: italic;
 }
 .markdown-body a { color: var(--accent-2); text-decoration: underline; text-underline-offset: 2px; }
-.markdown-body a.markdown-session-link { vertical-align: baseline; }
-.markdown-body a.markdown-session-link svg { flex-shrink: 0; }
+.markdown-body .markdown-session-link {
+  vertical-align: baseline; font-family: var(--font-mono); font-size: 0.9em;
+}
+.markdown-body .markdown-session-link svg { flex-shrink: 0; }
 .markdown-body hr { border: 0; border-top: 1px solid var(--hairline); margin: 1.5em 0; }
 .markdown-body table { border-collapse: collapse; margin: 0.8em 0; font-size: 12.5px; }
 .markdown-body th, .markdown-body td { border: 1px solid var(--hairline); padding: 6px 10px; text-align: left; }

--- a/app/tests/electron-memory-session-links.mjs
+++ b/app/tests/electron-memory-session-links.mjs
@@ -5,20 +5,24 @@ import { setTimeout as delay } from 'node:timers/promises';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const appRoot = join(here, '..');
-const sessionId = 'codex:019f6392-0dba-7f13-be12-541db3645a69';
+const codexSessionId = 'codex:019f6392-0dba-7f13-be12-541db3645a69';
+const providerNeutralSessionId = 'claude-session-id';
 const missingSessionId = 'codex:00000000-0000-0000-0000-000000000000';
+const fencedOnlySessionId = 'codex:fenced-code-only';
 const memoryId = 'memory-session-links';
 const memoryMarkdown = `# Linked memory
 
-[MR review session](obelisk://session/${encodeURIComponent(sessionId)})
+The implementation came from \`${codexSessionId}\`.
 
-[Missing session](obelisk://session/${encodeURIComponent(missingSessionId)})
+Another provider can work without a renderer format rule: \`${providerNeutralSessionId}\`.
 
-\`${sessionId}\`
+An unknown value stays code: \`${missingSessionId}\`.
 
-\`\`\`markdown
-[Code sample](obelisk://session/${encodeURIComponent(sessionId)})
-\`\`\`
+Ordinary inline code also stays code: \`npm test\`.
+
+~~~text
+${fencedOnlySessionId}
+~~~
 `;
 
 const channels = [
@@ -39,18 +43,32 @@ const channels = [
 ];
 
 let failures = 0;
+let exactLookupIds = [];
 
-const session = {
-  id: sessionId,
-  title: 'MR review session',
-  project: 'tcode',
-  project_path: '/tmp/tcode',
-  source: 'codex',
-  started_at: '2026-07-15T02:19:04.014Z',
-  ended_at: '2026-07-15T03:00:00.000Z',
-  message_count: 1,
-  git_branch: 'main',
-};
+const sessions = [
+  {
+    id: codexSessionId,
+    title: 'MR review session',
+    project: 'tcode',
+    project_path: '/tmp/tcode',
+    source: 'codex',
+    started_at: '2026-07-15T02:19:04.014Z',
+    ended_at: '2026-07-15T03:00:00.000Z',
+    message_count: 1,
+    git_branch: 'main',
+  },
+  {
+    id: providerNeutralSessionId,
+    title: 'Provider-neutral session',
+    project: 'tcode',
+    project_path: '/tmp/tcode',
+    source: 'claude',
+    started_at: '2026-07-14T02:19:04.014Z',
+    ended_at: '2026-07-14T03:00:00.000Z',
+    message_count: 1,
+    git_branch: 'main',
+  },
+];
 
 function assert(condition, message) {
   if (condition) console.log(`PASS: ${message}`);
@@ -71,10 +89,11 @@ async function waitFor(webContents, expression, message, timeoutMs = 8_000) {
 
 function registerHandlers() {
   ipcMain.handle('db:getSessions', (_event, opts = {}) => {
-    if (Array.isArray(opts.ids)) return opts.ids.includes(sessionId) ? [session] : [];
-    return [session];
+    if (!Array.isArray(opts.ids)) return sessions;
+    exactLookupIds = [...opts.ids];
+    return sessions.filter(session => opts.ids.includes(session.id));
   });
-  ipcMain.handle('db:getSessionMessages', () => [{
+  ipcMain.handle('db:getSessionMessages', (_event, sessionId) => [{
     uuid: `${sessionId}:000001`,
     session_id: sessionId,
     type: 'assistant',
@@ -86,20 +105,20 @@ function registerHandlers() {
   }]);
   ipcMain.handle('db:getSessionToolCalls', () => []);
   ipcMain.handle('db:getSessionToolResults', () => []);
-  ipcMain.handle('db:getSessionPatch', () => null);
   ipcMain.handle('db:getSessionSubagents', () => []);
   ipcMain.handle('db:getSessionWorkflows', () => []);
+  ipcMain.handle('db:getSessionPatch', () => null);
   ipcMain.handle('db:getSessionSummaries', () => []);
   ipcMain.handle('db:getMessageFullText', () => null);
   ipcMain.handle('db:getMemories', () => [{
     id: memoryId,
-    session_id: sessionId,
+    session_id: codexSessionId,
     project: 'tcode',
     message_start: null,
     message_end: null,
     path: '/tmp/linked-memory.md',
     anchors: null,
-    summary: 'A Memory with an explicit Obelisk session link.',
+    summary: 'A Memory containing inline-code session IDs.',
     created_at: '2026-07-30T04:55:28.011Z',
     deleted_at: null,
     deleted_reason: null,
@@ -128,34 +147,41 @@ async function run() {
   });
   await waitFor(
     win.webContents,
-    `document.querySelectorAll('.markdown-session-link').length === 1`,
-    'resolved Memory session link',
+    `document.querySelectorAll('.markdown-session-link').length === 2`,
+    'resolved inline-code sessions',
   );
 
   const rendered = await win.webContents.executeJavaScript(`(() => {
-    const link = document.querySelector('.markdown-session-link');
-    const unavailable = document.querySelector('.markdown-session-reference-unavailable');
-    const inlineCodes = [...document.querySelectorAll('.markdown-body code')].map(node => node.textContent);
+    const links = [...document.querySelectorAll('.markdown-session-link')];
+    const inlineCodes = [...document.querySelectorAll('.markdown-body code')]
+      .filter(node => !node.closest('pre'))
+      .map(node => node.textContent.trim());
+    const fencedCodes = [...document.querySelectorAll('.markdown-body pre code')]
+      .map(node => node.textContent.trim());
     return {
-      linkText: link?.textContent.trim(),
-      linkSessionId: link?.dataset.obeliskSessionId,
-      linkHref: link?.getAttribute('href'),
-      hasIcon: Boolean(link?.querySelector('svg')),
-      unavailableText: unavailable?.textContent.trim(),
-      unavailableIsLink: unavailable?.matches('a'),
+      linkIds: links.map(link => link.dataset.sessionId),
+      linkTexts: links.map(link => link.textContent.trim()),
+      linkTags: links.map(link => link.tagName),
+      allReuseSessionStyle: links.every(link => link.classList.contains('session-link')),
+      allHaveIcons: links.every(link => Boolean(link.querySelector('svg'))),
       inlineCodes,
-      renderedLinkCount: document.querySelectorAll('.markdown-body a').length,
+      fencedCodes,
     };
   })()`, true);
 
-  assert(rendered.linkText === 'MR review session', `canonical link keeps its descriptive label (${JSON.stringify(rendered)})`);
-  assert(rendered.linkSessionId === sessionId, 'resolved link carries the canonical session id');
-  assert(rendered.linkHref === `obelisk://session/${encodeURIComponent(sessionId)}`, 'rendered link keeps the canonical Obelisk href');
-  assert(rendered.hasIcon, 'rendered link reuses the session icon language');
-  assert(rendered.unavailableText === 'Missing session' && rendered.unavailableIsLink === false, 'missing target becomes readable non-link text');
-  assert(rendered.inlineCodes.includes(sessionId), 'bare inline session id remains ordinary code');
-  assert(rendered.inlineCodes.some(text => text.includes('Code sample')), 'fenced Markdown sample remains code');
-  assert(rendered.renderedLinkCount === 1, 'fenced and missing references do not become navigable links');
+  assert(
+    JSON.stringify(rendered.linkIds) === JSON.stringify([codexSessionId, providerNeutralSessionId]),
+    `only exact DB matches become links (${JSON.stringify(rendered)})`,
+  );
+  assert(rendered.linkTexts.includes(codexSessionId), 'link keeps the stored Codex session ID visible');
+  assert(rendered.linkTexts.includes(providerNeutralSessionId), 'linking does not assume a provider-specific ID shape');
+  assert(rendered.linkTags.every(tag => tag === 'BUTTON'), 'resolved references use internal navigation buttons');
+  assert(rendered.allReuseSessionStyle && rendered.allHaveIcons, 'links reuse the existing session-link visual language');
+  assert(rendered.inlineCodes.includes(missingSessionId), 'unknown session ID remains ordinary inline code');
+  assert(rendered.inlineCodes.includes('npm test'), 'unrelated inline code remains ordinary code');
+  assert(rendered.fencedCodes.includes(fencedOnlySessionId), 'session ID inside a fenced block remains code');
+  assert(exactLookupIds.includes(missingSessionId) && exactLookupIds.includes('npm test'), 'the DB lookup, not a format regex, decides which candidates resolve');
+  assert(!exactLookupIds.includes(fencedOnlySessionId), 'fenced code is excluded from exact lookup candidates');
 
   await win.webContents.executeJavaScript(
     `document.querySelector('.markdown-session-link').click()`,
@@ -167,7 +193,7 @@ async function run() {
     'internal Session Detail navigation',
   );
   const route = await win.webContents.executeJavaScript('window.location.hash', true);
-  assert(decodeURIComponent(route).includes(sessionId), `click stays inside Obelisk and opens the requested session (${route})`);
+  assert(decodeURIComponent(route).includes(codexSessionId), `click opens the requested session inside Obelisk (${route})`);
 
   win.destroy();
 }

--- a/app/tests/electron-memory-session-links.mjs
+++ b/app/tests/electron-memory-session-links.mjs
@@ -7,6 +7,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const appRoot = join(here, '..');
 const codexSessionId = 'codex:019f6392-0dba-7f13-be12-541db3645a69';
 const providerNeutralSessionId = 'claude-session-id';
+const untitledSessionId = 'codex:untitled-session';
 const missingSessionId = 'codex:00000000-0000-0000-0000-000000000000';
 const fencedOnlySessionId = 'codex:fenced-code-only';
 const memoryId = 'memory-session-links';
@@ -15,6 +16,8 @@ const memoryMarkdown = `# Linked memory
 The implementation came from \`${codexSessionId}\`.
 
 Another provider can work without a renderer format rule: \`${providerNeutralSessionId}\`.
+
+An untitled session keeps its exact identity visible: \`${untitledSessionId}\`.
 
 An unknown value stays code: \`${missingSessionId}\`.
 
@@ -65,6 +68,17 @@ const sessions = [
     source: 'claude',
     started_at: '2026-07-14T02:19:04.014Z',
     ended_at: '2026-07-14T03:00:00.000Z',
+    message_count: 1,
+    git_branch: 'main',
+  },
+  {
+    id: untitledSessionId,
+    title: null,
+    project: 'tcode',
+    project_path: '/tmp/tcode',
+    source: 'codex',
+    started_at: '2026-07-13T02:19:04.014Z',
+    ended_at: '2026-07-13T03:00:00.000Z',
     message_count: 1,
     git_branch: 'main',
   },
@@ -147,7 +161,7 @@ async function run() {
   });
   await waitFor(
     win.webContents,
-    `document.querySelectorAll('.markdown-session-link').length === 2`,
+    `document.querySelectorAll('.markdown-session-link').length === 3`,
     'resolved inline-code sessions',
   );
 
@@ -161,20 +175,49 @@ async function run() {
     return {
       linkIds: links.map(link => link.dataset.sessionId),
       linkTexts: links.map(link => link.textContent.trim()),
+      hoverTitles: links.map(link => link.title),
+      ariaLabels: links.map(link => link.getAttribute('aria-label')),
       linkTags: links.map(link => link.tagName),
       allReuseSessionStyle: links.every(link => link.classList.contains('session-link')),
       allHaveIcons: links.every(link => Boolean(link.querySelector('svg'))),
+      headerLink: (() => {
+        const link = document.querySelector('.detail-meta .session-link');
+        return link && {
+          text: link.textContent.trim(),
+          title: link.title,
+          ariaLabel: link.getAttribute('aria-label'),
+        };
+      })(),
       inlineCodes,
       fencedCodes,
     };
   })()`, true);
 
   assert(
-    JSON.stringify(rendered.linkIds) === JSON.stringify([codexSessionId, providerNeutralSessionId]),
+    JSON.stringify(rendered.linkIds) === JSON.stringify([codexSessionId, providerNeutralSessionId, untitledSessionId]),
     `only exact DB matches become links (${JSON.stringify(rendered)})`,
   );
-  assert(rendered.linkTexts.includes(codexSessionId), 'link keeps the stored Codex session ID visible');
-  assert(rendered.linkTexts.includes(providerNeutralSessionId), 'linking does not assume a provider-specific ID shape');
+  assert(rendered.linkTexts.includes('MR review session'), 'resolved link displays the human-readable session title');
+  assert(rendered.linkTexts.includes('Provider-neutral session'), 'linking does not assume a provider-specific ID shape');
+  assert(rendered.linkTexts.includes(untitledSessionId), 'untitled session falls back to its full ID');
+  assert(
+    JSON.stringify(rendered.hoverTitles) === JSON.stringify(rendered.linkIds.map(id => `Session ID: ${id}`)),
+    'native hover text exposes the exact session ID',
+  );
+  assert(
+    JSON.stringify(rendered.ariaLabels) === JSON.stringify([
+      'Open session: MR review session',
+      'Open session: Provider-neutral session',
+      `Open session: ${untitledSessionId}`,
+    ]),
+    'session buttons have meaningful accessible labels',
+  );
+  assert(
+    rendered.headerLink?.text === 'MR review session'
+      && rendered.headerLink?.title === `Session ID: ${codexSessionId}`
+      && rendered.headerLink?.ariaLabel === 'Open session: MR review session',
+    'Memory header and body session links share title-first labels and UUID hover text',
+  );
   assert(rendered.linkTags.every(tag => tag === 'BUTTON'), 'resolved references use internal navigation buttons');
   assert(rendered.allReuseSessionStyle && rendered.allHaveIcons, 'links reuse the existing session-link visual language');
   assert(rendered.inlineCodes.includes(missingSessionId), 'unknown session ID remains ordinary inline code');

--- a/app/tests/electron-memory-session-links.mjs
+++ b/app/tests/electron-memory-session-links.mjs
@@ -1,0 +1,184 @@
+import { app, BrowserWindow, ipcMain } from 'electron';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appRoot = join(here, '..');
+const sessionId = 'codex:019f6392-0dba-7f13-be12-541db3645a69';
+const missingSessionId = 'codex:00000000-0000-0000-0000-000000000000';
+const memoryId = 'memory-session-links';
+const memoryMarkdown = `# Linked memory
+
+[MR review session](obelisk://session/${encodeURIComponent(sessionId)})
+
+[Missing session](obelisk://session/${encodeURIComponent(missingSessionId)})
+
+\`${sessionId}\`
+
+\`\`\`markdown
+[Code sample](obelisk://session/${encodeURIComponent(sessionId)})
+\`\`\`
+`;
+
+const channels = [
+  'db:getSessions',
+  'db:getSessionMessages',
+  'db:getSessionToolCalls',
+  'db:getSessionToolResults',
+  'db:getSessionPatch',
+  'db:getSessionSubagents',
+  'db:getSessionWorkflows',
+  'db:getSessionSummaries',
+  'db:getMessageFullText',
+  'db:getMemories',
+  'db:readMemoryFile',
+  'db:getProjects',
+  'db:getStats',
+  'settings:get',
+];
+
+let failures = 0;
+
+const session = {
+  id: sessionId,
+  title: 'MR review session',
+  project: 'tcode',
+  project_path: '/tmp/tcode',
+  source: 'codex',
+  started_at: '2026-07-15T02:19:04.014Z',
+  ended_at: '2026-07-15T03:00:00.000Z',
+  message_count: 1,
+  git_branch: 'main',
+};
+
+function assert(condition, message) {
+  if (condition) console.log(`PASS: ${message}`);
+  else {
+    failures++;
+    console.error(`FAIL: ${message}`);
+  }
+}
+
+async function waitFor(webContents, expression, message, timeoutMs = 8_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await webContents.executeJavaScript(`Boolean(${expression})`, true)) return;
+    await delay(40);
+  }
+  throw new Error(`Timed out waiting for ${message}`);
+}
+
+function registerHandlers() {
+  ipcMain.handle('db:getSessions', (_event, opts = {}) => {
+    if (Array.isArray(opts.ids)) return opts.ids.includes(sessionId) ? [session] : [];
+    return [session];
+  });
+  ipcMain.handle('db:getSessionMessages', () => [{
+    uuid: `${sessionId}:000001`,
+    session_id: sessionId,
+    type: 'assistant',
+    role: 'assistant',
+    timestamp: '2026-07-15T02:20:00.000Z',
+    text: 'Linked session detail',
+    content_type: 'text',
+    is_meta: 0,
+  }]);
+  ipcMain.handle('db:getSessionToolCalls', () => []);
+  ipcMain.handle('db:getSessionToolResults', () => []);
+  ipcMain.handle('db:getSessionPatch', () => null);
+  ipcMain.handle('db:getSessionSubagents', () => []);
+  ipcMain.handle('db:getSessionWorkflows', () => []);
+  ipcMain.handle('db:getSessionSummaries', () => []);
+  ipcMain.handle('db:getMessageFullText', () => null);
+  ipcMain.handle('db:getMemories', () => [{
+    id: memoryId,
+    session_id: sessionId,
+    project: 'tcode',
+    message_start: null,
+    message_end: null,
+    path: '/tmp/linked-memory.md',
+    anchors: null,
+    summary: 'A Memory with an explicit Obelisk session link.',
+    created_at: '2026-07-30T04:55:28.011Z',
+    deleted_at: null,
+    deleted_reason: null,
+  }]);
+  ipcMain.handle('db:readMemoryFile', () => memoryMarkdown);
+  ipcMain.handle('db:getProjects', () => [{ project: 'tcode', count: 1 }]);
+  ipcMain.handle('db:getStats', () => ({}));
+  ipcMain.handle('settings:get', () => ({}));
+}
+
+async function run() {
+  registerHandlers();
+  const win = new BrowserWindow({
+    show: false,
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      preload: join(appRoot, 'out', 'preload', 'index.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  await win.loadFile(join(appRoot, 'out', 'renderer', 'index.html'), {
+    hash: `/memory/${memoryId}`,
+  });
+  await waitFor(
+    win.webContents,
+    `document.querySelectorAll('.markdown-session-link').length === 1`,
+    'resolved Memory session link',
+  );
+
+  const rendered = await win.webContents.executeJavaScript(`(() => {
+    const link = document.querySelector('.markdown-session-link');
+    const unavailable = document.querySelector('.markdown-session-reference-unavailable');
+    const inlineCodes = [...document.querySelectorAll('.markdown-body code')].map(node => node.textContent);
+    return {
+      linkText: link?.textContent.trim(),
+      linkSessionId: link?.dataset.obeliskSessionId,
+      linkHref: link?.getAttribute('href'),
+      hasIcon: Boolean(link?.querySelector('svg')),
+      unavailableText: unavailable?.textContent.trim(),
+      unavailableIsLink: unavailable?.matches('a'),
+      inlineCodes,
+      renderedLinkCount: document.querySelectorAll('.markdown-body a').length,
+    };
+  })()`, true);
+
+  assert(rendered.linkText === 'MR review session', `canonical link keeps its descriptive label (${JSON.stringify(rendered)})`);
+  assert(rendered.linkSessionId === sessionId, 'resolved link carries the canonical session id');
+  assert(rendered.linkHref === `obelisk://session/${encodeURIComponent(sessionId)}`, 'rendered link keeps the canonical Obelisk href');
+  assert(rendered.hasIcon, 'rendered link reuses the session icon language');
+  assert(rendered.unavailableText === 'Missing session' && rendered.unavailableIsLink === false, 'missing target becomes readable non-link text');
+  assert(rendered.inlineCodes.includes(sessionId), 'bare inline session id remains ordinary code');
+  assert(rendered.inlineCodes.some(text => text.includes('Code sample')), 'fenced Markdown sample remains code');
+  assert(rendered.renderedLinkCount === 1, 'fenced and missing references do not become navigable links');
+
+  await win.webContents.executeJavaScript(
+    `document.querySelector('.markdown-session-link').click()`,
+    true,
+  );
+  await waitFor(
+    win.webContents,
+    `window.location.hash.includes('/sessions/') && document.body.textContent.includes('Linked session detail')`,
+    'internal Session Detail navigation',
+  );
+  const route = await win.webContents.executeJavaScript('window.location.hash', true);
+  assert(decodeURIComponent(route).includes(sessionId), `click stays inside Obelisk and opens the requested session (${route})`);
+
+  win.destroy();
+}
+
+app.whenReady()
+  .then(run)
+  .catch(error => {
+    failures++;
+    console.error(error.stack || error);
+  })
+  .finally(() => {
+    for (const channel of channels) ipcMain.removeHandler(channel);
+    app.exit(failures ? 1 : 0);
+  });

--- a/skill-doc/SKILL.md
+++ b/skill-doc/SKILL.md
@@ -296,6 +296,19 @@ briefly and ask before changing memory state.
 **Writing memories:** after a retrieval produces a conclusion worth persisting,
 propose writing a memory file. The user must approve. Flow:
 
+When earlier sessions materially support the Memory and a reader would benefit
+from revisiting them, keep that path open with a standard Markdown link:
+
+```markdown
+[descriptive session label](obelisk://session/codex%3A019f6392-0dba-7f13-be12-541db3645a69)
+```
+
+Use the full canonical `sessions.id` as the URL-encoded path segment and give
+the link a short label that explains why the session matters. Place links near
+the claims they support or in a naturally named source section when that reads
+better. This is an optional provenance aid, not a required section or rigid
+Memory template.
+
 1. Write a markdown file using the `Write` tool (user approves).
 2. Register it via `remember()` in a narrow memory-registration script:
 

--- a/skill-doc/SKILL.md
+++ b/skill-doc/SKILL.md
@@ -296,19 +296,6 @@ briefly and ask before changing memory state.
 **Writing memories:** after a retrieval produces a conclusion worth persisting,
 propose writing a memory file. The user must approve. Flow:
 
-When earlier sessions materially support the Memory and a reader would benefit
-from revisiting them, keep that path open with a standard Markdown link:
-
-```markdown
-[descriptive session label](obelisk://session/codex%3A019f6392-0dba-7f13-be12-541db3645a69)
-```
-
-Use the full canonical `sessions.id` as the URL-encoded path segment and give
-the link a short label that explains why the session matters. Place links near
-the claims they support or in a naturally named source section when that reads
-better. This is an optional provenance aid, not a required section or rigid
-Memory template.
-
 1. Write a markdown file using the `Write` tool (user approves).
 2. Register it via `remember()` in a narrow memory-registration script:
 

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -417,6 +417,26 @@ test('session IPC hides Codex rows by default and supports explicit source opt-i
     assert.match(queries.at(-1).sql, /COALESCE\(source, 'claude'\) = \?/);
     assert.ok(queries.at(-1).params.includes('codex'));
 
+    ipcHandlers.get('db:getSessions')(null, {
+      source: 'all',
+      ids: ['codex:session-a', 'claude-session-b', 'codex:session-a'],
+      limit: 50,
+    });
+    assert.match(queries.at(-1).sql, /id IN \(\?,\?\)/);
+    assert.deepEqual(
+      queries.at(-1).params,
+      ['codex:session-a', 'claude-session-b', 2],
+      'exact session lookup deduplicates IDs and limits the query to the requested set',
+    );
+
+    const queryCount = queries.length;
+    assert.deepEqual(
+      ipcHandlers.get('db:getSessions')(null, { source: 'all', ids: [] }),
+      [],
+      'an explicit empty ID set never falls back to the full session catalogue',
+    );
+    assert.equal(queries.length, queryCount);
+
     await ipcHandlers.get('settings:get')();
     assert.ok(
       queries.some(q => /GROUP BY COALESCE\(source, 'claude'\)/.test(q.sql)),

--- a/tests/memory-session-links.test.mjs
+++ b/tests/memory-session-links.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { parseObeliskSessionHref } from '../app/src/renderer/src/memory-session-links.mjs';
+
+test('parses canonical Obelisk session links without assuming a provider', () => {
+  assert.equal(
+    parseObeliskSessionHref('obelisk://session/codex%3A019f6392-0dba-7f13-be12-541db3645a69'),
+    'codex:019f6392-0dba-7f13-be12-541db3645a69',
+  );
+  assert.equal(
+    parseObeliskSessionHref('obelisk://session/claude-session-id'),
+    'claude-session-id',
+  );
+});
+
+test('rejects malformed or expanded Obelisk session targets', () => {
+  assert.equal(parseObeliskSessionHref('https://example.com/session/id'), null);
+  assert.equal(parseObeliskSessionHref('obelisk://memory/id'), null);
+  assert.equal(parseObeliskSessionHref('obelisk://session/'), null);
+  assert.equal(parseObeliskSessionHref('obelisk://session/a/b'), null);
+  assert.equal(parseObeliskSessionHref('obelisk://session/id?focus=message'), null);
+  assert.equal(parseObeliskSessionHref('obelisk://session/id#message'), null);
+  assert.equal(parseObeliskSessionHref('obelisk://user:secret@session/id'), null);
+  assert.equal(parseObeliskSessionHref('obelisk://session/id%2Fchild'), null);
+});
+
+test('the published skill source documents the canonical link without imposing a section template', () => {
+  const skill = readFileSync(new URL('../skill-doc/SKILL.md', import.meta.url), 'utf8');
+  assert.match(skill, /\[descriptive session label\]\(obelisk:\/\/session\/codex%3A/);
+  assert.match(skill, /optional provenance aid/);
+  assert.match(skill, /not a required section or rigid\s+Memory template/);
+});

--- a/tests/memory-session-links.test.mjs
+++ b/tests/memory-session-links.test.mjs
@@ -1,34 +1,47 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { parseObeliskSessionHref } from '../app/src/renderer/src/memory-session-links.mjs';
+import {
+  collectInlineSessionCandidates,
+  inlineCodeSessionCandidate,
+} from '../app/src/renderer/src/memory-session-links.mjs';
 
-test('parses canonical Obelisk session links without assuming a provider', () => {
-  assert.equal(
-    parseObeliskSessionHref('obelisk://session/codex%3A019f6392-0dba-7f13-be12-541db3645a69'),
-    'codex:019f6392-0dba-7f13-be12-541db3645a69',
-  );
-  assert.equal(
-    parseObeliskSessionHref('obelisk://session/claude-session-id'),
-    'claude-session-id',
+function inlineCode(text, { fenced = false } = {}) {
+  return {
+    textContent: text,
+    closest(selector) {
+      return fenced && selector === 'pre' ? {} : null;
+    },
+  };
+}
+
+test('collects whole inline-code values without assuming a provider or ID format', () => {
+  const codexId = 'codex:019f6392-0dba-7f13-be12-541db3645a69';
+  const providerNeutralId = 'claude-session-id';
+  const ordinaryCode = 'npm test';
+  const nodes = [
+    inlineCode(codexId),
+    inlineCode(`  ${providerNeutralId}  `),
+    inlineCode(ordinaryCode),
+    inlineCode(codexId),
+    inlineCode(codexId, { fenced: true }),
+  ];
+
+  assert.deepEqual(
+    collectInlineSessionCandidates({ querySelectorAll: () => nodes }),
+    [codexId, providerNeutralId, ordinaryCode],
   );
 });
 
-test('rejects malformed or expanded Obelisk session targets', () => {
-  assert.equal(parseObeliskSessionHref('https://example.com/session/id'), null);
-  assert.equal(parseObeliskSessionHref('obelisk://memory/id'), null);
-  assert.equal(parseObeliskSessionHref('obelisk://session/'), null);
-  assert.equal(parseObeliskSessionHref('obelisk://session/a/b'), null);
-  assert.equal(parseObeliskSessionHref('obelisk://session/id?focus=message'), null);
-  assert.equal(parseObeliskSessionHref('obelisk://session/id#message'), null);
-  assert.equal(parseObeliskSessionHref('obelisk://user:secret@session/id'), null);
-  assert.equal(parseObeliskSessionHref('obelisk://session/id%2Fchild'), null);
+test('ignores fenced, empty, and unreasonably large code values before DB lookup', () => {
+  assert.equal(inlineCodeSessionCandidate(inlineCode('codex:session', { fenced: true })), null);
+  assert.equal(inlineCodeSessionCandidate(inlineCode('   ')), null);
+  assert.equal(inlineCodeSessionCandidate(inlineCode('x'.repeat(513))), null);
 });
 
-test('the published skill source documents the canonical link without imposing a section template', () => {
-  const skill = readFileSync(new URL('../skill-doc/SKILL.md', import.meta.url), 'utf8');
-  assert.match(skill, /\[descriptive session label\]\(obelisk:\/\/session\/codex%3A/);
-  assert.match(skill, /optional provenance aid/);
-  assert.match(skill, /not a required section or rigid\s+Memory template/);
+test('bounds the number of inline-code candidates sent for exact lookup', () => {
+  const nodes = Array.from({ length: 120 }, (_, index) => inlineCode(`candidate-${index}`));
+  const candidates = collectInlineSessionCandidates({ querySelectorAll: () => nodes });
+  assert.equal(candidates.length, 100);
+  assert.equal(candidates.at(-1), 'candidate-99');
 });


### PR DESCRIPTION
## What this opens up

When a Memory already contains a session ID in inline code, Obelisk can now turn that existing trace into a direct reading path. For example, `codex:<uuid>` becomes interactive only when the local database confirms that the exact session exists.

There is no new Markdown syntax and nothing for agents to learn or rewrite.

## What changed

- Collect complete inline-code values from Memory Markdown as bounded candidates.
- Exclude fenced code blocks before lookup.
- Resolve candidates with a batched exact-ID query against the App's `sessions` table.
- Turn only confirmed matches into internal session buttons.
- Display each confirmed session's title and expose its exact ID through the App's existing native hover convention; untitled sessions fall back to the full ID.
- Keep unknown IDs and ordinary inline code exactly as they were.
- Reuse the existing `session-link` styling and icon from the Memory header.
- Open confirmed sessions through the Vue Router without leaving Obelisk.

## Boundary

After discussing the ownership boundary, this PR deliberately does **not** introduce an `obelisk://` protocol or document a new agent-facing convention. Core and the published Obelisk skill are unchanged.

The App does not parse UUIDs or assume a Codex-specific shape. A value becomes interactive only when it exactly matches a real `sessions.id`, which keeps the behavior provider-neutral and avoids accidental format rules.

Existing Memory files are not migrated or edited.

## Validation

Passed:

- `npm test` — 298 tests
- `npm run typecheck`
- `npm run lint` — no errors; 4 pre-existing unused-variable warnings
- `cd app && npm run test:electron:memory-links`
- `cd app && npm run test:electron`

The Electron Memory test exercises the production renderer build and confirms exact DB resolution, title-first labels, UUID hover text, untitled fallbacks, accessible labels, provider-neutral IDs, unknown and ordinary inline code, fenced-code exclusion, reused styling, and in-App navigation.

Closes #10
