### PR TITLE
feat(core): index failed tool results for retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,10 @@ run `npm ci` again.
 | **Workflow agents** | Claude `subagents/workflows/wf_<runId>/` | Per-agent transcripts |
 | **Memories** | registered markdown files | Conclusions linked to source sessions |
 
-Full-text search via FTS5 covers all layers.
+Full-text search via FTS5 covers messages, memories, and failed tool results.
+Successful tool output is stored and queryable with SQL, but not full-text
+indexed — it is by far the largest layer, and scoping a `LIKE` to a session is
+already fast once retrieval has found one.
 
 ## Structure
 

--- a/app/src/main/indexer.ts
+++ b/app/src/main/indexer.ts
@@ -124,6 +124,11 @@ function refreshSessionProjectPaths(db) {
 function rebuildFts(db) {
   db.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
   db.exec("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')");
+  // tool_errors_fts holds only is_error rows, so it is refreshed wholesale
+  // rather than by trigger. See packages/core/src/schema.sql for why.
+  db.exec('DELETE FROM tool_errors_fts');
+  db.exec(`INSERT INTO tool_errors_fts (tool_use_id, session_id, content)
+    SELECT tool_use_id, session_id, content FROM tool_results WHERE is_error = 1`);
 }
 
 // PASSIVE by default: it checkpoints what it can without blocking concurrent

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -49,5 +49,17 @@ function rebuildMemoryFts(db: SqliteDb): void {
   db.exec("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')");
 }
 
+/**
+ * Repopulate the failed-tool-result index. This is a full refresh rather than
+ * incremental bookkeeping: only `is_error` rows are indexed (a few thousand on a
+ * large history), and `tool_results` is written with INSERT OR REPLACE, whose
+ * implicit deletes do not fire DELETE triggers unless recursive_triggers is on.
+ */
+function rebuildToolErrorsFts(db: SqliteDb): void {
+  db.exec('DELETE FROM tool_errors_fts');
+  db.exec(`INSERT INTO tool_errors_fts (tool_use_id, session_id, content)
+    SELECT tool_use_id, session_id, content FROM tool_results WHERE is_error = 1`);
+}
 
-export { CLAUDE_DIR, CODEX_DIR, OBELISK_DIR, DB_PATH, TEXT_LIMIT, openDb, openReadDb, openWriterLeaseDb, rebuildMemoryFts, trunc, truncJson, extractText, extractContentType, extractMessageIsMeta, filePath, isDir, readLines, fs, path, os };
+
+export { CLAUDE_DIR, CODEX_DIR, OBELISK_DIR, DB_PATH, TEXT_LIMIT, openDb, openReadDb, openWriterLeaseDb, rebuildMemoryFts, rebuildToolErrorsFts, trunc, truncJson, extractText, extractContentType, extractMessageIsMeta, filePath, isDir, readLines, fs, path, os };

--- a/packages/core/src/indexer.ts
+++ b/packages/core/src/indexer.ts
@@ -1,5 +1,5 @@
 // Passive-pull indexing orchestration for the Core package.
-import { DB_PATH, openDb, openReadDb, openWriterLeaseDb, rebuildMemoryFts } from './db.ts';
+import { DB_PATH, openDb, openReadDb, openWriterLeaseDb, rebuildMemoryFts, rebuildToolErrorsFts } from './db.ts';
 import { fs, inferProjectPath } from './parsing.ts';
 import {
   createProviderIndexPlan,
@@ -145,6 +145,7 @@ function buildIndex({ force = false }: { force?: boolean } = {}) {
           refreshSessionProjectPaths(db);
           db.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
           rebuildMemoryFts(db);
+          rebuildToolErrorsFts(db);
           db.prepare("INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES ('__last_build__', ?, 0)").run(Date.now());
           writeProviderIndexMarkers(db, providerPlan, providerResult);
         }, { label: 'finalize' });

--- a/packages/core/src/schema.sql
+++ b/packages/core/src/schema.sql
@@ -50,6 +50,19 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_au AFTER UPDATE ON messages BEGIN
   INSERT INTO messages_fts(rowid, uuid, session_id, text)
   VALUES (new.rowid, new.uuid, new.session_id, new.text);
 END;
+-- Failed tool results are searchable on their own. Their text -- exit messages,
+-- stack traces, error codes -- is what "how did I fix this last time" actually
+-- looks for, and it is not in messages_fts: measured against a 380k-message
+-- index, ~37% of failed tool calls leave no trace in messages.text at all,
+-- because the model fixes the error instead of quoting it. Only is_error rows
+-- are indexed; they are 0.6% of tool_results by size.
+--
+-- Deliberately not maintained by triggers: tool_results is written with
+-- INSERT OR REPLACE, and REPLACE does not fire DELETE triggers unless
+-- recursive_triggers is on, so a trigger pair would leak stale rows. The
+-- indexer repopulates this table wholesale in finalize instead.
+CREATE VIRTUAL TABLE IF NOT EXISTS tool_errors_fts USING fts5(
+  tool_use_id UNINDEXED, session_id UNINDEXED, content);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);
 CREATE INDEX IF NOT EXISTS idx_messages_agent ON messages(agent_id);
 CREATE INDEX IF NOT EXISTS idx_messages_ts ON messages(session_id, timestamp);

--- a/skill-doc/references/query-patterns.md
+++ b/skill-doc/references/query-patterns.md
@@ -516,6 +516,31 @@ return {
 };
 ```
 
+## Finding A Past Failure By Its Error Text
+
+`search()` only covers `messages.text`. When the user remembers the error but not
+the task ("that ENOENT during the deploy"), `search()` often misses it outright —
+the model usually fixes an error rather than quoting it, so the text exists only
+in `tool_results`. Match `tool_errors_fts`, then pivot to the session.
+
+```js
+const failures = sql(`
+  SELECT tef.session_id, tef.tool_use_id, tc.name AS tool_name, s.title, s.project
+  FROM tool_errors_fts tef
+  JOIN tool_calls tc ON tc.id = tef.tool_use_id
+  LEFT JOIN sessions s ON s.id = tef.session_id
+  WHERE tool_errors_fts MATCH ?
+  LIMIT 10
+`, '"ENOENT"');
+
+// Then read what happened around it, in the session it belongs to.
+const nearby = failures[0] ? thread(failures[0].session_id) : [];
+```
+
+Quote the MATCH argument (`'"ENOENT"'`): bare hyphens and punctuation are FTS5
+operators. Only failed results are indexed; for successful tool output, scope a
+`LIKE` to a known `session_id` (indexed, fast) rather than scanning every row.
+
 ## Failed Tool Counts
 
 For precise counts, aggregate in SQL. Do not hand-count long result rows in the

--- a/skill-doc/references/schema.md
+++ b/skill-doc/references/schema.md
@@ -120,6 +120,28 @@ One row per tool result.
 
 `tool_results` does not have timestamps. Join through `messages`.
 
+### `tool_errors_fts`
+
+FTS5 index over failed tool results only (`is_error = 1`). `search()` covers
+`messages.text` and nothing else, so error text that the assistant never quoted
+is unreachable through it — match here instead when the user is looking for a
+past failure by its message.
+
+| Column | Meaning |
+| --- | --- |
+| `tool_use_id` | FK to `tool_calls.id` (UNINDEXED) |
+| `session_id` | Session the failure happened in (UNINDEXED) |
+| `content` | Indexed error text |
+
+```sql
+SELECT session_id, tool_use_id, content
+FROM tool_errors_fts WHERE tool_errors_fts MATCH '"ENOENT"' LIMIT 10
+```
+
+Quote the MATCH argument: bare hyphens and punctuation are FTS5 operators.
+Successful tool output is not indexed anywhere — filter `tool_results` with
+`LIKE` instead, scoped to a `session_id` once you have one.
+
 ### `summaries`
 
 Session summary rows.

--- a/tests/tool-errors-fts.test.mjs
+++ b/tests/tool-errors-fts.test.mjs
@@ -1,0 +1,120 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+
+import { rebuildToolErrorsFts } from '../packages/core/src/db.ts';
+
+const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+
+function openSchemaDb() {
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  return db;
+}
+
+function insertResult(db, { id, session = 'session-1', content, isError }) {
+  db.prepare('INSERT OR REPLACE INTO tool_results (tool_use_id, message_uuid, session_id, content, is_error) VALUES (?,?,?,?,?)')
+    .run(id, 'msg-' + id, session, content, isError);
+}
+
+const hits = (db, query) =>
+  db.prepare('SELECT COUNT(*) c FROM tool_errors_fts WHERE tool_errors_fts MATCH ?').get(query).c;
+const rows = db => db.prepare('SELECT COUNT(*) c FROM tool_errors_fts').get().c;
+
+test('schema declares the failed-tool-result index', () => {
+  assert.match(SCHEMA, /CREATE VIRTUAL TABLE IF NOT EXISTS tool_errors_fts USING fts5/);
+});
+
+test('only failed tool results are indexed', () => {
+  const db = openSchemaDb();
+  try {
+    insertResult(db, { id: 'a', content: 'ENOENT: no such file or directory', isError: 1 });
+    insertResult(db, { id: 'b', content: 'ENOENT appears here but the call succeeded', isError: 0 });
+
+    rebuildToolErrorsFts(db);
+
+    assert.equal(rows(db), 1, 'successful results stay out of the index');
+    assert.equal(hits(db, 'ENOENT'), 1);
+  } finally {
+    db.close();
+  }
+});
+
+test('error text is searchable and carries its session back', () => {
+  const db = openSchemaDb();
+  try {
+    insertResult(db, { id: 'a', session: 'session-42', content: 'TypeError: cannot read property length of undefined', isError: 1 });
+    rebuildToolErrorsFts(db);
+
+    const row = db.prepare('SELECT session_id, tool_use_id FROM tool_errors_fts WHERE tool_errors_fts MATCH ?').get('TypeError');
+    assert.equal(row.session_id, 'session-42');
+    assert.equal(row.tool_use_id, 'a');
+  } finally {
+    db.close();
+  }
+});
+
+test('a rebuild is idempotent', () => {
+  const db = openSchemaDb();
+  try {
+    insertResult(db, { id: 'a', content: 'ENOENT', isError: 1 });
+    rebuildToolErrorsFts(db);
+    rebuildToolErrorsFts(db);
+    assert.equal(rows(db), 1, 'repeated rebuilds must not duplicate rows');
+  } finally {
+    db.close();
+  }
+});
+
+// The reason this table is refreshed wholesale instead of by trigger: the persist
+// layer writes tool_results with INSERT OR REPLACE, and REPLACE only fires DELETE
+// triggers when recursive_triggers is on. A trigger pair would leave the old text
+// behind on every re-index of the same tool call.
+test('re-indexing the same tool call leaves no stale text behind', () => {
+  const db = openSchemaDb();
+  try {
+    insertResult(db, { id: 'a', content: 'ENOENT: original failure text', isError: 1 });
+    rebuildToolErrorsFts(db);
+    assert.equal(hits(db, 'original'), 1);
+
+    insertResult(db, { id: 'a', content: 'EACCES: replaced failure text', isError: 1 });
+    rebuildToolErrorsFts(db);
+
+    assert.equal(rows(db), 1);
+    assert.equal(hits(db, 'original'), 0, 'the superseded text must not remain searchable');
+    assert.equal(hits(db, 'EACCES'), 1);
+  } finally {
+    db.close();
+  }
+});
+
+test('a result that stops being an error drops out of the index', () => {
+  const db = openSchemaDb();
+  try {
+    insertResult(db, { id: 'a', content: 'ENOENT: transient failure', isError: 1 });
+    rebuildToolErrorsFts(db);
+    assert.equal(rows(db), 1);
+
+    insertResult(db, { id: 'a', content: 'ENOENT: transient failure', isError: 0 });
+    rebuildToolErrorsFts(db);
+    assert.equal(rows(db), 0);
+  } finally {
+    db.close();
+  }
+});
+
+test('clearing tool_results clears the index on the next rebuild', () => {
+  const db = openSchemaDb();
+  try {
+    insertResult(db, { id: 'a', content: 'ENOENT', isError: 1 });
+    rebuildToolErrorsFts(db);
+
+    db.exec('DELETE FROM tool_results');   // what a force build does
+    rebuildToolErrorsFts(db);
+
+    assert.equal(rows(db), 0);
+  } finally {
+    db.close();
+  }
+});


### PR DESCRIPTION
`search()` covers `messages.text` and nothing else, so a past failure is findable only when the assistant happened to quote the error — and it usually doesn't, because the model fixes an error rather than restating it. That makes *"how did I fix this last time"* miss precisely the cases it gets asked about most.

## Measurement

Against a real index — 380k messages, 127k tool results, 2.5 GB of transcripts — I sampled 400 error identifiers (`ENOENT`, `TypeError`, `error TS2339`, …) taken from `is_error=1` rows and asked whether `messages_fts` could locate the session they occurred in:

| | share |
|---|---|
| found in the right session via `messages_fts` | 33.7% |
| found only in *other* sessions (wrong hit) | 29.0% |
| **absent from `messages.text` entirely** | **37.3%** |

`InputValidationError` (96 rows) and `JSONDecodeError` (52 rows) are typical: zero hits in `messages_fts`, because they are runtime class names that only ever appeared in tool output.

For contrast, the same probe over *all* tool output — not just failures — is far less alarming (48.8% locatable), and over file names it is 74%. Failures are the sharp edge, which is why this PR indexes only them.

## What this does

`tool_errors_fts` indexes `is_error` rows only — **0.6% of `tool_results` by size** (1.3 MB here), about **6 MB of inverted index on a 950 MB database**.

Successful tool output stays unindexed on purpose. It is ~99% of the volume (`Read` 98.9 MB, `Bash` 90.7 MB on my index), and full-text indexing it would add roughly 1.1 GB. It doesn't earn that: once retrieval has produced a `session_id`, a `LIKE` scoped to it is ~1 ms via `idx_tr_session`, and even an unscoped scan of all 209 MB is 1.7–3.2 s — fine as a deliberate last resort.

**Refreshed wholesale in `finalize`, not maintained by triggers.** `tool_results` is written with `INSERT OR REPLACE`, and REPLACE fires DELETE triggers only when `recursive_triggers` is on (off by default) — a trigger pair would leave superseded error text searchable forever, and re-indexing the same tool call would silently accumulate duplicates. A full refresh of a few thousand rows costs **~0.5 s warm** (4.7 s on a cold page cache), against a 113 s full build. Both index paths do it: `packages/core/src/indexer.ts` via `rebuildToolErrorsFts()`, and the app's `rebuildFts()`.

Every write path stays correct without bookkeeping, since the refresh is unconditional: force build (`DELETE FROM tool_results` then re-index), incremental build, and per-session retraction all converge.

## Verification

`tests/tool-errors-fts.test.mjs`, 7 tests — including the two that motivate the no-trigger decision: re-indexing the same `tool_use_id` leaves no stale text searchable, and a result that stops being an error drops out. Also idempotence, `is_error` filtering, session pivot, and the force-build path.

Full suite / `lint` / `typecheck` / `build:core` / `build:cli`: no regression — failing tests on my machine are identical with and without this change (22 files, all `better-sqlite3`, which cannot build on Node 26). **I could not exercise the app's `rebuildFts()` at runtime for that reason, only typecheck it** — that call site deserves a second look.

## Notes

- The skill is updated too (`references/schema.md`, `references/query-patterns.md`); without it agents won't know the table exists and will keep missing these.
- Independent of #14, but they touch adjacent ground: if #14 lands first, `tool_errors_fts` should join `FTS_TABLES` so a configured tokenizer applies to it as well. Happy to rebase in whichever order you prefer.
- No tokenizer specified here, so it follows the schema default. Error text is overwhelmingly ASCII, so `unicode61` is a reasonable default even for CJK users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
