### PR TITLE
fix(core): apply provider unit retractions

### DIFF
--- a/docs/adr/0001-parse-core-and-persist-layers.md
+++ b/docs/adr/0001-parse-core-and-persist-layers.md
@@ -30,8 +30,8 @@ binding-agnostic and does not need a per-binding implementation.
   adapter is *pure*: it emits normalized records and never touches a database.
   Discovery receives a read-only view of the provider's already-indexed session
   paths. A full-reparse adapter can therefore attach `retractSessionIds` to a
-  replacement or tombstone unit without querying SQLite itself. Retraction and
-  replacement records commit in the same unit transaction, so a failed parse
+  replacement or tombstone unit without querying SQLite itself. Unit retractions
+  and replacement records commit in the same unit transaction, so a failed parse
   preserves the last complete snapshot.
   Provider identity may therefore be richer than a wire-level ID. Pi, whose
   explicit session IDs are project-local, deterministically namespaces the

--- a/packages/core/src/persist.ts
+++ b/packages/core/src/persist.ts
@@ -86,6 +86,7 @@ function deleteSession(db: SqliteDb, sessionId: string) {
 // (also written to index_state). `db` is any SQLite handle sharing prepare/run.
 export function persist(db: SqliteDb, unit: IndexUnit, gen: Generator<TranscriptRecord, Cursor>): Cursor {
   const st = statements(db);
+  for (const sessionId of unit.retractSessionIds ?? []) deleteSession(db, sessionId);
 
   const write = (r: TranscriptRecord) => {
     switch (r.kind) {

--- a/packages/core/src/providers/pi.ts
+++ b/packages/core/src/providers/pi.ts
@@ -1331,12 +1331,8 @@ function parsePi(unit: IndexUnit): { records: TranscriptRecord[]; cursor: string
   const meta = unit.meta as PiSessionUnitMeta | undefined;
   if (meta?.kind === 'pi-tombstone') {
     return {
-      records: (unit.retractSessionIds ?? [unit.sessionId]).map((sessionId) => ({
-        kind: 'delete-session',
-        sessionId,
-      })),
-      // A zero watermark keeps recreation discoverable even if no watcher
-      // event is available, without teaching persist about provider tombstones.
+      records: [],
+      // A zero watermark keeps recreation discoverable even if no watcher event is available.
       cursor: '0:0',
     };
   }
@@ -1375,10 +1371,6 @@ function parsePi(unit: IndexUnit): { records: TranscriptRecord[]; cursor: string
   };
   return {
     records: [
-      ...(unit.retractSessionIds ?? []).map((staleSessionId) => ({
-        kind: 'delete-session' as const,
-        sessionId: staleSessionId,
-      })),
       { kind: 'delete-session', sessionId },
       session,
       ...projected.records,

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -37,7 +37,7 @@ export interface IndexUnit {
   agentId?: string;
   /** Adapter-private payload, opaque to the orchestration. */
   meta?: unknown;
-  /** Previously indexed sessions this unit atomically supersedes or retracts. */
+  /** Previously indexed sessions atomically retracted by persist before this unit is written. */
   retractSessionIds?: readonly string[];
 }
 
@@ -208,9 +208,9 @@ export interface MessageTurnDurationRecord {
   turn_duration_ms: number | null;
 }
 
-// Retraction op (not a table). The adapter emits this when a previously-indexed
-// session must be removed — e.g. a Codex guardian/auto-review thread. Persist
-// executes the cascade delete across all tables for that session.
+// Retraction op (not a table). An adapter emits this when removal is discovered
+// during parsing, e.g. a Codex guardian thread. Discovery-known retractions use
+// IndexUnit.retractSessionIds instead. Persist cascades either form.
 export interface DeleteSessionRecord {
   kind: 'delete-session';
   sessionId: string;

--- a/tests/app-pi-index.test.mjs
+++ b/tests/app-pi-index.test.mjs
@@ -579,6 +579,35 @@ test('app replay keeps Pi identity stable across migration and retracts replacem
   db.close();
 });
 
+test('a failed Pi identity replacement preserves the prior session snapshot', () => {
+  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-replacement-rollback-'));
+  const piDir = join(home, 'pi-sessions');
+  const sessionPath = writeFixture(piDir);
+  const options = indexOptions(home, piDir);
+  const header = JSON.parse(readFileSync(TOOL_FIXTURE, 'utf8').split('\n')[0]);
+  const priorId = piSessionId(header);
+
+  assert.equal(buildIndex(options).complete, true);
+  writeFileSync(sessionPath, [
+    JSON.stringify({ ...header, id: 'invalid-replacement' }),
+    invalidMessageLine(),
+    '',
+  ].join('\n'));
+
+  assert.throws(
+    () => buildIndex({ ...options, changedPaths: [sessionPath] }),
+    /Malformed Pi message at line 2/,
+  );
+
+  const db = new TestDatabase(options.dbPath);
+  assert.deepEqual(
+    db.prepare("SELECT id,message_count FROM sessions WHERE source='pi'").all().map(row => ({ ...row })),
+    [{ id: priorId, message_count: 4 }],
+  );
+  assert.equal(db.prepare('SELECT COUNT(*) AS c FROM messages WHERE session_id=?').get(priorId).c, 4);
+  db.close();
+});
+
 test('passive Pi inventory retracts deleted sessions when its configured root remains readable', () => {
   const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-passive-delete-'));
   const piDir = join(home, 'pi-sessions');

--- a/tests/persist.test.mjs
+++ b/tests/persist.test.mjs
@@ -139,3 +139,20 @@ test('delete-session cascades across tables', () => {
   assert.equal(db.prepare('SELECT COUNT(*) c FROM workflows WHERE session_id=?').get('sid-p').c, 0);
   assert.equal(db.prepare('SELECT COUNT(*) c FROM workflow_agents WHERE session_id=?').get('sid-p').c, 0);
 });
+
+test('IndexUnit retracts a previously indexed session without adapter delete records', () => {
+  const db = freshDb();
+  const unit = fixtureUnit();
+  persist(db, unit, parse(unit, null));
+
+  function* tombstone() { yield* []; return '0:0'; }
+  persist(db, {
+    key: 'tombstone',
+    sessionId: unit.sessionId,
+    retractSessionIds: [unit.sessionId],
+  }, tombstone());
+
+  assert.equal(db.prepare('SELECT COUNT(*) c FROM sessions WHERE id=?').get(unit.sessionId).c, 0);
+  assert.equal(db.prepare('SELECT COUNT(*) c FROM messages WHERE session_id=?').get(unit.sessionId).c, 0);
+  assert.equal(db.prepare('SELECT cursor FROM index_state WHERE jsonl_path=?').get('tombstone').cursor, '0:0');
+});

--- a/tests/pi-parse.test.mjs
+++ b/tests/pi-parse.test.mjs
@@ -1938,7 +1938,7 @@ test('identity migration retracts a legacy row attached to a non-selected identi
     drain(provider.parse(migration[0], null)).values
       .filter(record => record.kind === 'delete-session')
       .map(record => record.sessionId),
-    [legacyId, piSessionId(sourceHeader)],
+    [piSessionId(sourceHeader)],
   );
 });
 
@@ -2108,7 +2108,7 @@ test('indexed provenance retracts a replaced identity and emits an unlink tombst
   assert.notEqual(afterSession, beforeSession);
   assert.deepEqual(
     after.values.filter(record => record.kind === 'delete-session').map(record => record.sessionId),
-    [beforeSession, afterSession],
+    [afterSession],
   );
 
   unlinkSync(written.path);
@@ -2120,7 +2120,7 @@ test('indexed provenance retracts a replaced identity and emits an unlink tombst
   assert.equal(tombstones.length, 1);
   assert.deepEqual(tombstones[0].retractSessionIds, [afterSession]);
   const tombstone = drain(provider.parse(tombstones[0], after.cursor));
-  assert.deepEqual(tombstone.values, [{ kind: 'delete-session', sessionId: afterSession }]);
+  assert.deepEqual(tombstone.values, []);
   assert.equal(tombstone.cursor, '0:0');
 });
 


### PR DESCRIPTION
## Summary

- Apply provider-declared `IndexUnit.retractSessionIds` in shared persistence before parsing and writing the unit.
- Keep retractions, replacement records, and cursor publication atomic in the existing per-unit transaction.
- Let Pi tombstones and identity replacements use the unit contract directly, while preserving record-level deletion for current-session replay.

Follow-up to #23.

## Verification

Environment: Obelisk 0.2.0, Node.js v24.1.0, npm 11.3.0.

- Targeted persistence and Pi suites: 67/67 passed
- `npm test`: 410/410 passed
- `npm run typecheck`
- `npm run build:core`
- `npm run build:cli`
- `npm run build:skill`
- `npm run lint`: 0 errors (4 existing warnings)
- `git diff --check`
