### PR TITLE
feat(core): add search({ excludeSession }) and derive missing session titles

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -10,6 +10,7 @@ interface QueryOptions extends Record<string, any> {
   limit?: number;
   sessionId?: string;
   sessions?: string[];
+  excludeSession?: string | string[];
   project?: string;
   after?: string;
   before?: string;
@@ -71,6 +72,22 @@ function buildWhere(opts: QueryOptions, aliases: ColumnAliases) {
   return { where: clauses.length ? clauses.join(' AND ') : '1=1', params };
 }
 
+// Most sessions carry no title: current Claude Code versions stopped writing
+// `ai-title` transcript rows and dropped `title` from history.jsonl, so the two
+// upstream title sources are usually absent (96% null on a real index). Derive a
+// navigable label from the opening user message instead of returning null.
+// Command envelopes (`<command-message>…`) are skipped: they name the slash
+// command, not the task.
+function titleExpr(alias: string): string {
+  return `COALESCE(NULLIF(${alias}.title, ''), (
+    SELECT substr(replace(replace(m_t.text, char(10), ' '), char(13), ' '), 1, 80)
+    FROM messages m_t
+    WHERE m_t.session_id = ${alias}.id AND m_t.role = 'user' AND m_t.content_type = 'text'
+      AND COALESCE(m_t.is_meta, 0) = 0 AND m_t.text IS NOT NULL AND m_t.text <> ''
+      AND m_t.text NOT LIKE '<command-%'
+    ORDER BY m_t.timestamp LIMIT 1))`;
+}
+
 const BASH_EXIT_PAT = 'Exit code %';
 
 function assertReadOnlySql(sql: unknown): void {
@@ -119,10 +136,18 @@ function createQueryApi(
   };
 
   const search = (text: string, opts: QueryOptions = {}) => {
-    const { limit = 20, sessionId, project, after, before, cwd, source, includeMeta = false } = opts;
+    const { limit = 20, sessionId, excludeSession, project, after, before, cwd, source, includeMeta = false } = opts;
     let where = 'WHERE mf.text MATCH ?';
     const filterParams: any[] = [];
     if (sessionId) { where += ' AND mf.session_id=?'; filterParams.push(sessionId); }
+    // Searching history from inside a session almost always hits that session's
+    // own prompt, because the query terms came from it. Excluding in SQL keeps
+    // `limit` spent on other sessions; a post-filter in the script would not.
+    const excluded = typeof excludeSession === 'string' ? [excludeSession] : (excludeSession ?? []);
+    if (excluded.length) {
+      where += ` AND mf.session_id NOT IN (${excluded.map(() => '?').join(',')})`;
+      filterParams.push(...excluded);
+    }
     if (project)   { where += ' AND s.project LIKE ?'; filterParams.push(project); }
     if (after)     { where += ' AND m.timestamp>?';    filterParams.push(after); }
     if (before)    { where += ' AND m.timestamp<?';    filterParams.push(before); }
@@ -131,7 +156,7 @@ function createQueryApi(
     if (!includeMeta) where += ' AND COALESCE(m.is_meta,0)=0';
     const stmt = db.prepare(`
       SELECT m.uuid,m.session_id,m.text,m.content_type,m.is_meta,m.role,m.timestamp,m.model,m.cwd,m.source as m_source,
-             s.id as s_id,s.title as s_title,s.project as s_project,s.started_at as s_started,
+             s.id as s_id,${titleExpr('s')} as s_title,s.project as s_project,s.started_at as s_started,
              s.source as s_source,
              rank
       FROM messages_fts mf JOIN messages m ON m.uuid=mf.uuid LEFT JOIN sessions s ON s.id=m.session_id
@@ -266,7 +291,7 @@ function createQueryApi(
     const { limit = 50 } = opts;
     const { where, params } = buildWhere(opts, { sessionId: 's.id', project: 's.project', timestamp: 's.started_at', branch: 's.git_branch', source: 's.source' });
     params.push(limit);
-    return db.prepare(`SELECT * FROM sessions s WHERE ${where} ORDER BY ended_at DESC LIMIT ?`).all(...params);
+    return db.prepare(`SELECT s.*, ${titleExpr('s')} AS title FROM sessions s WHERE ${where} ORDER BY ended_at DESC LIMIT ?`).all(...params);
   };
 
   const recent = (n = 10) => sessions({ limit: n });
@@ -396,7 +421,7 @@ function createQueryApi(
     if (currentProject?.project) {
       const sessionTotal = db.prepare('SELECT COUNT(*) AS c FROM sessions WHERE project = ?').get(currentProject.project)?.c || 0;
       const sessionsForProject = db.prepare(`
-        SELECT id, title, project, project_path, started_at, ended_at, git_branch, message_count, COALESCE(source, 'claude') AS source
+        SELECT id, ${titleExpr('sessions')} AS title, project, project_path, started_at, ended_at, git_branch, message_count, COALESCE(source, 'claude') AS source
         FROM sessions
         WHERE project = ?
         ORDER BY COALESCE(ended_at, started_at) DESC

--- a/skill-doc/SKILL.md
+++ b/skill-doc/SKILL.md
@@ -173,7 +173,11 @@ be treated as the user's request by default. `search()` and `thread()` omit meta
 messages unless `includeMeta: true` is passed; `context()` and `trace()` preserve
 the original chain and expose `is_meta` on rows.
 
-Opts: `{ limit, sessionId, project, after, before, cwd, source, includeMeta }`.
+Opts: `{ limit, sessionId, excludeSession, project, after, before, cwd, source, includeMeta }`.
+
+`excludeSession` takes one session ID or an array of them and filters in SQL,
+before `limit` applies. Use it for the current session; see Exclude Yourself in
+the Retrieval Contract.
 
 `project` is a SQL `LIKE` filter over `sessions.project`, not an exact project
 identity. Results are already ordered by FTS5 rank; lower rank sorts earlier.
@@ -225,6 +229,7 @@ filters or return fields.
 
 - `overview(opts?)` -- compact orientation map. Returns current cwd/project if knowable, global project/source counts, and current-project recent sessions plus memory records. It is a map, not evidence.
 - `sessions(opts?)` -- session rows, newest first. `project` is a SQL `LIKE` pattern.
+- Session `title` is often not stored — recent Claude Code versions rarely write one. `overview()`, `sessions()`, and `search()` therefore fall back to the first 80 characters of the opening user message. Read it as a navigation label, not as a curated title; it is `null` only when the session has no user text.
 - `recent(n?)` -- shorthand for recent sessions.
 - `summaries(opts?)` -- summary rows, newest first: `{ id, session_id, timestamp, source, content, session_title, project }`; here `source` is the summary kind, not the transcript provider.
 - `subagents(opts?)` -- subagent metadata plus `messageCount`.
@@ -247,6 +252,7 @@ Keep queries scoped, bounded, and structural.
 - Plan Before Probe: for conclusion, broad history, failure investigation, or file evolution, write a bounded retrieval script instead of spending turns on intermediate results.
 - Structure Before Text: compute counts, joins, grouping, dedupe, and projection in SQL or JS; keep runtime JSON compact, ideally under 10k-12k chars for synthesis tasks.
 - Evidence Before Conclusion: return compact evidence with stable IDs (`session_id`, `uuid`, `tool_call_id`, `run_id`, `agent_id`) and short snippets, then synthesize in the final answer.
+- Exclude Yourself: when searching history from inside a session, pass that session's ID as `excludeSession`. Your own prompt contains the search terms — they came from it — so it is a guaranteed hit that carries no prior knowledge. Excluding it in SQL keeps `limit` spent on other sessions; filtering the returned array does not.
 - Exclude Meta By Default: `is_meta=1` rows are injected/control-plane transcript material. Helpers hide them by default; raw SQL for ordinary conversation evidence should include `COALESCE(m.is_meta,0)=0` unless meta rows are the investigation target.
 - Persist Durable Conclusions: after answering, if retrieval produced a durable conclusion that future sessions are likely to reuse and `memories()` does not already cover it, explicitly offer to write a memory. Keep the offer brief. Do not write the markdown file or run `--attune` until the user approves.
 

--- a/skill-doc/references/api-reference.md
+++ b/skill-doc/references/api-reference.md
@@ -53,12 +53,17 @@ Full-text search across all indexed message text using FTS5.
 | `text` | `string` | FTS5 query string |
 | `opts.limit` | `number` | Max results, default 20 |
 | `opts.sessionId` | `string` | Restrict to one session |
+| `opts.excludeSession` | `string \| string[]` | Drop hits from these sessions, filtered in SQL before `limit` |
 | `opts.project` | `string` | SQL `LIKE` pattern over `sessions.project` |
 | `opts.after` | `string` | ISO lower bound on message timestamp |
 | `opts.before` | `string` | ISO upper bound on message timestamp |
 | `opts.cwd` | `string` | SQL `LIKE` filter over `messages.cwd` |
 | `opts.source` | `string` | `"claude"`, `"codex"`, or omitted/all |
 | `opts.includeMeta` | `boolean` | Include `is_meta=1` rows, default false |
+
+Pass the current session ID as `excludeSession` when searching history: the query
+terms usually come from the current prompt, so that prompt is a near-guaranteed
+self-hit. Filtering in the script instead wastes part of `limit` on it.
 
 Returns:
 
@@ -200,6 +205,12 @@ Session rows ordered by `ended_at` descending. Passing a number is treated as
 | `opts.sessions` | `string[]` | Restrict to session IDs |
 
 Returns `Array<session_row>`.
+
+`title` is derived when the transcript has none: current Claude Code versions
+rarely emit a session title, so `sessions()`, `overview()`, and `search()` fall
+back to the first 80 characters of the opening user message (command envelopes
+skipped). It stays `null` only when the session has no user text at all. Treat a
+derived title as a navigation label, not as a stored fact.
 
 #### `recent(n?)`
 

--- a/tests/query.test.mjs
+++ b/tests/query.test.mjs
@@ -65,6 +65,63 @@ function searchDb() {
   return db;
 }
 
+// Two untitled sessions, as produced by current Claude Code versions: the
+// current one whose own prompt repeats the search terms, and an older one
+// holding the actual evidence.
+function untitledDb() {
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  const insertSession = db.prepare(`
+    INSERT INTO sessions (id, title, project, project_path, started_at, ended_at, message_count)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `);
+  insertSession.run('sid-current', null, 'quiet-zero', '/tmp/quiet-zero-test', '2026-06-12T10:00:00Z', '2026-06-12T11:00:00Z', 3);
+  insertSession.run('sid-past', null, 'quiet-zero', '/tmp/quiet-zero-test', '2026-06-11T10:00:00Z', '2026-06-11T11:00:00Z', 2);
+  const insert = db.prepare(`
+    INSERT INTO messages (uuid, session_id, text, role, timestamp, content_type, is_meta)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `);
+  insert.run('cur-cmd', 'sid-current', '<command-message>obelisk</command-message>', 'user', '2026-06-12T10:00:00Z', 'text', 0);
+  insert.run('cur-prompt', 'sid-current', 'find the retry needle discussion', 'user', '2026-06-12T10:00:10Z', 'text', 0);
+  insert.run('past-prompt', 'sid-past', 'why does the retry path drop it', 'user', '2026-06-11T10:00:10Z', 'text', 0);
+  insert.run('past-answer', 'sid-past', 'the needle fix landed in the retry path', 'assistant', '2026-06-11T10:05:00Z', 'text', 0);
+  db.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
+  return db;
+}
+
+test('search excludes the caller session in SQL so limit is spent on other sessions', () => {
+  const db = untitledDb();
+  const api = createQueryApi(db);
+
+  const all = api.search('needle', { limit: 5 }).map(r => r.message.uuid);
+  assert.deepEqual(all.sort(), ['cur-prompt', 'past-answer']);
+
+  // limit 1 would otherwise be consumed by the caller's own prompt.
+  const others = api.search('needle', { excludeSession: 'sid-current', limit: 1 });
+  assert.deepEqual(others.map(r => r.message.uuid), ['past-answer']);
+
+  assert.deepEqual(
+    api.search('needle', { excludeSession: ['sid-current', 'sid-past'], limit: 5 }),
+    [],
+  );
+  db.close();
+});
+
+test('untitled sessions fall back to the opening user message as a title', () => {
+  const db = untitledDb();
+  const api = createQueryApi(db);
+
+  // The command envelope is skipped; the first real prompt becomes the label.
+  assert.equal(api.search('needle', { excludeSession: 'sid-current' })[0].session.title, 'why does the retry path drop it');
+  assert.equal(api.sessions({ sessionId: 'sid-current' })[0].title, 'find the retry needle discussion');
+
+  // A session with no user text at all keeps a null title rather than inventing one.
+  db.prepare(`INSERT INTO sessions (id, title, project, started_at) VALUES (?, ?, ?, ?)`)
+    .run('sid-empty', null, 'quiet-zero', '2026-06-13T10:00:00Z');
+  assert.equal(api.sessions({ sessionId: 'sid-empty' })[0].title, null);
+  db.close();
+});
+
 test('search falls back to safe tokenization for FTS-special input instead of throwing', () => {
   const db = searchDb();
   const api = createQueryApi(db);


### PR DESCRIPTION
Fixes the two behavioural items from #16. Documentation-only items from that issue are not included here.

## `search(text, { excludeSession })`

Searching history from inside a session reliably hits that session's own prompt, because the query terms came from it. Filtering afterwards in the query script does not recover the loss: `limit` is applied in SQL, so the self-hits have already displaced evidence from other sessions. `excludeSession` accepts one session ID or an array and filters before `limit`.

## Derived session titles

`overview()` and `sessions()` are advertised as a navigation map, but on a current index most rows come back with `title: null` — 792 of 821 Claude sessions on the index I measured. Both title sources are usually absent now: `ai-title` transcript rows have become rare (most recent one in a 264-transcript project directory: 2026-07-21), and `history.jsonl` entries no longer carry a `title` field at all, so the `historyTitles` path in `providers/claude.ts` cannot populate. Neither is an indexing failure — every title that exists is picked up.

`overview()`, `sessions()`, and `search()` now fall back to the first 80 characters of the opening user message, skipping `<command-…>` envelopes so the label describes the task instead of naming the slash command. A session with no user text keeps `title: null` rather than getting an invented one.

Implemented as a SQL expression in the query layer (`titleExpr()`), for two reasons: it covers sessions indexed before this change without a rebuild, and it leaves `sessions.title` meaning "a title the transcript actually provided". The tradeoff is that a derived title is not distinguishable from a stored one in the returned row — the docs call it a navigation label. Happy to switch to a separate field, or to compute it at index time, if you would rather have the provenance explicit.

## Notes

- `skill-doc` changes are limited to what documents the new behaviour: the `search()` opts list, an `Exclude Yourself` entry in the Retrieval Contract, the `sessions()` note about derived titles, and the `api-reference.md` rows. The broader documentation suggestions stay in #16.
- Tests: two added to `tests/query.test.mjs` (SQL-level exclusion including the `limit: 1` case, and the title fallback including the command-envelope skip and the null case). On this machine `npm test` goes from 207 passing to 209 with an unchanged set of 12 failures — all in the app/session suites, which need Electron deps that are not installed here.
- Branched from current `main`, so this may touch `api-reference.md` near #15. Say the word if you want it rebased onto either of the open branches instead.