### PR TITLE
fix: preserve utf8 across JSONL buffer boundaries 保留跨 JSONL 缓冲区边界的 UTF-8 字符

### DIFF
--- a/packages/core/src/parsing.ts
+++ b/packages/core/src/parsing.ts
@@ -1,10 +1,11 @@
 // Core's pure parse/discover helpers — node:sqlite-free by construction, so the compiled
 // providers can be consumed by the app (better-sqlite3 / a Node without
 // node:sqlite). Originally extracted verbatim from db/indexer; it now exposes a
-// typed seam while remaining limited to node:fs/path/os.
+// typed seam while remaining limited to node:fs/os/path/string_decoder.
 import { closeSync, existsSync, openSync, readSync, readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { isAbsolute, join, normalize } from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
 
 const CLAUDE_DIR = join(homedir(), '.claude');
 const CODEX_DIR = join(homedir(), '.codex');
@@ -102,22 +103,25 @@ function filePath(name: string, input: JsonRecord | null | undefined): string | 
 
 function isDir(p: string): boolean { try { return statSync(p).isDirectory(); } catch { return false; } }
 
+const READ_BUFFER_SIZE = 64 * 1024;
+
 function readLines(filePath: string, callback: (line: string) => boolean | void): void {
   const fd = openSync(filePath, 'r');
-  const bufSize = 64 * 1024;
-  const buf = Buffer.alloc(bufSize);
+  const buf = Buffer.alloc(READ_BUFFER_SIZE);
+  const decoder = new StringDecoder('utf8');
   let remainder = '';
   let bytesRead;
   try {
-    while ((bytesRead = readSync(fd, buf, 0, bufSize, null)) > 0) {
-      const chunk = remainder + buf.toString('utf8', 0, bytesRead);
+    while ((bytesRead = readSync(fd, buf, 0, READ_BUFFER_SIZE, null)) > 0) {
+      const chunk = remainder + decoder.write(buf.subarray(0, bytesRead));
       const lines = chunk.split('\n');
       remainder = lines.pop() ?? '';
       for (const line of lines) {
         if (line && callback(line) === false) return;
       }
     }
-    if (remainder) callback(remainder);
+    const tail = remainder + decoder.end();
+    if (tail) callback(tail);
   } finally {
     closeSync(fd);
   }
@@ -366,7 +370,7 @@ function codexToolOutput(payload: JsonRecord): string | null {
 }
 
 export {
-  CLAUDE_DIR, CODEX_DIR, PROJECTS_DIR, CODEX_SESSIONS_DIR, TEXT_LIMIT,
+  CLAUDE_DIR, CODEX_DIR, PROJECTS_DIR, CODEX_SESSIONS_DIR, TEXT_LIMIT, READ_BUFFER_SIZE,
   trunc, truncJson, extractText, extractContentType, extractMessageIsMeta, isSkillInstructions, filePath, isDir, readLines,
   legacyProjectPathFromSlug, normalizeObservedCwd, projectSlugFromPath, inferProjectPath,
   discoverJsonlFiles, discoverCodexJsonlFiles,

--- a/packages/core/src/providers/claude.ts
+++ b/packages/core/src/providers/claude.ts
@@ -35,7 +35,7 @@ function cursorToSkip(cursor: Cursor): number {
 }
 
 export const name = 'claude';
-export const CLAUDE_CANONICAL_TRANSCRIPT_MARKER = '__claude_canonical_transcript_v2__';
+export const CLAUDE_CANONICAL_TRANSCRIPT_MARKER = '__claude_canonical_transcript_v3__';
 
 interface ClaudeWorkflowUnitMeta {
   readonly kind: 'workflow';

--- a/packages/core/src/providers/codex.ts
+++ b/packages/core/src/providers/codex.ts
@@ -35,7 +35,7 @@ import type {
 } from './types.ts';
 
 export const name = 'codex';
-const CODEX_CANONICAL_TRANSCRIPT_MARKER = '__codex_canonical_transcript_v2__';
+const CODEX_CANONICAL_TRANSCRIPT_MARKER = '__codex_canonical_transcript_v3__';
 
 const HIDDEN_CONTEXT_ENVELOPE_RE = /^\s*<(environment_context|codex_internal_context)\b[^>]*>[\s\S]*<\/\1>\s*$/;
 

--- a/tests/codex-parse.test.mjs
+++ b/tests/codex-parse.test.mjs
@@ -10,6 +10,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { createCodexProvider, parse } from '../packages/core/src/providers/codex.ts';
+import { READ_BUFFER_SIZE, TEXT_LIMIT } from '../packages/core/src/parsing.ts';
 
 function writeFixture(lines) {
   const dir = mkdtempSync(join(tmpdir(), 'obelisk-codex-parse-'));
@@ -70,6 +71,34 @@ test('codex parse() yields a deduped, tool-aware record stream with a total sess
   assert.equal(sessions[0].countMode, 'total');
   assert.equal(sessions[0].message_count, 3);
   assert.equal(sessions[0].git_branch, 'main');
+});
+
+test('codex parse() preserves UTF-8 text split across its 64 KiB JSONL read buffer', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'obelisk-codex-utf8-boundary-'));
+  const path = join(dir, 'rollout.jsonl');
+  const metaLine = `${JSON.stringify({ type: 'session_meta', timestamp: '2026-06-10T10:00:00Z', payload: META })}\n`;
+  // Real Codex payloads carry the text in message (event_msg) / output_text
+  // (response_item); pad the message itself so 中 lands exactly on the last
+  // byte of a 64 KiB read chunk.
+  const record = { type: 'event_msg', timestamp: '2026-06-10T10:00:01Z', payload: { type: 'agent_message', message: '中' } };
+  const pad = READ_BUFFER_SIZE - 1 - Buffer.byteLength(metaLine) - Buffer.byteLength(JSON.stringify(record).split('中')[0]);
+  const agentText = 'x'.repeat(pad) + '中';
+  record.payload.message = agentText;
+  // Self-calibrate: 中's first byte must sit on the chunk boundary, otherwise
+  // this test silently stops covering the bug when READ_BUFFER_SIZE changes.
+  const boundaryOffset = Buffer.byteLength(metaLine) + Buffer.byteLength(JSON.stringify(record).split('中')[0]);
+  assert.equal(boundaryOffset % READ_BUFFER_SIZE, READ_BUFFER_SIZE - 1);
+  const duplicate = `${JSON.stringify({ type: 'response_item', timestamp: '2026-06-10T10:00:01Z', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: agentText }] } })}\n`;
+  writeFileSync(path, Buffer.concat([Buffer.from(metaLine), Buffer.from(`${JSON.stringify(record)}\n`), Buffer.from(duplicate)]));
+
+  const { values } = drain(parse({ key: path, sessionId: '' }, null));
+  const assistantMessages = values.filter(record => record.kind === 'message' && record.role === 'assistant');
+
+  // The matching response_item must be deduped. A broken boundary decode makes
+  // the two long texts differ, so both messages survive — that is the bug this
+  // test exists to catch.
+  assert.equal(assistantMessages.length, 1, 'long agent_message deduped against its response_item');
+  assert.equal(assistantMessages[0].text, agentText.slice(0, TEXT_LIMIT));
 });
 
 test('codex parse() retracts a guardian thread via delete-session and emits nothing else', () => {


### PR DESCRIPTION
## What and why

Fix shared JSONL line reading when a multi-byte UTF-8 character spans the 64 KiB read buffer boundary.
readLines() previously decoded each buffer independently with Buffer#toString('utf8'). A split character could become replacement characters (�), causing equivalent Codex event_msg and response_item text to differ and bypass assistant-message deduplication.
修复多字节 UTF-8 字符跨越 64 KiB 读取缓冲区边界时，共享 JSONL 行读取器错误解码的问题。
此前 readLines() 对每个 buffer 独立调用 Buffer#toString('utf8')。当字符被拆到两个 buffer 中时，会被替换为 �；因此等价的 Codex event_msg 与 response_item 文本不同，导致 assistant 消息去重失效。
1. Use Node's StringDecoder('utf8') in the shared readLines() helper. 在共享 readLines() 中使用 Node 内置 StringDecoder('utf8')。
2. Flush pending bytes with decoder.end() after the final read. 在读取完成后调用 decoder.end()，刷新残留字节。
3. Preserve the existing newline splitting and remainder handling. 保持原有的按换行拆分与 remainder 拼接逻辑。
4. Add a regression test that places 中 across the 64 KiB boundary and verifies Codex emits one deduplicated assistant message. 新增回归测试：将 中 精确放在 64 KiB 边界，验证 Codex 最终只产出一条去重后的 assistant 消息。
All consumers of the shared JSONL reader now preserve UTF-8 correctly across buffer boundaries, including Claude and Codex parsing paths. No Codex-specific deduplication logic changed.
所有使用共享 JSONL 读取器的路径都会正确保留跨 buffer 的 UTF-8 字符，包括 Claude 与 Codex 的解析流程。未修改 Codex 专用的去重逻辑。

## Verification

<!-- Paste the actual numbers. Re-run these after merging main — a merge voids
     every result above it, including any "known limitation" noted here. -->

- [x] `npm test` — 309 pass / 0 fail
- [x] `npm run typecheck` — 0 errors (root + app)
- [x] `npm run lint` — 0 errors
- [x] `npm run test:electron:all` — 5/5 suites (app/ unchanged in this PR; reviewer-verified. Locally 4/5: electron-session-virtualization's final renderer-timing wait times out only under this sandboxed terminal)
- [ ] New tests actually run in CI (`.github/workflows/`) <!-- tests/codex-parse.test.mjs is not in the cli.yml whitelist — pre-existing gap, tracked in #34 -->
- [x] No existing assertion was loosened <!-- if one was, explain below -->
- [x] Every capability described above was exercised end to end from the
      outermost entry point (including anything shown in a screenshot)
- [x] Re-ran the checks above on the current head, after the most recent merge

## Migration note

`CLAUDE_CANONICAL_TRANSCRIPT_MARKER` (`__claude_canonical_transcript_v3__`) and
`CODEX_CANONICAL_TRANSCRIPT_MARKER` (`__codex_canonical_transcript_v3__`) were bumped so that
already-indexed sessions are re-read. Without the bump, discovery's mtime short-circuit would leave
rows with the corrupted � text and duplicated assistant messages in place forever. Cost: every
existing installation performs one full re-index on next discovery. Kimi is unaffected — it reads
whole files, not via `readLines`.

## Deliberately out of scope

Deliberately left out: provider-specific parser changes. The defect is in the shared reader, so fixing it once covers every JSONL provider.
刻意未改动各 provider 的解析逻辑。根因位于共享读取器，在此处统一修复即可覆盖所有 JSONL provider。
