### PR TITLE
feat(core): make the FTS5 tokenizer configurable (CJK recall)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,23 @@ run `npm ci` again.
 
 Full-text search via FTS5 covers all layers.
 
+### CJK transcripts
+
+FTS5 defaults to the `unicode61` tokenizer, which treats an unbroken run of Chinese,
+Japanese, or Korean characters as a single token — a phrase only matches when it happens
+to be delimited by punctuation or ASCII, and identifiers glued to CJK text (`重跑gen-itgc后`)
+are missed. Sessions in those languages can set a different tokenizer:
+
+```bash
+export OBELISK_FTS_TOKENIZER=trigram
+```
+
+The next command migrates both FTS tables and reindexes them from the content tables;
+nothing else needs to be rebuilt, and unsetting the variable leaves the existing index
+alone. The trade-off is a larger index (the inverted index grows roughly 5x, though it is
+a small share of the database) and a floor of 3 characters per query — `trigram` cannot
+match anything shorter, so short queries need `sql()` with `LIKE`.
+
 ## Structure
 
 ```

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -10,7 +10,7 @@ import { createIndexerService } from './indexer-service.ts';
 import { createWorkerBuildIndex } from './indexer-worker-client.ts';
 import { buildRecapExportQuery } from './recap-capture-query.ts';
 import { acquireWriterLease, writerLockPathFor } from '../../../packages/core/src/writer-lease.ts';
-import { migrateCoreSchemaColumns } from '../../../packages/core/src/schema-migrations.ts';
+import { migrateCoreSchemaColumns, migrateFtsTokenizer, resolveFtsTokenizer } from '../../../packages/core/src/schema-migrations.ts';
 import { createBuiltinProviderRegistry } from '../../../packages/core/src/providers/builtins.ts';
 import {
   buildSourceCatalog,
@@ -167,6 +167,7 @@ function migrateDb(db) {
   const schemaPath = resolveSchemaPath();
   if (schemaPath) db.exec(fs.readFileSync(schemaPath, 'utf8'));
   migrateCoreSchemaColumns(db);
+  migrateFtsTokenizer(db, resolveFtsTokenizer());
 }
 
 function closeDb() {

--- a/app/src/main/indexer.ts
+++ b/app/src/main/indexer.ts
@@ -11,7 +11,7 @@ import {
   writeProviderIndexMarkers,
 } from '../../../packages/core/src/provider-indexing.ts';
 import { runWriteTransaction, configureConnection, betterSqliteTransactionAdapter } from '../../../packages/core/src/tx.ts';
-import { migrateCoreSchemaColumns } from '../../../packages/core/src/schema-migrations.ts';
+import { migrateCoreSchemaColumns, migrateFtsTokenizer, resolveFtsTokenizer } from '../../../packages/core/src/schema-migrations.ts';
 import { acquireWriterLease, writerLockPathFor } from '../../../packages/core/src/writer-lease.ts';
 import { runRetryableWriteTransaction, isBeginBusyFailure, hasUnusableTransaction } from '../../../packages/core/src/write-coordinator.ts';
 import {
@@ -38,6 +38,7 @@ function resolveSchemaPath() {
 function installSchema(db, schemaPath = resolveSchemaPath()) {
   db.exec(fs.readFileSync(schemaPath, 'utf8'));
   migrateCoreSchemaColumns(db);
+  migrateFtsTokenizer(db, resolveFtsTokenizer());
 }
 
 function openIndexDb({ dbPath = DEFAULT_DB_PATH, schemaPath = resolveSchemaPath(), DatabaseImpl = Database }: { dbPath?: string; schemaPath?: string; DatabaseImpl?: new (dbPath: string) => any } = {}) {

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2,7 +2,7 @@
 import { createRequire } from 'node:module';
 import { CLAUDE_DIR, CODEX_DIR, TEXT_LIMIT, trunc, truncJson, extractText, extractContentType, extractMessageIsMeta, filePath, isDir, readLines } from './parsing.ts';
 import { configureConnection } from './tx.ts';
-import { migrateCoreSchemaColumns } from './schema-migrations.ts';
+import { migrateCoreSchemaColumns, migrateFtsTokenizer, resolveFtsTokenizer } from './schema-migrations.ts';
 import type { NodeSqliteDb, SqliteDb } from './sqlite-types.ts';
 const require = createRequire(import.meta.url);
 const fs = require('node:fs');
@@ -30,6 +30,7 @@ function openDb(): NodeSqliteDb {
   migrateCoreSchemaColumns(db);
   db.exec(SCHEMA);
   migrateCoreSchemaColumns(db);
+  migrateFtsTokenizer(db, resolveFtsTokenizer());
   return db;
 }
 

--- a/packages/core/src/indexer.ts
+++ b/packages/core/src/indexer.ts
@@ -6,6 +6,7 @@ import {
   indexProviderPlan,
   writeProviderIndexMarkers,
 } from './provider-indexing.ts';
+import { ftsTokenizerMigrationPending, resolveFtsTokenizer } from './schema-migrations.ts';
 import { nodeSqliteTransactionAdapter } from './tx.ts';
 import { acquireWriterLease, writerLockPathFor } from './writer-lease.ts';
 import { runRetryableWriteTransaction, isBeginBusyFailure, hasUnusableTransaction } from './write-coordinator.ts';
@@ -21,6 +22,7 @@ interface SkippedFile {
 interface BuildCheckOptions {
   now?: number;
   ignoreRecentBuild?: boolean;
+  ftsTokenizer?: string | null;
 }
 
 function errorMessage(error: unknown): string {
@@ -47,14 +49,16 @@ function refreshSessionProjectPaths(db: NodeSqliteDb): void {
 const BUILD_DEBOUNCE_MS = 30000;
 const APP_HEARTBEAT_FRESH_MS = 60000;
 
-function shouldSkipBuild(db: NodeSqliteDb, { now = Date.now(), ignoreRecentBuild = false }: BuildCheckOptions = {}) {
+function shouldSkipBuild(db: NodeSqliteDb, { now = Date.now(), ignoreRecentBuild = false, ftsTokenizer = resolveFtsTokenizer() }: BuildCheckOptions = {}) {
   const appHeartbeat = db.prepare("SELECT mtime FROM index_state WHERE jsonl_path='__app_heartbeat__'").get();
   if (appHeartbeat && now - appHeartbeat.mtime < APP_HEARTBEAT_FRESH_MS) {
     return { skip: true, reason: 'daemon_active' };
   }
   if (!ignoreRecentBuild) {
     const last = db.prepare("SELECT mtime FROM index_state WHERE jsonl_path='__last_build__'").get();
-    if (last && now - last.mtime < BUILD_DEBOUNCE_MS) {
+    // A pending tokenizer switch needs the write path, which only the build acquires.
+    // Debouncing here would leave a newly configured tokenizer silently inactive.
+    if (last && now - last.mtime < BUILD_DEBOUNCE_MS && !ftsTokenizerMigrationPending(db, ftsTokenizer)) {
       return { skip: true, reason: 'recent_build' };
     }
   }

--- a/packages/core/src/schema-migrations.ts
+++ b/packages/core/src/schema-migrations.ts
@@ -13,8 +13,82 @@ const COLUMN_MIGRATIONS = [
   ['memories', 'deleted_reason', 'TEXT'],
 ] as const;
 
+const FTS_TABLES = ['messages_fts', 'memories_fts'] as const;
+
+// FTS5 built-in tokenizers plus their word-only arguments. The configured value is
+// interpolated into DDL, so the grammar is a whitelist: no quotes, no separators.
+const TOKENIZER_PATTERN = /^(unicode61|ascii|porter|trigram)(?: [A-Za-z0-9_=]+)*$/;
+
 function tableExists(db: SqliteDb, table: string): boolean {
   return Boolean(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(table));
+}
+
+/**
+ * Read the configured FTS5 tokenizer, or null to keep whatever `schema.sql` declares.
+ * `trigram` makes CJK transcripts searchable (unicode61 indexes a run of CJK as one
+ * token); it costs a larger index and cannot match queries shorter than 3 characters.
+ */
+export function resolveFtsTokenizer(env: Record<string, string | undefined> = process.env): string | null {
+  const configured = String(env.OBELISK_FTS_TOKENIZER || '').trim();
+  if (!configured) return null;
+  if (!TOKENIZER_PATTERN.test(configured)) {
+    throw new Error(`OBELISK_FTS_TOKENIZER must be an FTS5 tokenizer (unicode61|ascii|porter|trigram) with word arguments, got: ${configured}`);
+  }
+  return configured;
+}
+
+function currentTokenizer(createSql: string): string {
+  const match = /tokenize\s*=\s*(['"])(.*?)\1/i.exec(createSql);
+  // FTS5 defaults to unicode61 when the clause is absent.
+  return match ? match[2].trim() : 'unicode61';
+}
+
+function withTokenizer(createSql: string, tokenizer: string): string {
+  const clause = `tokenize='${tokenizer}'`;
+  if (/tokenize\s*=\s*(['"])(.*?)\1/i.test(createSql)) {
+    return createSql.replace(/tokenize\s*=\s*(['"])(.*?)\1/i, clause);
+  }
+  const close = createSql.lastIndexOf(')');
+  return `${createSql.slice(0, close)}, ${clause}${createSql.slice(close)}`;
+}
+
+/**
+ * Whether any FTS table still uses a tokenizer other than the configured one.
+ * The build debounce consults this so a newly configured tokenizer takes effect on the
+ * next command instead of waiting for the next unthrottled build.
+ */
+export function ftsTokenizerMigrationPending(db: SqliteDb, tokenizer: string | null): boolean {
+  if (!tokenizer) return false;
+  return FTS_TABLES.some(table => {
+    const row = db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name=?").get(table) as { sql?: string } | undefined;
+    if (!row?.sql) return false;
+    return currentTokenizer(row.sql) !== tokenizer;
+  });
+}
+
+/**
+ * Binding-agnostic FTS tokenizer migration shared by the CLI and desktop app.
+ *
+ * `schema.sql` is `CREATE VIRTUAL TABLE IF NOT EXISTS`, so an existing FTS table keeps
+ * its original tokenizer forever; switching requires dropping and repopulating it. The
+ * table definition is rewritten from `sqlite_master` rather than restated here, so
+ * `schema.sql` stays the single source of truth for the columns.
+ *
+ * Not wrapped in a transaction on purpose: if this is interrupted between the drop and
+ * the create, the next `schema.sql` pass recreates the table and this migration runs
+ * again. Triggers live on the content tables and survive the drop.
+ */
+export function migrateFtsTokenizer(db: SqliteDb, tokenizer: string | null): void {
+  if (!tokenizer) return;
+  for (const table of FTS_TABLES) {
+    const row = db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name=?").get(table) as { sql?: string } | undefined;
+    if (!row?.sql) continue;
+    if (currentTokenizer(row.sql) === tokenizer) continue;
+    db.exec(`DROP TABLE ${table}`);
+    db.exec(withTokenizer(row.sql, tokenizer));
+    // External content tables hold no data of their own; repopulate from the content table.
+    db.exec(`INSERT INTO ${table}(${table}) VALUES('rebuild')`);
+  }
 }
 
 /** Binding-agnostic additive migrations shared by the CLI and desktop app. */

--- a/tests/fts-tokenizer.test.mjs
+++ b/tests/fts-tokenizer.test.mjs
@@ -1,0 +1,172 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+
+import { ftsTokenizerMigrationPending, migrateFtsTokenizer, resolveFtsTokenizer } from '../packages/core/src/schema-migrations.ts';
+import { shouldSkipBuild } from '../packages/core/src/indexer.ts';
+
+const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+
+function openSchemaDb() {
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  return db;
+}
+
+function insertMessage(db, uuid, text) {
+  db.prepare('INSERT INTO messages (uuid, session_id, text) VALUES (?,?,?)').run(uuid, 'session-1', text);
+}
+
+function ftsHits(db, query) {
+  return db.prepare('SELECT COUNT(*) c FROM messages_fts WHERE text MATCH ?').get(query).c;
+}
+
+function createSqlFor(db, table) {
+  return db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name=?").get(table).sql;
+}
+
+test('resolveFtsTokenizer keeps the schema default when unset', () => {
+  assert.equal(resolveFtsTokenizer({}), null);
+  assert.equal(resolveFtsTokenizer({ OBELISK_FTS_TOKENIZER: '' }), null);
+  assert.equal(resolveFtsTokenizer({ OBELISK_FTS_TOKENIZER: '  ' }), null);
+});
+
+test('resolveFtsTokenizer accepts FTS5 tokenizers and their word arguments', () => {
+  assert.equal(resolveFtsTokenizer({ OBELISK_FTS_TOKENIZER: 'trigram' }), 'trigram');
+  assert.equal(resolveFtsTokenizer({ OBELISK_FTS_TOKENIZER: ' trigram ' }), 'trigram');
+  assert.equal(
+    resolveFtsTokenizer({ OBELISK_FTS_TOKENIZER: 'unicode61 remove_diacritics 1' }),
+    'unicode61 remove_diacritics 1',
+  );
+});
+
+test('resolveFtsTokenizer rejects values that could break out of the DDL', () => {
+  for (const value of ["trigram'); DROP TABLE messages; --", 'bogus', "unicode61'", 'trigram; VACUUM']) {
+    assert.throws(() => resolveFtsTokenizer({ OBELISK_FTS_TOKENIZER: value }), /OBELISK_FTS_TOKENIZER/);
+  }
+});
+
+test('migrateFtsTokenizer is a no-op without configuration', () => {
+  const db = openSchemaDb();
+  try {
+    const before = createSqlFor(db, 'messages_fts');
+    migrateFtsTokenizer(db, null);
+    assert.equal(createSqlFor(db, 'messages_fts'), before);
+  } finally {
+    db.close();
+  }
+});
+
+test('migrateFtsTokenizer switches both FTS tables and repopulates existing rows', () => {
+  const db = openSchemaDb();
+  try {
+    // Indexed before the migration: a CJK phrase glued into a longer run of CJK,
+    // which unicode61 indexes as a single token and cannot match on a sub-phrase.
+    insertMessage(db, 'msg-1', '步2 重跑gen-itgc后50条悬空引用清零，修复已验证');
+    assert.equal(ftsHits(db, '悬空引用'), 0, 'unicode61 should miss the sub-phrase');
+
+    migrateFtsTokenizer(db, 'trigram');
+
+    for (const table of ['messages_fts', 'memories_fts']) {
+      assert.match(createSqlFor(db, table), /tokenize='trigram'/);
+    }
+    assert.equal(ftsHits(db, '悬空引用'), 1, 'rebuild should reindex rows written before the switch');
+    assert.equal(ftsHits(db, 'itgc'), 1, 'ASCII glued to CJK should match too');
+  } finally {
+    db.close();
+  }
+});
+
+test('migrateFtsTokenizer keeps the content triggers working after the swap', () => {
+  const db = openSchemaDb();
+  try {
+    migrateFtsTokenizer(db, 'trigram');
+
+    insertMessage(db, 'msg-2', '额度调整链在这里被提到');
+    assert.equal(ftsHits(db, '额度调整链'), 1, 'insert trigger should feed the rebuilt table');
+
+    db.prepare('UPDATE messages SET text=? WHERE uuid=?').run('所有权制度改写后的正文', 'msg-2');
+    assert.equal(ftsHits(db, '额度调整链'), 0, 'update trigger should retract the old text');
+    assert.equal(ftsHits(db, '所有权制度'), 1, 'update trigger should index the new text');
+
+    db.prepare('DELETE FROM messages WHERE uuid=?').run('msg-2');
+    assert.equal(ftsHits(db, '所有权制度'), 0, 'delete trigger should retract the row');
+  } finally {
+    db.close();
+  }
+});
+
+test('ftsTokenizerMigrationPending reports only a real mismatch', () => {
+  const db = openSchemaDb();
+  try {
+    assert.equal(ftsTokenizerMigrationPending(db, null), false, 'unconfigured means nothing to do');
+    assert.equal(ftsTokenizerMigrationPending(db, 'trigram'), true);
+    assert.equal(ftsTokenizerMigrationPending(db, 'unicode61'), true, 'memories_fts still carries arguments');
+
+    migrateFtsTokenizer(db, 'trigram');
+    assert.equal(ftsTokenizerMigrationPending(db, 'trigram'), false);
+  } finally {
+    db.close();
+  }
+});
+
+test('the build debounce yields to a pending tokenizer switch', () => {
+  const db = openSchemaDb();
+  try {
+    db.prepare('INSERT INTO index_state (jsonl_path, mtime, lines_processed) VALUES (?, ?, 0)').run('__last_build__', 100000);
+
+    assert.deepEqual(
+      shouldSkipBuild(db, { now: 110000, ftsTokenizer: null }),
+      { skip: true, reason: 'recent_build' },
+      'an unconfigured tokenizer keeps the debounce intact',
+    );
+    assert.equal(
+      shouldSkipBuild(db, { now: 110000, ftsTokenizer: 'trigram' }).skip,
+      false,
+      'a pending switch needs the write path the build owns',
+    );
+
+    migrateFtsTokenizer(db, 'trigram');
+    assert.deepEqual(
+      shouldSkipBuild(db, { now: 110000, ftsTokenizer: 'trigram' }),
+      { skip: true, reason: 'recent_build' },
+      'once migrated the debounce applies again',
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test('daemon ownership still wins over a pending tokenizer switch', () => {
+  const db = openSchemaDb();
+  try {
+    db.prepare('INSERT INTO index_state (jsonl_path, mtime, lines_processed) VALUES (?, ?, 0)').run('__app_heartbeat__', 100000);
+
+    assert.deepEqual(
+      shouldSkipBuild(db, { now: 110000, ftsTokenizer: 'trigram' }),
+      { skip: true, reason: 'daemon_active' },
+      'the app owns writes and runs the same migration itself',
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test('migrateFtsTokenizer is idempotent and reversible', () => {
+  const db = openSchemaDb();
+  try {
+    insertMessage(db, 'msg-3', '悬空清零');
+
+    migrateFtsTokenizer(db, 'trigram');
+    const afterFirst = createSqlFor(db, 'messages_fts');
+    migrateFtsTokenizer(db, 'trigram');
+    assert.equal(createSqlFor(db, 'messages_fts'), afterFirst, 'second run should not rewrite the table');
+
+    migrateFtsTokenizer(db, 'unicode61');
+    assert.match(createSqlFor(db, 'messages_fts'), /tokenize='unicode61'/);
+    assert.equal(ftsHits(db, '悬空清零'), 1, 'switching back should keep the row searchable');
+  } finally {
+    db.close();
+  }
+});


### PR DESCRIPTION
Closes #9 — but as an opt-in rather than a default change, since switching every user to `trigram` would be a regression for Latin-script transcripts.

## Problem

`messages_fts` is created without a `tokenize` option (`packages/core/src/schema.sql:37`), so FTS5 falls back to `unicode61`, which indexes an unbroken run of CJK as one token. The repro from #9:

```sql
CREATE VIRTUAL TABLE t USING fts5(c);  -- default unicode61, same as messages_fts
INSERT INTO t VALUES ('步2 重跑gen-itgc后50条悬空引用清零，修复已验证');
SELECT count(*) FROM t WHERE t MATCH '悬空';   -- 0
SELECT count(*) FROM t WHERE t MATCH 'itgc';   -- 0  (glued to CJK)
```

One correction to the issue, from measuring a real index rather than the minimal repro: CJK phrases are not uniformly zero-hit. A phrase matches when it happens to be delimited by punctuation or ASCII, so the real failure mode is **silent partial recall**, which is worse than an obvious zero. Against 379,877 messages (2.5 GB of transcripts), with `LIKE` as ground truth:

| query | `LIKE` | `unicode61` | `trigram` |
|---|---|---|---|
| 额度调整链 | 12 | 7 | 12 |
| 所有权制度 | 21 | 4 | 21 |
| `itgc` (glued to CJK) | 368 | 361 | 368 |

## Approach

`OBELISK_FTS_TOKENIZER` selects any built-in FTS5 tokenizer. Unset — the default — nothing changes at all.

`schema.sql` is deliberately untouched. Because it is `CREATE VIRTUAL TABLE IF NOT EXISTS`, an existing FTS table keeps its original tokenizer forever, so switching means dropping and repopulating. The migration rewrites the `tokenize` clause of the table's own `sqlite_master` definition instead of restating the columns, so `schema.sql` stays the single source of truth and this keeps working if the FTS columns ever change. Triggers live on the content tables and survive the drop.

It runs alongside `migrateCoreSchemaColumns` at all three call sites (core `openDb`, app `migrateDb`, app `installSchema`), so the CLI and the desktop app converge on the same tokenizer.

Two details worth review:

- **The build debounce yields to a pending switch.** Only the build path opens a write connection, so a newly configured tokenizer would otherwise stay silently inactive for up to 30s — or indefinitely while the app holds write ownership. `daemon_active` still wins, since the app runs the same migration itself.
- **No transaction around drop/create/rebuild**, on purpose: if it is interrupted, the next `schema.sql` pass recreates the table and the migration runs again. Wrapping it would add a long write transaction for no additional safety.

The env value is interpolated into DDL, so it is whitelisted against `^(unicode61|ascii|porter|trigram)( [A-Za-z0-9_=]+)*$` and throws on anything else.

## Trade-offs (measured, not estimated)

On the same 379,877-message index:

| | `unicode61` | `trigram` |
|---|---|---|
| full build | 95 s | 113 s |
| whole database | 817 MB | 945 MB (+15.7%) |
| `messages_fts` inverted index | 28 MB | 151 MB (5.4x) |
| one-time migration | — | ~35 s |

The inverted index grows 5.4x, but only +15.7% of the database, since `messages.text` is 30 MB of an 817 MB file dominated by `tool_results`.

The real cost is the **3-character floor**: `trigram` cannot match a shorter query and returns zero *without an error*, which is a sharp edge for 2-character CJK words and for `ok` / `id`-style ASCII. That is precisely why this is opt-in. It is documented in the README next to the setting, pointing at `sql()` + `LIKE` for short queries.

## Verification

- New `tests/fts-tokenizer.test.mjs` (10 tests): whitelist rejection, no-op when unset, both tables switching, **rows written before the switch becoming searchable after the rebuild**, insert/update/delete triggers still feeding the rebuilt table, idempotence, reversibility, the debounce interaction, and daemon precedence.
- Full suite, `typecheck`, `lint`, `build:core`, `build:cli`: no regression. Pre-existing failures on my machine (`better-sqlite3` cannot build on Node 26) are identical with and without this change — I could not exercise the app runtime path locally, only typecheck it, so that call site deserves a second look.
- End-to-end against the real 2.5 GB transcript corpus in an isolated `HOME`: default build stays `unicode61`; setting the variable migrates both tables and every query above goes from partial to exact agreement with `LIKE`; switching back to `unicode61` and forward to `trigram` again both work, the second one inside the debounce window.

## Not included

The skill still tells agents to translate the request into English topic terms first, which is the right default for `unicode61` but leaves recall on the table once `trigram` is on. Happy to follow up there, and on surfacing this in the app's settings UI, if the approach looks right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
