### PR TITLE
docs(skill): scope inactive visibility to what a source can attest

### DIFF
--- a/skill-doc/SKILL.md
+++ b/skill-doc/SKILL.md
@@ -173,7 +173,10 @@ messages unless `includeMeta: true` is passed; `context()` and `trace()` preserv
 the current causal chain and expose `is_meta` on returned rows.
 
 Pi can preserve a branch that was tried and later superseded as
-`visibility='inactive'`. Default helpers return only `visible` evidence. Pass
+`visibility='inactive'`. Only Pi populates it: other sources either do not
+record supersession in their transcripts or discard it while indexing, so an
+empty inactive result never means nothing was abandoned -- only that this
+source cannot say. Default helpers return only `visible` evidence. Pass
 `includeInactive: true` to `search()`, `context()`, `trace()`, `thread()`,
 `summaries()`, `raw()`, `fileHistory()`, or `failures()` only when the abandoned
 path matters. Every returned message or evidence row is labeled with

--- a/skill-doc/references/schema.md
+++ b/skill-doc/references/schema.md
@@ -80,7 +80,7 @@ Core evidence table.
 | `text` | Extracted text, truncated to 10k chars |
 | `content_type` | `text`, `thinking`, `tool_use`, `tool_result`, or `unknown` |
 | `is_meta` | 1 for injected/control-plane messages |
-| `visibility` | `visible` for current evidence, `inactive` for provider-attested superseded history, `hidden` for display-suppressed or transport-only material |
+| `visibility` | `visible` for current evidence, `inactive` for provider-attested superseded history, `hidden` for display-suppressed or transport-only material. Only Pi emits `inactive` |
 | `model` | Assistant model name |
 | `is_sidechain` | Retry/branch marker |
 | `agent_id` | Subagent/workflow agent ID |


### PR DESCRIPTION
Follow-up to #23.

## Why

`inactive` is populated only by Pi. The skill described it as a Pi capability but never said what its absence means for the other sources, so an agent querying a Claude Code session with `includeInactive: true` reads an empty result as "nothing was abandoned here".

That reading is wrong most of the time. Across 43 local Claude Code transcripts, 20 contained branches off the surviving path — someone edited a message and re-ran, or rewound and took another route. The history is there; the format simply does not mark it, so Obelisk cannot either.

## What changed

Two sentences, no behavior change.

`skill-doc/SKILL.md` — the paragraph introducing `inactive` now says only Pi populates it, and that an empty result means the source cannot say rather than that nothing was abandoned.

`skill-doc/references/schema.md` — the `messages.visibility` row notes that only Pi emits `inactive`.

## On the wording

The added sentence says other sources "either do not record supersession in their transcripts or discard it while indexing" rather than naming Claude Code and Codex directly. That covers all three non-Pi adapters accurately: Claude Code and Codex record no supersession event at all, while Kimi does record one (`context.undo`) that the adapter currently drops (#26). If Kimi later marks retracted history instead of discarding it, only "Only Pi populates it" needs to change — the reason clause stays true.

## Verification

- `npm test` — 408/408
- `npm run lint` — 0 errors, 4 unchanged warnings