### PR TITLE
fix: correct provider replay and refresh behavior

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -12,6 +12,7 @@ import { buildRecapExportQuery } from './recap-capture-query.ts';
 import { buildEditorUrl, DEFAULT_EDITOR_SCHEME, EDITOR_SCHEMES, resolveFileReference } from './file-reference.ts';
 import { acquireWriterLease, writerLockPathFor } from '../../../packages/core/src/writer-lease.ts';
 import { migrateCoreSchemaColumns } from '../../../packages/core/src/schema-migrations.ts';
+import { storedSessionCursor } from '../../../packages/core/src/provider-indexing.ts';
 import { createBuiltinProviderRegistry } from '../../../packages/core/src/providers/builtins.ts';
 import {
   createConfiguredBuiltinProviderRuntime,
@@ -269,10 +270,11 @@ function appendWhere(sql, params, clause) {
 }
 
 function startIndexerService({ buildOnStart = false } = {}) {
+  if (indexerService) return indexerService;
   const paths = getRuntimePaths();
   if (latestSettingsError !== null) return null;
   migrateLegacyDbIfNeeded(paths);
-  indexerService = createIndexerService({
+  const service = createIndexerService({
     projectsDir: paths.projectsDir,
     watchDirs: paths.providerRegistry.watchRoots(paths.providerRoots),
     buildIndex: async ({ reason, changedPaths }) => {
@@ -302,8 +304,9 @@ function startIndexerService({ buildOnStart = false } = {}) {
     },
     writeHeartbeat: () => writeHeartbeat({ dbPath: paths.dbPath }),
   });
-  indexerService.start({ buildOnStart });
-  return indexerService;
+  service.start({ buildOnStart });
+  indexerService = service;
+  return service;
 }
 
 function startBackgroundResources({ runStartupBuild = false } = {}) {
@@ -671,16 +674,13 @@ ipcMain.handle('db:getMessageFullText', (_, uuid) => {
   const workflowAgent = msg.agent_id
     ? db.prepare('SELECT * FROM workflow_agents WHERE agent_id=?').get(msg.agent_id) ?? null
     : null;
-  const cursorRow = typeof session?.jsonl_path === 'string'
-    ? db.prepare('SELECT cursor FROM index_state WHERE jsonl_path=?').get(session.jsonl_path)
-    : undefined;
   const paths = getRuntimePaths();
   const raw = paths.providerRegistry.raw({
     source: msg.source || session?.source || 'claude',
     messageUuid: String(uuid),
     session,
     agentId: msg.agent_id || null,
-    cursor: typeof cursorRow?.cursor === 'string' ? cursorRow.cursor : null,
+    cursor: storedSessionCursor(db, paths.providerRegistry, session),
     subagent,
     workflowAgent,
   });
@@ -1008,7 +1008,7 @@ ipcMain.handle('settings:set', async (_, key, value) => {
       await stopIndexerServiceAndWait();
     } else if (value !== false) {
       if (indexerService) await stopIndexerServiceAndWait();
-      startIndexerService({ buildOnStart: false });
+      startIndexerService({ buildOnStart: true });
     }
   }
 
@@ -1050,7 +1050,6 @@ ipcMain.handle('settings:rebuildIndex', async () => {
   if (latestSettingsError !== null) throw new Error(latestSettingsError);
   const paths = getRuntimePaths(persisted);
   const tempDbPath = rebuildTempDbPath(paths.dbPath);
-  const shouldRestartWatcher = persisted.autoRefresh !== false;
   await stopIndexerServiceAndWait({ waitForIdle: false });
   if (indexerWorker) {
     await Promise.resolve(indexerWorker.stop());
@@ -1117,7 +1116,9 @@ ipcMain.handle('settings:rebuildIndex', async () => {
       }
     } finally {
       writerLease?.release();
-      if (shouldRestartWatcher) startIndexerService({ buildOnStart: false });
+      if (loadPersistedSettings().autoRefresh !== false) {
+        startIndexerService({ buildOnStart: false });
+      }
     }
   }
 });

--- a/app/src/main/indexer-service.ts
+++ b/app/src/main/indexer-service.ts
@@ -136,7 +136,7 @@ function createIndexerService({
   let stabilityTimer: TimerHandle | null = null;
   let heartbeatTimer: TimerHandle | null = null;
   let watchRetryTimer: TimerHandle | null = null;
-  let deferredRetryTimer: TimerHandle | null = null;
+  let retryTimer: TimerHandle | null = null;
   let watcher: Watcher | null = null;
   let stopped = false;
   let running = false;
@@ -200,16 +200,18 @@ function createIndexerService({
           );
         }
       }
-      if (result?.deferred) {
-        if (buildChangedPaths === undefined) requestFullInventory();
+      const incompleteInventory = (result?.inventoryIssues?.length ?? 0) > 0;
+      if (result?.deferred || incompleteInventory) {
+        if (incompleteInventory || buildChangedPaths === undefined) requestFullInventory();
         else addChangedPath(buildChangedPaths);
-        if (!stopped && !deferredRetryTimer) {
-          deferredRetryTimer = timers.setTimeout(() => {
-            deferredRetryTimer = null;
-            runBuildNow('writer-lease');
-          }, deferredRetryMs);
+        if (!stopped && !retryTimer) {
+          const retryReason = result?.deferred ? 'writer-lease' : 'incomplete-inventory';
+          retryTimer = timers.setTimeout(() => {
+            retryTimer = null;
+            runBuildNow(retryReason);
+          }, result?.deferred ? deferredRetryMs : heartbeatMs);
         }
-        return;
+        if (result?.deferred) return;
       }
       publishHeartbeat();
     })()
@@ -234,8 +236,8 @@ function createIndexerService({
     else addChangedPath(changedPath);
     lastReason = reason;
     if (running) pending = true;
-    if (deferredRetryTimer) timers.clearTimeout(deferredRetryTimer);
-    deferredRetryTimer = null;
+    if (retryTimer) timers.clearTimeout(retryTimer);
+    retryTimer = null;
     if (buildTimer) timers.clearTimeout(buildTimer);
     if (stabilityTimer) timers.clearTimeout(stabilityTimer);
     buildTimer = timers.setTimeout(() => {
@@ -294,8 +296,8 @@ function createIndexerService({
     stabilityTimer = null;
     if (watchRetryTimer) timers.clearTimeout(watchRetryTimer);
     watchRetryTimer = null;
-    if (deferredRetryTimer) timers.clearTimeout(deferredRetryTimer);
-    deferredRetryTimer = null;
+    if (retryTimer) timers.clearTimeout(retryTimer);
+    retryTimer = null;
     if (heartbeatTimer && typeof timers.clearInterval === 'function') timers.clearInterval(heartbeatTimer);
     heartbeatTimer = null;
     if (watcher?.close) watcher.close();

--- a/app/src/main/indexer.ts
+++ b/app/src/main/indexer.ts
@@ -462,8 +462,7 @@ function buildIndex({
               error: error.sourceError instanceof Error
                 ? error.sourceError.message
                 : String(error.sourceError),
-              diagnostics: (error as { obelisk?: unknown }).obelisk
-                ?? (error.sourceError as { obelisk?: unknown } | null)?.obelisk,
+              diagnostics: (error as { obelisk?: unknown }).obelisk,
             });
             console.warn(
               `Warning: failed to index ${error.item.provider.name} unit ${error.item.unit.key}: ${error.message}`,

--- a/app/src/renderer/src/views/Settings.vue
+++ b/app/src/renderer/src/views/Settings.vue
@@ -19,11 +19,14 @@ const editorPicker = ref(null);
 const editorMenuOpen = ref(false);
 const memoryCount = ref(0);
 const rebuilding = ref(false);
+const rebuildError = ref('');
 const version = ref('');
 let stopIndexUpdates = null;
 
 onMounted(async () => {
-  stopIndexUpdates = window.obelisk?.onIndexUpdated?.(() => loadSettings()) ?? null;
+  stopIndexUpdates = window.obelisk?.onIndexUpdated?.(() => {
+    void loadSettings({ preserveRecapPath: true });
+  }) ?? null;
   document.addEventListener('pointerdown', closeEditorMenuOutside);
   document.addEventListener('keydown', closeEditorMenuOnEscape);
   await loadSettings();
@@ -36,12 +39,12 @@ onBeforeUnmount(() => {
   document.removeEventListener('keydown', closeEditorMenuOnEscape);
 });
 
-async function loadSettings() {
+async function loadSettings({ preserveRecapPath = false } = {}) {
   if (!window.obelisk?.getSettings) return;
   const s = await window.obelisk.getSettings();
   sources.value = s.sources || [];
   dbPath.value = s.dbPath || '';
-  recapPath.value = s.recapDir || '~/.obelisk/recap';
+  if (!preserveRecapPath) recapPath.value = s.recapDir || '~/.obelisk/recap';
   autoRefresh.value = s.autoRefresh !== false;
   editorScheme.value = s.editorScheme || 'vscode';
   memoryCount.value = s.memoryCount || 0;
@@ -106,11 +109,14 @@ async function commitRecapPath() {
 async function rebuildIndex() {
   if (rebuilding.value || !window.obelisk?.rebuildIndex) return;
   rebuilding.value = true;
+  rebuildError.value = '';
   await nextTick();
   await new Promise(resolve => requestAnimationFrame(resolve));
   try {
     await window.obelisk.rebuildIndex();
     await loadSettings();
+  } catch (error) {
+    rebuildError.value = error instanceof Error ? error.message : String(error);
   } finally {
     rebuilding.value = false;
   }
@@ -318,6 +324,7 @@ function fmtRelative(iso) {
             <div class="reset-hint">
               Rebuilding re-reads your coding agent session data. It does not delete memories or recaps.
             </div>
+            <div v-if="rebuildError" class="reset-error">{{ rebuildError }}</div>
           </div>
         </div>
       </section>
@@ -463,6 +470,7 @@ function fmtRelative(iso) {
 .btn.subtle { background: transparent; border-color: transparent; color: var(--muted); }
 .btn.subtle:hover { background: var(--surface); color: var(--fg-2); }
 .btn svg { width: 13px; height: 13px; }
+.reset-error { margin-top: 8px; color: #f87171; font-size: 11.5px; }
 
 .status-row {
   display: flex; align-items: center; gap: 14px;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -11,7 +11,7 @@
 import { createContext, runInNewContext } from 'node:vm';
 
 import { DB_PATH, openDb, openReadDb, openWriterLeaseDb } from './db.ts';
-import { buildIndex, shouldSkipBuild } from './indexer.ts';
+import { buildIndex, ensureReadableSchema, shouldSkipBuild } from './indexer.ts';
 import {
   createConfiguredBuiltinProviderRuntime,
   readPersistedProviderSettings,
@@ -53,11 +53,23 @@ function refreshQueryIndex(): ProviderRegistry {
   const settings = readPersistedProviderSettings();
   const providerRegistry = createConfiguredBuiltinProviderRuntime(settings.settings).registry;
   if (!settings.ok) {
+    const schema = ensureReadableSchema();
+    if (!schema.ready) {
+      throw new Error(`Obelisk index schema upgrade is blocked by ${schema.reason ?? 'an unknown writer'}`);
+    }
     process.stderr.write(`Warning: ${settings.error}; index refresh skipped\n`);
     return providerRegistry;
   }
   reportIncompleteInventory(buildIndex({ providerRegistry }));
   return providerRegistry;
+}
+
+function rethrowUnlessSchemaBlocked(error: unknown): never {
+  const schema = ensureReadableSchema();
+  if (!schema.ready) {
+    throw new Error(`Obelisk index schema upgrade is blocked by ${schema.reason ?? 'an unknown writer'}`);
+  }
+  throw error;
 }
 
 // Run a user-supplied CodeAct script inside the query/attune sandbox. The script
@@ -76,7 +88,11 @@ export function searchText(text: string, opts?: Record<string, unknown>): unknow
   const providerRegistry = refreshQueryIndex();
   const db = openReadDb();
   try {
-    return createQueryApi(db, { providerRegistry }).search(text, opts);
+    try {
+      return createQueryApi(db, { providerRegistry }).search(text, opts);
+    } catch (error) {
+      return rethrowUnlessSchemaBlocked(error);
+    }
   } finally {
     db.close();
   }
@@ -87,7 +103,11 @@ export async function executeQuery(scriptContent: string): Promise<unknown> {
   const providerRegistry = refreshQueryIndex();
   const db = openReadDb();
   try {
-    return await runInSandbox(createQueryApi(db, { providerRegistry }), scriptContent);
+    try {
+      return await runInSandbox(createQueryApi(db, { providerRegistry }), scriptContent);
+    } catch (error) {
+      return rethrowUnlessSchemaBlocked(error);
+    }
   } finally {
     db.close();
   }
@@ -95,7 +115,10 @@ export async function executeQuery(scriptContent: string): Promise<unknown> {
 
 // Execute a memory-mutation CodeAct script (remember/forget only).
 export async function executeAttune(scriptContent: string): Promise<unknown> {
-  const build = buildIndex() as { reason?: string } | undefined;
+  const settings = readPersistedProviderSettings();
+  if (!settings.ok) throw new Error(`${settings.error}; attune was not applied`);
+  const providerRegistry = createConfiguredBuiltinProviderRuntime(settings.settings).registry;
+  const build = buildIndex({ providerRegistry }) as { reason?: string } | undefined;
   reportIncompleteInventory(build);
   if (build?.reason === 'daemon_active') {
     throw new Error('Obelisk daemon owns index writes; attune is read-only until the daemon stops');

--- a/packages/core/src/indexer.ts
+++ b/packages/core/src/indexer.ts
@@ -16,6 +16,7 @@ import {
   createConfiguredBuiltinProviderRuntime,
   readPersistedProviderSettings,
 } from './provider-settings.ts';
+import { coreSchemaNeedsMigration } from './schema-migrations.ts';
 import type { ProviderRegistry } from './providers/registry.ts';
 import type { NodeSqliteDb, SqliteRow } from './sqlite-types.ts';
 
@@ -83,7 +84,9 @@ function inspectBuildOwnership({ force = false }: { force?: boolean } = {}) {
   if (!existsSync(DB_PATH)) return { skip: false };
   const db = openReadDb();
   try {
-    return shouldSkipBuild(db, { ignoreRecentBuild: force });
+    const ownership = shouldSkipBuild(db, { ignoreRecentBuild: force });
+    if (!ownership.skip || ownership.reason === 'daemon_active') return ownership;
+    return coreSchemaNeedsMigration(db) ? { skip: false } : ownership;
   } catch (error) {
     // A missing table means the write path must initialize a new/legacy index.
     // Any other read failure leaves daemon ownership unknown, so fail closed.
@@ -91,6 +94,44 @@ function inspectBuildOwnership({ force = false }: { force?: boolean } = {}) {
     throw error;
   } finally {
     db.close();
+  }
+}
+
+function ensureReadableSchema(): { ready: boolean; reason?: string } {
+  const inspect = () => {
+    if (!existsSync(DB_PATH)) return { ready: false };
+    const db = openReadDb();
+    try {
+      if (!coreSchemaNeedsMigration(db)) return { ready: true };
+      try {
+        if (shouldSkipBuild(db, { ignoreRecentBuild: true }).reason === 'daemon_active') {
+          return { ready: false, reason: 'daemon_active' };
+        }
+      } catch (error) {
+        if (!isMissingIndexStateTable(error)) throw error;
+      }
+      return { ready: false };
+    } finally {
+      db.close();
+    }
+  };
+
+  let state = inspect();
+  if (state.ready || state.reason) return state;
+  const lease = acquireWriterLease({
+    lockPath: writerLockPathFor(DB_PATH),
+    openDb: openWriterLeaseDb,
+    waitMs: 1000,
+  });
+  if (!lease) return { ready: false, reason: 'writer_busy' };
+  try {
+    state = inspect();
+    if (state.ready || state.reason) return state;
+    const db = openDb();
+    db.close();
+    return { ready: true };
+  } finally {
+    lease.release();
   }
 }
 
@@ -171,8 +212,7 @@ function buildIndex({ force = false, providerRegistry }: BuildIndexOptions = {})
               provider: error.item.provider.name,
               path: error.item.unit.key,
               error: errorMessage(error.sourceError),
-              diagnostics: (error as { obelisk?: unknown }).obelisk
-                ?? (error.sourceError as { obelisk?: unknown } | null)?.obelisk,
+              diagnostics: (error as { obelisk?: unknown }).obelisk,
             };
             skippedFiles.push(skippedFile);
             process.stderr.write(
@@ -270,4 +310,4 @@ function buildIndex({ force = false, providerRegistry }: BuildIndexOptions = {})
   }
 }
 
-export { buildIndex, inferProjectPath, refreshSessionProjectPaths, shouldSkipBuild };
+export { buildIndex, ensureReadableSchema, inferProjectPath, refreshSessionProjectPaths, shouldSkipBuild };

--- a/packages/core/src/provider-indexing.ts
+++ b/packages/core/src/provider-indexing.ts
@@ -58,6 +58,27 @@ export function storedProviderCursor(db: SqliteDb, key: string): Cursor {
     : `${String(row.mtime)}:${String(row.lines_processed)}`;
 }
 
+export function providerSessionUnitKey(
+  provider: ProviderAdapter | undefined,
+  session: IndexedSession,
+): string {
+  return provider?.sessionUnitKey?.(session) ?? session.jsonlPath;
+}
+
+export function storedSessionCursor(
+  db: SqliteDb,
+  registry: ProviderRegistry,
+  session: Record<string, unknown> | null,
+): Cursor {
+  if (typeof session?.jsonl_path !== 'string') return null;
+  const source = typeof session.source === 'string' ? session.source : 'claude';
+  const unitKey = providerSessionUnitKey(registry.get(source), {
+    sessionId: typeof session.id === 'string' ? session.id : '',
+    jsonlPath: session.jsonl_path,
+  });
+  return storedProviderCursor(db, unitKey);
+}
+
 export function readProviderSessionProvenance(db: SqliteDb): ProviderSessionProvenance[] {
   return db.prepare(`
     SELECT id, jsonl_path, COALESCE(source, 'claude') AS source
@@ -100,7 +121,9 @@ export function createProviderIndexPlan(
     ).get(marker);
     const fullReindex = force || (markerMissing && indexedSessions.length > 0);
     if (markerMissing && indexedSessions.length > 0) {
-      replayKeys.set(provider.name, [...new Set(indexedSessions.map((session) => session.jsonlPath))]);
+      replayKeys.set(provider.name, [
+        ...new Set(indexedSessions.map((session) => providerSessionUnitKey(provider, session))),
+      ]);
     }
     let inventoryComplete = true;
     let reportedIssue: InventoryIssue | undefined;

--- a/packages/core/src/provider-settings.ts
+++ b/packages/core/src/provider-settings.ts
@@ -122,13 +122,15 @@ export function createConfiguredBuiltinProviderRuntime(
         },
         watchRoots: () => [],
         discover: (ctx) => {
-          ctx.reportIncompleteInventory?.({
-            path: provider.descriptor.defaultRoot,
-            error: reason,
-          });
+          const indexed = ctx.indexedSessions?.()[0];
+          if (indexed) {
+            ctx.reportIncompleteInventory?.({
+              path: indexed.jsonlPath,
+              error: reason,
+            });
+          }
           return [];
         },
-        raw: () => null,
       };
     })),
   };

--- a/packages/core/src/providers/kimi.ts
+++ b/packages/core/src/providers/kimi.ts
@@ -619,6 +619,13 @@ function changedSessionDirectories(rootDir: string, changedPaths: readonly strin
   return result;
 }
 
+function sessionDirectoryFromWirePath(wirePath: string): string {
+  const parent = dirname(wirePath);
+  return basename(parent) === 'main' && basename(dirname(parent)) === 'agents'
+    ? dirname(dirname(parent))
+    : parent;
+}
+
 function rawFromWire(path: string, messageUuid: string): RawRecord | null {
   if (!existsSync(path)) return null;
   const fallbackLine = /:line-(\d+)$/.exec(messageUuid)?.[1];
@@ -664,6 +671,7 @@ export function createKimiProvider({ rootDir = defaultKimiRoot() }: { rootDir?: 
     name,
     descriptor: { id: name, name: 'Kimi Code', vendor: 'Moonshot AI', defaultRoot: rootDir, color: '#6d6afc' },
     indexVersionMarker: KIMI_CANONICAL_TRANSCRIPT_MARKER,
+    sessionUnitKey: ({ jsonlPath }) => sessionDirectoryFromWirePath(jsonlPath),
     watchRoots: (configuredRoot) => [join(configuredRoot, 'sessions'), join(configuredRoot, 'session_index.jsonl')],
     discover(ctx: DiscoverContext): IndexUnit[] {
       const units: IndexUnit[] = [];
@@ -739,9 +747,7 @@ export function createKimiProvider({ rootDir = defaultKimiRoot() }: { rootDir?: 
       if (input.agentId === null) return rawFromWire(mainPath, input.messageUuid);
       const rawAgentId = input.agentId.split(':').at(-1);
       if (rawAgentId === undefined) return null;
-      const sessionDir = basename(dirname(mainPath)) === 'main'
-        ? dirname(dirname(dirname(mainPath)))
-        : dirname(mainPath);
+      const sessionDir = sessionDirectoryFromWirePath(mainPath);
       return rawFromWire(join(sessionDir, 'agents', rawAgentId, 'wire.jsonl'), input.messageUuid);
     },
   };

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -297,6 +297,11 @@ export interface ProviderAdapter extends Provider {
   readonly descriptor: ProviderDescriptor;
   /** Optional index semantics marker; absence forces one provider-owned replay. */
   readonly indexVersionMarker?: string;
+  /**
+   * Recover the IndexUnit key for a persisted session when it differs from the
+   * canonical source path. File-backed providers normally omit this.
+   */
+  sessionUnitKey?(session: IndexedSession): string;
   watchRoots(configuredRoot: string): string[];
   raw(input: RawLookup): RawRecord | null;
 }

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -1,6 +1,7 @@
 // Query and attune sandbox helpers for the Core package.
 import { statSync } from 'node:fs';
 import { isAbsolute, normalize, resolve, sep } from 'node:path';
+import { storedSessionCursor } from './provider-indexing.ts';
 import { createBuiltinProviderRegistry } from './providers/builtins.ts';
 import type { ProviderRegistry } from './providers/registry.ts';
 import type { SqliteDb, SqliteRow } from './sqlite-types.ts';
@@ -343,11 +344,17 @@ function createQueryApi(
     ].join(' AND ');
     const allParams = [...filterParams, limit];
     const rows = db.prepare(`
-      SELECT tr.*, COALESCE(rm.visibility,'visible') AS visibility
+      SELECT tr.*,
+        CASE
+          WHEN COALESCE(rm.visibility,'visible') = 'inactive'
+            OR COALESCE(cm.visibility,'visible') = 'inactive'
+          THEN 'inactive'
+          ELSE 'visible'
+        END AS visibility
       FROM tool_results tr
-      JOIN messages rm ON rm.uuid=tr.message_uuid
-      JOIN tool_calls tc ON tc.id=tr.tool_use_id
-      JOIN messages cm ON cm.uuid=tc.message_uuid
+      LEFT JOIN messages rm ON rm.uuid=tr.message_uuid
+      LEFT JOIN tool_calls tc ON tc.id=tr.tool_use_id
+      LEFT JOIN messages cm ON cm.uuid=tc.message_uuid
       ${join}
       WHERE ${errorCond} AND ${where}
       ORDER BY rm.timestamp DESC
@@ -592,15 +599,12 @@ function createQueryApi(
       ? db.prepare('SELECT * FROM workflow_agents WHERE agent_id=?').get(message.agent_id) ?? null
       : null;
     const source = message.source || session?.source || 'claude';
-    const cursorRow = typeof session?.jsonl_path === 'string'
-      ? db.prepare('SELECT cursor FROM index_state WHERE jsonl_path=?').get(session.jsonl_path)
-      : undefined;
     const record = providerRegistry.raw({
       source,
       messageUuid,
       session,
       agentId: message.agent_id || null,
-      cursor: typeof cursorRow?.cursor === 'string' ? cursorRow.cursor : null,
+      cursor: storedSessionCursor(db, providerRegistry, session),
       subagent,
       workflowAgent,
     });

--- a/packages/core/src/schema-migrations.ts
+++ b/packages/core/src/schema-migrations.ts
@@ -21,6 +21,20 @@ function tableExists(db: SqliteDb, table: string): boolean {
   return Boolean(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(table));
 }
 
+export function coreSchemaNeedsMigration(db: SqliteDb): boolean {
+  const columnsByTable = new Map<string, Set<string>>();
+  for (const [table, column] of COLUMN_MIGRATIONS) {
+    if (!tableExists(db, table)) return true;
+    let columns = columnsByTable.get(table);
+    if (!columns) {
+      columns = new Set(db.prepare(`PRAGMA table_info(${table})`).all().map((row) => String(row.name)));
+      columnsByTable.set(table, columns);
+    }
+    if (!columns.has(column)) return true;
+  }
+  return false;
+}
+
 /** Binding-agnostic additive migrations shared by the CLI and desktop app. */
 export function migrateCoreSchemaColumns(db: SqliteDb): void {
   const columnsByTable = new Map<string, Set<string>>();

--- a/packages/core/src/session-detail.ts
+++ b/packages/core/src/session-detail.ts
@@ -206,6 +206,10 @@ function assembleMessages(
       .filter((result) => visibleCallIds.has(result.tool_use_id))
       .map((result) => result.message_uuid),
   );
+  const omitToolResultMessage = (message: SessionDetailMessage) => (
+    message.content_type === 'tool_result'
+    && (attachedResultMessageUuids.has(message.uuid) || !message.text)
+  );
   const resultsByCallId = new Map<string, SessionDetailToolResult>();
   for (const result of visibleToolResults) {
     resultsByCallId.set(result.tool_use_id, withoutKind(result));
@@ -255,10 +259,7 @@ function assembleMessages(
   const output: AssembledMessage[] = [];
   for (let index = 0; index < raw.length; index++) {
     const message = raw[index];
-    if (
-      message.content_type === 'tool_result'
-      && attachedResultMessageUuids.has(message.uuid)
-    ) continue;
+    if (omitToolResultMessage(message)) continue;
 
     if (message.type === 'assistant' && message.content_type === 'thinking') {
       const thinkingParts = [message.text ?? ''];
@@ -296,10 +297,7 @@ function assembleMessages(
       let nextIndex = index + 1;
       while (nextIndex < raw.length) {
         const next = raw[nextIndex];
-        if (
-          next.content_type === 'tool_result'
-          && attachedResultMessageUuids.has(next.uuid)
-        ) {
+        if (omitToolResultMessage(next)) {
           nextIndex++;
           continue;
         }
@@ -330,10 +328,7 @@ function assembleMessages(
       let nextIndex = index + 1;
       while (nextIndex < raw.length) {
         const next = raw[nextIndex];
-        if (
-          next.content_type === 'tool_result'
-          && attachedResultMessageUuids.has(next.uuid)
-        ) {
+        if (omitToolResultMessage(next)) {
           nextIndex++;
           continue;
         }

--- a/tests/app-indexer-service.test.mjs
+++ b/tests/app-indexer-service.test.mjs
@@ -171,6 +171,7 @@ test('indexer service logs a build that fails while running', async () => {
 });
 
 test('indexer service reports partial inventory paths on ordinary builds', async () => {
+  const timers = manualTimers();
   const warnings = [];
   const service = createIndexerService({
     buildIndex: async () => ({
@@ -185,14 +186,74 @@ test('indexer service reports partial inventory paths on ordinary builds', async
     watchProjects: () => null,
     writeHeartbeat: () => {},
     logger: { warn: (msg) => warnings.push(msg) },
+    timers,
     stabilityMs: 0,
   });
 
   await service.runBuildNow('startup');
+  service.stop();
 
   assert.deepEqual(warnings, [
     'Obelisk indexed a partial pi inventory at /tmp/pi/locked: EACCES: permission denied',
   ]);
+});
+
+test('an incomplete inventory schedules a full retry', async () => {
+  const timers = manualTimers();
+  const calls = [];
+  const service = createIndexerService({
+    buildIndex: async (args) => {
+      calls.push(args);
+      return calls.length === 1
+        ? {
+            complete: false,
+            inventoryIssues: [{
+              provider: 'pi',
+              path: '/tmp/pi/locked',
+              error: 'EACCES: permission denied',
+            }],
+          }
+        : { complete: true };
+    },
+    watchProjects: () => null,
+    writeHeartbeat: () => {},
+    logger: { warn() {} },
+    timers,
+    stabilityMs: 0,
+  });
+
+  await service.runBuildNow('watch', ['/tmp/pi/session.jsonl']);
+  timers.flush();
+  await service.idle();
+
+  assert.deepEqual(calls, [
+    { reason: 'watch', changedPaths: ['/tmp/pi/session.jsonl'] },
+    { reason: 'incomplete-inventory', changedPaths: undefined },
+  ]);
+});
+
+test('a failed unit does not promote its changed-path build to a full retry', async () => {
+  const timers = manualTimers();
+  const calls = [];
+  const service = createIndexerService({
+    buildIndex: async (args) => {
+      calls.push(args);
+      return { complete: false, inventoryIssues: [] };
+    },
+    watchProjects: () => null,
+    writeHeartbeat: () => {},
+    timers,
+    stabilityMs: 0,
+  });
+
+  await service.runBuildNow('watch', ['/tmp/pi/bad-session.jsonl']);
+  timers.flush();
+  await service.idle();
+
+  assert.deepEqual(calls, [{
+    reason: 'watch',
+    changedPaths: ['/tmp/pi/bad-session.jsonl'],
+  }]);
 });
 
 test('indexer service reports partial inventory paths before a deferred retry', async () => {

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -1263,3 +1263,112 @@ test('settings rebuild cancels an in-flight background build instead of waiting 
     rmSync(home, { recursive: true, force: true });
   }
 });
+
+test('settings changes during rebuild keep one watcher and re-enable with a catch-up build', async () => {
+  const home = join(tmpdir(), `obelisk-main-settings-rebuild-race-${Date.now()}`);
+  mkdirSync(join(home, '.obelisk'), { recursive: true });
+  writeFileSync(join(home, '.obelisk', 'obelisk.sqlite'), '');
+  writeFileSync(join(home, '.obelisk', 'settings.json'), JSON.stringify({ autoRefresh: true }));
+  const originalHome = process.env.HOME;
+  process.env.HOME = home;
+
+  const ipcHandlers = new Map();
+  const services = [];
+  let finishRebuild;
+
+  class FakeDatabase {
+    constructor(dbPath) {
+      this.lockDb = dbPath.endsWith('writer.lock.sqlite') ? new DatabaseSync(dbPath) : null;
+    }
+    pragma() {}
+    exec(sql) { return this.lockDb?.exec(sql); }
+    close() { this.lockDb?.close(); }
+    prepare() {
+      return { get: () => null, all: () => [], run: () => ({}) };
+    }
+  }
+
+  class FakeBrowserWindow {
+    constructor() {
+      this.webContents = { on() {}, setWindowOpenHandler() {}, getURL() { return ''; }, setZoomLevel() {}, openDevTools() {}, send() {} };
+    }
+    loadFile() {}
+    loadURL() {}
+    close() {}
+    static getAllWindows() { return []; }
+    static fromWebContents() { return null; }
+  }
+
+  const restore = registerMocks([
+    [ELECTRON_URL, {
+      namedExports: electronNamespace({
+        BrowserWindow: FakeBrowserWindow,
+        ipcMain: {
+          handle(channel, handler) {
+            ipcHandlers.set(channel, handler);
+          },
+        },
+      }),
+    }],
+    [DATABASE_URL, { defaultExport: FakeDatabase }],
+    [CHOKIDAR_URL, { defaultExport: noopChokidar() }],
+    [INDEXER_URL, { namedExports: { writeHeartbeat() {} } }],
+    [INDEXER_SERVICE_URL, {
+      namedExports: {
+        createIndexerService: () => {
+          const service = {
+            starts: [],
+            stops: 0,
+            start(options) { this.starts.push(options); },
+            stop() { this.stops += 1; },
+            idle: async () => {},
+            runBuildNow() { return Promise.resolve(); },
+          };
+          services.push(service);
+          return service;
+        },
+      },
+    }],
+    [INDEXER_WORKER_URL, {
+      namedExports: {
+        createWorkerBuildIndex: () => ({
+          buildIndex: () => new Promise(resolve => {
+            finishRebuild = () => resolve({
+              files: 0,
+              affectedSessionIds: [],
+              complete: false,
+              deferred: false,
+              inventoryIssues: [],
+              skippedFiles: [],
+              reason: 'incomplete_snapshot',
+            });
+          }),
+          stop() { return Promise.resolve(); },
+        }),
+      },
+    }],
+  ]);
+
+  try {
+    await importMain();
+    assert.equal(services.length, 1);
+
+    const rebuildPromise = ipcHandlers.get('settings:rebuildIndex')();
+    await new Promise(resolve => setImmediate(resolve));
+    await ipcHandlers.get('settings:set')(null, 'autoRefresh', false);
+    await ipcHandlers.get('settings:set')(null, 'autoRefresh', true);
+
+    assert.equal(services.length, 2);
+    assert.deepEqual(services[1].starts, [{ buildOnStart: true }]);
+    finishRebuild();
+    await rebuildPromise;
+
+    assert.equal(services.length, 2, 'the rebuild finally block reused the current service');
+    assert.equal(services[0].stops, 1);
+    assert.equal(services[1].stops, 0);
+  } finally {
+    restore();
+    process.env.HOME = originalHome;
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/tests/app-provider-indexer.test.mjs
+++ b/tests/app-provider-indexer.test.mjs
@@ -96,8 +96,61 @@ test('serialized invalid provider settings stay disabled when the worker rebuild
   });
 
   assert.equal(result.files, 0);
+  assert.equal(result.complete, true);
+  assert.deepEqual(result.incompleteProviders, []);
+});
+
+test('an invalid provider root cannot erase a previously indexed source snapshot', () => {
+  const home = mkdtempSync(join(tmpdir(), 'obelisk-provider-settings-preserve-'));
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  const sourcePath = join(home, '.claude', 'projects', 'session.jsonl');
+  const registry = createProviderRegistry([{
+    name: 'claude',
+    descriptor: { id: 'claude', name: 'Claude', vendor: 'Test', defaultRoot: join(home, '.claude'), color: '#123456' },
+    watchRoots: () => [],
+    discover: (ctx) => ctx.lastCursor(sourcePath) === '10:1'
+      ? []
+      : [{ key: sourcePath, sessionId: 'claude:preserved' }],
+    *parse(unit) {
+      yield {
+        kind: 'session', id: unit.sessionId, title: 'Preserved', project: null,
+        started_at: null, ended_at: null, git_branch: null, version: null,
+        message_count: 0, countMode: 'total', jsonl_path: sourcePath, source: 'claude',
+      };
+      return '10:1';
+    },
+    raw: () => null,
+  }]);
+
+  assert.equal(buildIndex({
+    providerRegistry: registry,
+    dbPath,
+    DatabaseImpl: TestDatabase,
+  }).complete, true);
+
+  const result = buildIndex({
+    force: true,
+    providerSettings: {
+      providerRoots: {
+        claude: './invalid',
+        codex: './invalid',
+        kimi: './invalid',
+        pi: './invalid',
+      },
+    },
+    claudeDir: join(home, '.claude'),
+    codexDir: join(home, '.codex'),
+    dbPath,
+    DatabaseImpl: TestDatabase,
+  });
+
   assert.equal(result.complete, false);
-  assert.deepEqual(result.incompleteProviders, ['claude', 'codex', 'kimi']);
+  assert.equal(result.reason, 'incomplete_snapshot');
+  assert.deepEqual(result.incompleteProviders, ['claude']);
+  assert.equal(result.inventoryIssues[0].path, sourcePath);
+  const db = new TestDatabase(dbPath);
+  assert.equal(db.prepare('SELECT COUNT(*) AS c FROM sessions WHERE id=?').get('claude:preserved').c, 1);
+  db.close();
 });
 
 test('an incomplete canonical inventory converges without replaying readable units forever', () => {
@@ -181,6 +234,63 @@ test('an incomplete canonical inventory converges without replaying readable uni
   db.close();
   assert.equal(buildIndex(options).files, 0);
   assert.equal(parseCalls, 2);
+});
+
+test('marker replay invalidates provider unit keys that differ from source paths', () => {
+  const home = mkdtempSync(join(tmpdir(), 'obelisk-provider-unit-key-replay-'));
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  const unitKey = 'alpha:session-unit';
+  const sourcePath = '/alpha/session/agents/main/wire.jsonl';
+  const marker = '__alpha_canonical_v1__';
+  let incomplete = false;
+  let parseCalls = 0;
+  const provider = {
+    name: 'alpha',
+    descriptor: { id: 'alpha', name: 'Alpha', vendor: 'Test', defaultRoot: '/alpha', color: '#123456' },
+    indexVersionMarker: marker,
+    sessionUnitKey: () => unitKey,
+    watchRoots: () => [],
+    discover(ctx) {
+      if (incomplete) {
+        ctx.reportIncompleteInventory({ path: '/alpha/locked', error: 'EACCES' });
+        return [];
+      }
+      return ctx.lastCursor(unitKey) === '10:1'
+        ? []
+        : [{ key: unitKey, sessionId: 'alpha:session' }];
+    },
+    *parse(unit) {
+      parseCalls += 1;
+      yield {
+        kind: 'session', id: unit.sessionId, title: 'Alpha', project: null,
+        started_at: null, ended_at: null, git_branch: null, version: null,
+        message_count: 0, countMode: 'total', jsonl_path: sourcePath, source: 'alpha',
+      };
+      return '10:1';
+    },
+    raw: () => null,
+  };
+  const options = {
+    providerRegistry: createProviderRegistry([provider]),
+    dbPath,
+    DatabaseImpl: TestDatabase,
+  };
+
+  assert.equal(buildIndex(options).complete, true);
+  assert.equal(parseCalls, 1);
+  let db = new TestDatabase(dbPath);
+  db.prepare('DELETE FROM index_state WHERE jsonl_path=?').run(marker);
+  db.close();
+
+  incomplete = true;
+  assert.equal(buildIndex(options).complete, false);
+  db = new TestDatabase(dbPath);
+  assert.equal(db.prepare('SELECT COUNT(*) AS c FROM index_state WHERE jsonl_path=?').get(unitKey).c, 0);
+  db.close();
+
+  incomplete = false;
+  assert.equal(buildIndex(options).complete, true);
+  assert.equal(parseCalls, 2, 'the missing unit retries after an incomplete marker replay');
 });
 
 test('a provider can withhold inventory-dependent tombstones from a partial census', () => {

--- a/tests/daemon-arbitration.test.mjs
+++ b/tests/daemon-arbitration.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -34,6 +34,46 @@ test('a passive query does not mutate the index while a fresh daemon owns writes
   const tables = check.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all().map(row => row.name);
   check.close();
   assert.deepEqual(tables, ['index_state']);
+});
+
+test('a passive query reports when a daemon blocks its schema upgrade', () => {
+  const home = mkdtempSync(join(tmpdir(), 'obelisk-daemon-schema-'));
+  const obeliskDir = join(home, '.obelisk');
+  const dbPath = join(obeliskDir, 'obelisk.sqlite');
+  mkdirSync(obeliskDir, { recursive: true });
+  const schema = readFileSync(
+    new URL('../packages/core/src/schema.sql', import.meta.url),
+    'utf8',
+  )
+    .replace(', cursor TEXT);', ');')
+    .replace(
+      ", visibility TEXT DEFAULT 'visible',\n  input_tokens INTEGER, output_tokens INTEGER);",
+      ');',
+    );
+  const db = new DatabaseSync(dbPath);
+  db.exec(schema);
+  db.prepare('INSERT INTO sessions (id,title,source) VALUES (?,?,?)')
+    .run('daemon-legacy', 'Daemon legacy', 'claude');
+  db.prepare(`
+    INSERT INTO summaries (id,session_id,timestamp,source,content)
+    VALUES (?,?,?,?,?)
+  `).run('daemon-summary', 'daemon-legacy', '2026-08-05T00:00:00Z', 'compaction', 'summary');
+  db.prepare(`
+    INSERT INTO index_state (jsonl_path,mtime,lines_processed)
+    VALUES ('__app_heartbeat__',?,0)
+  `).run(Date.now());
+  db.close();
+
+  const queryPath = join(home, 'query.mjs');
+  writeFileSync(queryPath, "return summaries('daemon-legacy');");
+  const result = runCli(['--query', queryPath], { home });
+
+  assert.equal(result.status, 1);
+  assert.match(JSON.parse(result.stdout).error, /schema upgrade is blocked by daemon_active/i);
+  const check = new DatabaseSync(dbPath, { readOnly: true });
+  assert.equal(check.prepare('PRAGMA table_info(index_state)').all().some(row => row.name === 'cursor'), false);
+  assert.equal(check.prepare('PRAGMA table_info(summaries)').all().some(row => row.name === 'visibility'), false);
+  check.close();
 });
 
 test('attune refuses to mutate the index while a fresh daemon owns writes', () => {

--- a/tests/pi-runtime.test.mjs
+++ b/tests/pi-runtime.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -160,6 +160,46 @@ test('CLI force rebuild rejects a structurally invalid Pi snapshot and preserves
   const failed = runCli(['--build'], { home, env });
   assert.equal(failed.status, 1, failed.stderr || failed.stdout);
   assert.match(JSON.parse(failed.stdout).error, /provider_failure/);
+
+  db = new DatabaseSync(dbPath, { readOnly: true });
+  const after = {
+    sessions: db.prepare("SELECT id,title,message_count,jsonl_path FROM sessions WHERE source='pi'").all()
+      .map(row => ({ ...row })),
+    messages: db.prepare("SELECT uuid,text FROM messages WHERE source='pi' ORDER BY uuid").all()
+      .map(row => ({ ...row })),
+  };
+  db.close();
+  assert.deepEqual(after, before);
+});
+
+test('CLI force rebuild rejects an incomplete provider inventory and preserves the last good index', () => {
+  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-cli-incomplete-force-'));
+  const piRoot = join(home, '.pi', 'agent', 'sessions');
+  const sessionPath = join(piRoot, 'project', 'session.jsonl');
+  mkdirSync(dirname(sessionPath), { recursive: true });
+  writeFileSync(
+    sessionPath,
+    readFileSync(new URL('./fixtures/pi/tool-session.jsonl', import.meta.url)),
+  );
+  const env = { PI_CODING_AGENT_DIR: '', PI_CODING_AGENT_SESSION_DIR: '' };
+  const first = runCli(['--build'], { home, env });
+  assert.equal(first.status, 0, first.stderr || first.stdout);
+
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  let db = new DatabaseSync(dbPath, { readOnly: true });
+  const before = {
+    sessions: db.prepare("SELECT id,title,message_count,jsonl_path FROM sessions WHERE source='pi'").all()
+      .map(row => ({ ...row })),
+    messages: db.prepare("SELECT uuid,text FROM messages WHERE source='pi' ORDER BY uuid").all()
+      .map(row => ({ ...row })),
+  };
+  db.close();
+
+  rmSync(piRoot, { recursive: true, force: true });
+  writeFileSync(piRoot, 'not a directory');
+  const failed = runCli(['--build'], { home, env });
+  assert.equal(failed.status, 1, failed.stderr || failed.stdout);
+  assert.match(JSON.parse(failed.stdout).error, /incomplete_snapshot/);
 
   db = new DatabaseSync(dbPath, { readOnly: true });
   const after = {

--- a/tests/provider-inventory.test.mjs
+++ b/tests/provider-inventory.test.mjs
@@ -54,3 +54,18 @@ for (const [name, createProvider, inventoryDir] of providers) {
     }]);
   });
 }
+
+test('Kimi recovers its session unit key from canonical wire provenance', () => {
+  const root = join(tmpdir(), 'obelisk-kimi-unit-key');
+  const sessionDir = join(root, 'sessions', 'workspace', 'session');
+  const provider = createKimiProvider({ rootDir: root });
+
+  assert.equal(provider.sessionUnitKey({
+    sessionId: 'kimi:session',
+    jsonlPath: join(sessionDir, 'agents', 'main', 'wire.jsonl'),
+  }), sessionDir);
+  assert.equal(provider.sessionUnitKey({
+    sessionId: 'kimi:legacy',
+    jsonlPath: join(sessionDir, 'wire.jsonl'),
+  }), sessionDir);
+});

--- a/tests/provider-settings.test.mjs
+++ b/tests/provider-settings.test.mjs
@@ -172,6 +172,9 @@ test('relative provider roots never depend on the Obelisk process cwd', () => {
 });
 
 test('an invalid persisted root disables that provider instead of selecting its default', () => {
+  const rawDir = mkdtempSync(join(tmpdir(), 'obelisk-disabled-provider-'));
+  const rawPath = join(rawDir, 'session.jsonl');
+  writeFileSync(rawPath, '{"uuid":"raw-message","message":{"content":"preserved"}}\n');
   const runtime = createConfiguredBuiltinProviderRuntime({
     providerRoots: { claude: './relative-claude' },
   }, {
@@ -179,21 +182,34 @@ test('an invalid persisted root disables that provider instead of selecting its 
     baseRoots: { claude: '/default/claude' },
   });
   const claude = runtime.registry.get('claude');
-  let issue;
 
   assert.equal(runtime.roots.claude, undefined);
   assert.equal(claude.descriptor.requiresExplicitRoot, true);
   assert.deepEqual(claude.watchRoots('/default/claude'), []);
+  let issue;
   assert.deepEqual(claude.discover({
     lastCursor: () => null,
-    reportIncompleteInventory(value) {
-      issue = value;
-    },
+    indexedSessions: () => [],
+  }), []);
+  assert.deepEqual(claude.discover({
+    lastCursor: () => null,
+    indexedSessions: () => [{ sessionId: 'claude:preserved', jsonlPath: rawPath }],
+    reportIncompleteInventory(value) { issue = value; },
   }), []);
   assert.deepEqual(issue, {
-    path: '/default/claude',
+    path: rawPath,
     error: 'Configured claude root must be absolute or start with ~',
   });
+  assert.match(claude.raw({
+    source: 'claude',
+    messageUuid: 'raw-message',
+    session: { id: 'claude:preserved', jsonl_path: rawPath },
+    agentId: null,
+    cursor: null,
+    subagent: null,
+    workflowAgent: null,
+  }).text, /preserved/);
+  rmSync(rawDir, { recursive: true, force: true });
 });
 
 test('malformed provider root containers cannot select defaults and are repairable', () => {

--- a/tests/query.test.mjs
+++ b/tests/query.test.mjs
@@ -230,6 +230,36 @@ test('raw rejects hidden targets and labels explicitly included inactive evidenc
   db.close();
 });
 
+test('raw looks up cursors by provider unit identity instead of source path', () => {
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  db.prepare('INSERT INTO sessions (id,title,jsonl_path,source) VALUES (?,?,?,?)')
+    .run('sid-raw-key', 'Raw key', '/alpha/agents/main/wire.jsonl', 'alpha');
+  db.prepare(`
+    INSERT INTO messages (uuid,session_id,type,role,text,content_type,visibility,source)
+    VALUES (?,?,?,?,?,?,?,?)
+  `).run('msg-raw-key', 'sid-raw-key', 'user', 'user', 'raw key', 'text', 'visible', 'alpha');
+  db.prepare(`
+    INSERT INTO index_state (jsonl_path,mtime,lines_processed,cursor)
+    VALUES (?,?,?,?)
+  `).run('alpha:unit', 10, 1, '10:1');
+  let cursor;
+  const provider = {
+    sessionUnitKey: () => 'alpha:unit',
+  };
+  const providerRegistry = {
+    get: () => provider,
+    raw(input) {
+      cursor = input.cursor;
+      return { text: 'raw', totalLength: 3 };
+    },
+  };
+
+  assert.equal(createQueryApi(db, { providerRegistry }).raw('msg-raw-key').text, 'raw');
+  assert.equal(cursor, '10:1');
+  db.close();
+});
+
 test('failures nextMessages does not leak hidden branch messages', () => {
   const db = new DatabaseSync(':memory:');
   db.exec(SCHEMA);
@@ -329,10 +359,32 @@ test('failures gates both result and linked call message visibility', () => {
   );
   assert.deepEqual(
     api.failures({ sessionId: 'sid-edge-visibility', includeInactive: true })
-      .map(record => record.toolCall.id)
+      .map(record => [record.toolCall.id, record.visibility])
       .sort(),
-    ['call-inactive', 'call-visible'],
+    [
+      ['call-inactive', 'inactive'],
+      ['call-visible', 'visible'],
+    ],
   );
+  db.close();
+});
+
+test('failures preserves orphaned error results without linked messages or calls', () => {
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  db.prepare('INSERT INTO sessions (id,title,source) VALUES (?,?,?)')
+    .run('sid-orphan-failure', 'Orphan failure', 'codex');
+  db.prepare(`
+    INSERT INTO tool_results (tool_use_id,message_uuid,session_id,content,is_error)
+    VALUES (?,?,?,?,?)
+  `).run('missing-call', '', 'sid-orphan-failure', 'orphaned failure', 1);
+
+  const rows = createQueryApi(db).failures('sid-orphan-failure');
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].toolCall, undefined);
+  assert.equal(rows[0].result.content, 'orphaned failure');
+  assert.equal(rows[0].visibility, 'visible');
+  assert.deepEqual(rows[0].nextMessages, []);
   db.close();
 });
 

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdtempSync, mkdirSync, statSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, normalize } from 'node:path';
 
@@ -67,6 +67,20 @@ test('malformed Obelisk settings skip refresh without disabling provider-backed 
   assert.equal(rebuild.status, 1);
   assert.match(JSON.parse(rebuild.stdout).error, /settings_unavailable/);
   assert.match(JSON.parse(rebuild.stdout).error, /Unable to read Obelisk settings/);
+
+  const memoryPath = join(home, 'blocked-memory.md');
+  const attunePath = join(home, 'attune.mjs');
+  writeFileSync(memoryPath, '# Blocked memory\n');
+  writeFileSync(attunePath, `
+    return remember({
+      path: ${JSON.stringify(memoryPath)},
+      project: 'runtime-test',
+      summary: 'Decision: this mutation must not use an index with unavailable settings.'
+    });
+  `);
+  const attune = runRuntime(['--attune', attunePath], { home });
+  assert.equal(attune.status, 1);
+  assert.match(JSON.parse(attune.stdout).error, /settings.*attune was not applied/i);
 });
 
 test('runtime attune scripts expose only memory mutation helpers', () => {
@@ -137,6 +151,108 @@ test('runtime migrates old memories schema before recall', () => {
 
   assert.equal(result.status, 0, result.stderr || result.stdout);
   assert.deepEqual(JSON.parse(result.stdout), [{ id: 'mem-old', rankType: 'number' }]);
+});
+
+test('runtime migrates a recently built legacy schema before honoring the skip window', () => {
+  const home = tempHome();
+  const obeliskDir = join(home, '.obelisk');
+  const dbPath = join(obeliskDir, 'obelisk.sqlite');
+  mkdirSync(obeliskDir, { recursive: true });
+  const schema = readFileSync(
+    new URL('../packages/core/src/schema.sql', import.meta.url),
+    'utf8',
+  )
+    .replace(', cursor TEXT);', ');')
+    .replace(
+      ", visibility TEXT DEFAULT 'visible',\n  input_tokens INTEGER, output_tokens INTEGER);",
+      ');',
+    );
+  const db = new DatabaseSync(dbPath);
+  db.exec(schema);
+  db.prepare(`
+    INSERT INTO sessions (id,title,jsonl_path,source)
+    VALUES (?,?,?,?)
+  `).run('legacy-session', 'Legacy session', '/missing/session.jsonl', 'claude');
+  db.prepare(`
+    INSERT INTO messages (
+      uuid,session_id,type,role,text,content_type,visibility,source
+    ) VALUES (?,?,?,?,?,?,?,?)
+  `).run('legacy-message', 'legacy-session', 'user', 'user', 'legacy evidence', 'text', 'visible', 'claude');
+  db.prepare(`
+    INSERT INTO index_state (jsonl_path,mtime,lines_processed)
+    VALUES ('__last_build__',?,0)
+  `).run(Date.now());
+  db.close();
+
+  const scriptPath = join(home, 'legacy-query.mjs');
+  writeFileSync(scriptPath, `
+    return thread('legacy-session').map(message => message.uuid);
+  `);
+  const result = runRuntime(['--query', scriptPath], { home });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.deepEqual(JSON.parse(result.stdout), ['legacy-message']);
+  const migrated = new DatabaseSync(dbPath, { readOnly: true });
+  assert.ok(migrated.prepare('PRAGMA table_info(index_state)').all().some(row => row.name === 'cursor'));
+  assert.ok(migrated.prepare('PRAGMA table_info(summaries)').all().some(row => row.name === 'visibility'));
+  migrated.close();
+});
+
+test('malformed settings still allow a legacy query schema to migrate', () => {
+  const home = tempHome();
+  const obeliskDir = join(home, '.obelisk');
+  const dbPath = join(obeliskDir, 'obelisk.sqlite');
+  mkdirSync(obeliskDir, { recursive: true });
+  const schema = readFileSync(
+    new URL('../packages/core/src/schema.sql', import.meta.url),
+    'utf8',
+  )
+    .replace(', cursor TEXT);', ');')
+    .replace(
+      ", visibility TEXT DEFAULT 'visible',\n  input_tokens INTEGER, output_tokens INTEGER);",
+      ');',
+    );
+  const db = new DatabaseSync(dbPath);
+  db.exec(schema);
+  db.prepare(`
+    INSERT INTO sessions (id,title,jsonl_path,source)
+    VALUES (?,?,?,?)
+  `).run('legacy-recovery', 'Legacy recovery', '/missing/session.jsonl', 'claude');
+  db.prepare(`
+    INSERT INTO messages (
+      uuid,session_id,type,role,text,content_type,visibility,source
+    ) VALUES (?,?,?,?,?,?,?,?)
+  `).run('legacy-recovery-message', 'legacy-recovery', 'user', 'user', 'legacy recovery', 'text', 'visible', 'claude');
+  db.prepare(`
+    INSERT INTO summaries (id,session_id,timestamp,source,content)
+    VALUES (?,?,?,?,?)
+  `).run('legacy-summary', 'legacy-recovery', '2026-08-05T00:00:00Z', 'compaction', 'summary');
+  db.prepare(`
+    INSERT INTO index_state (jsonl_path,mtime,lines_processed)
+    VALUES ('__last_build__',?,0)
+  `).run(Date.now());
+  db.close();
+  writeFileSync(join(obeliskDir, 'settings.json'), '{broken');
+
+  const scriptPath = join(home, 'legacy-recovery-query.mjs');
+  writeFileSync(scriptPath, `
+    return {
+      summaries: summaries('legacy-recovery').map(summary => summary.id),
+      raw: raw('legacy-recovery-message')
+    };
+  `);
+  const result = runRuntime(['--query', scriptPath], { home });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stderr, /index refresh skipped/);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    summaries: ['legacy-summary'],
+    raw: null,
+  });
+  const migrated = new DatabaseSync(dbPath, { readOnly: true });
+  assert.ok(migrated.prepare('PRAGMA table_info(index_state)').all().some(row => row.name === 'cursor'));
+  assert.ok(migrated.prepare('PRAGMA table_info(summaries)').all().some(row => row.name === 'visibility'));
+  migrated.close();
 });
 
 test('runtime indexes Codex root sessions into the shared query helpers', () => {

--- a/tests/session-detail-assembly.test.mjs
+++ b/tests/session-detail-assembly.test.mjs
@@ -36,6 +36,32 @@ test('session assembly preserves thinking and attaches tool result and subagent 
   assert.equal(assembled[0].tool_calls[0].subagent.agent_id, 'agent-1');
 });
 
+test('orphan tool results stay out of the timeline and do not break assistant merging', () => {
+  const assembled = assembleSessionDetail({
+    messages: [
+      { uuid: 'answer', type: 'assistant', content_type: 'text', text: 'answer' },
+      { uuid: 'orphan-result', type: 'user', content_type: 'tool_result', text: '' },
+      { uuid: 'tool', type: 'assistant', content_type: 'tool_use', text: '' },
+    ],
+    toolCalls: [{
+      id: 'call',
+      message_uuid: 'tool',
+      name: 'Read',
+      input_json: '{"path":"/tmp/file"}',
+    }],
+    toolResults: [{
+      tool_use_id: 'missing-call',
+      message_uuid: '',
+      content: 'orphaned failure',
+      is_error: 1,
+    }],
+  }).messages;
+
+  assert.equal(assembled.length, 1);
+  assert.equal(assembled[0].uuid, 'answer');
+  assert.deepEqual(assembled[0].tool_calls.map(call => call.id), ['call']);
+});
+
 test('session assembly keeps Skill evidence standalone and embeds matching workflow agents', () => {
   const assembled = assembleSessionDetail({
     messages: [

--- a/tests/settings-view.test.mjs
+++ b/tests/settings-view.test.mjs
@@ -20,3 +20,14 @@ test('Editor selector uses the themed Settings control vocabulary', () => {
   assert.match(source, /aria-haspopup="listbox"/);
   assert.match(source, /role="option"/);
 });
+
+test('background index updates preserve an in-progress Recap path edit', () => {
+  assert.match(source, /loadSettings\(\{\s*preserveRecapPath:\s*true\s*\}\)/);
+  assert.match(source, /if\s*\(!preserveRecapPath\)\s*recapPath\.value\s*=/);
+});
+
+test('rebuild failures are caught and surfaced in Settings', () => {
+  assert.match(source, /catch\s*\(error\)\s*\{[\s\S]*rebuildError\.value\s*=/);
+  assert.match(source, /v-if="rebuildError"/);
+  assert.match(source, /\{\{\s*rebuildError\s*\}\}/);
+});


### PR DESCRIPTION
## Summary

- Use provider-owned unit identities for marker replay and raw cursor lookup, including Kimi's directory-backed sessions.
- Preserve orphan failure evidence and effective inactive visibility without rendering empty orphan tool-result bubbles.
- Keep destructive rebuilds, schema upgrades, and desktop refresh/rebuild behavior safe across invalid settings, incomplete inventories, and concurrent ownership.

Follow-up to #23. This PR is independent of and compatible with #37.

## Verification

Environment: Obelisk 0.2.0 (CLI 0.2.2), Node.js v24.1.0, npm 11.3.0.

- `npm test`: 423/423 passed
- Combined locally with #37: 425/425 passed
- Fixed-seed Pi 0.83.0 differential: seed `0x5eedc0de`, 512 cases, 18,124 entries, 11,586 messages, 2,230 compactions, and 1,060 orphan-parent cases
- `npm run typecheck`
- `npm run build:core`
- `npm run build:cli`
- `npm run build:skill`
- `npm run lint`: 0 errors (4 existing test warnings)
- `git diff --check`
