### PR TITLE
fix(core): scope subagents() time filters by message timeline

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -274,7 +274,9 @@ function createQueryApi(
     const opts = normalizeOpts(optsOrSid);
     const { limit = 100 } = opts;
     const needsJoin = opts.project || opts.branch || opts.source;
-    const { where, params } = buildWhere(opts, { sessionId: 'sa.session_id', project: 's.project', timestamp: 'sa.session_id', branch: 's.git_branch', source: 's.source' });
+    // The subagents table has no timestamp column; scope time filters by the
+    // subagent's own message timeline instead of comparing session IDs.
+    const { where, params } = buildWhere(opts, { sessionId: 'sa.session_id', project: 's.project', timestamp: '(SELECT MIN(m.timestamp) FROM messages m WHERE m.agent_id = sa.agent_id)', branch: 's.git_branch', source: 's.source' });
     params.push(limit);
     const join = needsJoin ? 'LEFT JOIN sessions s ON s.id=sa.session_id' : '';
     return db.prepare(`SELECT sa.* FROM subagents sa ${join} WHERE ${where} LIMIT ?`).all(...params).map((r: DbRow) => {

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -29,6 +29,9 @@ interface ColumnAliases {
   sessionId: string;
   project: string;
   timestamp: string;
+  /** Optional per-direction overrides for range-typed rows (activity intervals). */
+  timestampAfter?: string;
+  timestampBefore?: string;
   branch: string;
   source?: string;
 }
@@ -64,8 +67,8 @@ function buildWhere(opts: QueryOptions, aliases: ColumnAliases) {
     params.push(...opts.sessions);
   }
   if (opts.project) { clauses.push(`${aliases.project} LIKE ?`); params.push(opts.project); }
-  if (opts.after) { clauses.push(`${aliases.timestamp} > ?`); params.push(opts.after); }
-  if (opts.before) { clauses.push(`${aliases.timestamp} < ?`); params.push(opts.before); }
+  if (opts.after) { clauses.push(`${aliases.timestampAfter ?? aliases.timestamp} > ?`); params.push(opts.after); }
+  if (opts.before) { clauses.push(`${aliases.timestampBefore ?? aliases.timestamp} < ?`); params.push(opts.before); }
   if (opts.branch) { clauses.push(`${aliases.branch} = ?`); params.push(opts.branch); }
   if (opts.source && opts.source !== 'all' && aliases.source) {
     clauses.push(`COALESCE(${aliases.source}, 'claude') = ?`);
@@ -275,8 +278,13 @@ function createQueryApi(
     const { limit = 100 } = opts;
     const needsJoin = opts.project || opts.branch || opts.source;
     // The subagents table has no timestamp column; scope time filters by the
-    // subagent's own message timeline instead of comparing session IDs.
-    const { where, params } = buildWhere(opts, { sessionId: 'sa.session_id', project: 's.project', timestamp: '(SELECT MIN(m.timestamp) FROM messages m WHERE m.agent_id = sa.agent_id)', branch: 's.git_branch', source: 's.source' });
+    // subagent's activity interval instead of comparing session IDs. `after`
+    // matches agents still active past the bound (latest message), `before`
+    // matches agents already started by the bound (earliest message), so
+    // combined bounds select every agent active during the window.
+    const firstMessageAt = '(SELECT MIN(m.timestamp) FROM messages m WHERE m.agent_id = sa.agent_id)';
+    const lastMessageAt = '(SELECT MAX(m.timestamp) FROM messages m WHERE m.agent_id = sa.agent_id)';
+    const { where, params } = buildWhere(opts, { sessionId: 'sa.session_id', project: 's.project', timestamp: firstMessageAt, timestampAfter: lastMessageAt, timestampBefore: firstMessageAt, branch: 's.git_branch', source: 's.source' });
     params.push(limit);
     const join = needsJoin ? 'LEFT JOIN sessions s ON s.id=sa.session_id' : '';
     return db.prepare(`SELECT sa.* FROM subagents sa ${join} WHERE ${where} LIMIT ?`).all(...params).map((r: DbRow) => {

--- a/skill-doc/references/api-reference.md
+++ b/skill-doc/references/api-reference.md
@@ -334,8 +334,8 @@ Subagent metadata plus message counts. Passing a string is treated as
 | --- | --- | --- |
 | `opts.sessionId` | `string` | Restrict to one session |
 | `opts.project` | `string` | SQL `LIKE` pattern over source session project |
-| `opts.after` | `string` | ISO lower bound on the subagent's first message timestamp |
-| `opts.before` | `string` | ISO upper bound on the subagent's first message timestamp |
+| `opts.after` | `string` | ISO lower bound; matches subagents still active past it (latest message) |
+| `opts.before` | `string` | ISO upper bound; matches subagents already started by it (earliest message) |
 | `opts.source` | `string` | Provider filter |
 | `opts.limit` | `number` | Max rows, default 100 |
 

--- a/skill-doc/references/api-reference.md
+++ b/skill-doc/references/api-reference.md
@@ -334,6 +334,8 @@ Subagent metadata plus message counts. Passing a string is treated as
 | --- | --- | --- |
 | `opts.sessionId` | `string` | Restrict to one session |
 | `opts.project` | `string` | SQL `LIKE` pattern over source session project |
+| `opts.after` | `string` | ISO lower bound on the subagent's first message timestamp |
+| `opts.before` | `string` | ISO upper bound on the subagent's first message timestamp |
 | `opts.source` | `string` | Provider filter |
 | `opts.limit` | `number` | Max rows, default 100 |
 

--- a/tests/query.test.mjs
+++ b/tests/query.test.mjs
@@ -641,7 +641,7 @@ test('remember rejects missing memory files', () => {
   db.close();
 });
 
-test('subagents after/before narrow by the subagent message timeline, not session IDs', () => {
+test('subagents after/before narrow by the subagent activity interval, not session IDs', () => {
   const db = new DatabaseSync(':memory:');
   db.exec(SCHEMA);
   db.prepare('INSERT INTO sessions (id,title,started_at) VALUES (?,?,?)')
@@ -652,6 +652,7 @@ test('subagents after/before narrow by the subagent message timeline, not sessio
   `);
   insertAgent.run('agent-early', 'sid-agents', 'explore', 'Early agent');
   insertAgent.run('agent-late', 'sid-agents', 'coder', 'Late agent');
+  insertAgent.run('agent-spanning', 'sid-agents', 'coder', 'Agent active across the bound');
   const insertMessage = db.prepare(`
     INSERT INTO messages (uuid,session_id,type,role,text,timestamp,agent_id)
     VALUES (?,?,?,?,?,?,?)
@@ -659,19 +660,30 @@ test('subagents after/before narrow by the subagent message timeline, not sessio
   insertMessage.run('m-early-1', 'sid-agents', 'assistant', 'assistant', 'early start', '2026-06-01T10:00:00Z', 'agent-early');
   insertMessage.run('m-early-2', 'sid-agents', 'assistant', 'assistant', 'early end', '2026-06-01T10:05:00Z', 'agent-early');
   insertMessage.run('m-late-1', 'sid-agents', 'assistant', 'assistant', 'late start', '2026-06-03T10:00:00Z', 'agent-late');
+  insertMessage.run('m-span-1', 'sid-agents', 'assistant', 'assistant', 'spanning start', '2026-06-01T12:00:00Z', 'agent-spanning');
+  insertMessage.run('m-span-2', 'sid-agents', 'assistant', 'assistant', 'spanning end', '2026-06-03T12:00:00Z', 'agent-spanning');
   const api = createQueryApi(db);
 
+  // `after` keeps agents still active past the bound: the spanning agent's
+  // interval crosses 06-02 even though it started before it.
   assert.deepEqual(
-    api.subagents({ after: '2026-06-02T00:00:00Z' }).map((row) => row.agent_id),
-    ['agent-late'],
+    api.subagents({ after: '2026-06-02T00:00:00Z' }).map((row) => row.agent_id).sort(),
+    ['agent-late', 'agent-spanning'],
   );
+  // `before` keeps agents already started by the bound.
   assert.deepEqual(
-    api.subagents({ before: '2026-06-02T00:00:00Z' }).map((row) => row.agent_id),
-    ['agent-early'],
+    api.subagents({ before: '2026-06-02T00:00:00Z' }).map((row) => row.agent_id).sort(),
+    ['agent-early', 'agent-spanning'],
   );
+  // Combined bounds select every agent active during the window.
   assert.deepEqual(
     api.subagents({ after: '2026-06-01T09:00:00Z', before: '2026-06-04T00:00:00Z' }).map((row) => row.agent_id).sort(),
-    ['agent-early', 'agent-late'],
+    ['agent-early', 'agent-late', 'agent-spanning'],
+  );
+  // A window inside the spanning agent's interval matches it alone.
+  assert.deepEqual(
+    api.subagents({ after: '2026-06-02T00:00:00Z', before: '2026-06-03T00:00:00Z' }).map((row) => row.agent_id),
+    ['agent-spanning'],
   );
 
   db.close();

--- a/tests/query.test.mjs
+++ b/tests/query.test.mjs
@@ -640,3 +640,39 @@ test('remember rejects missing memory files', () => {
 
   db.close();
 });
+
+test('subagents after/before narrow by the subagent message timeline, not session IDs', () => {
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  db.prepare('INSERT INTO sessions (id,title,started_at) VALUES (?,?,?)')
+    .run('sid-agents', 'Subagent session', '2026-06-01T09:00:00Z');
+  const insertAgent = db.prepare(`
+    INSERT INTO subagents (agent_id,session_id,agent_type,description)
+    VALUES (?,?,?,?)
+  `);
+  insertAgent.run('agent-early', 'sid-agents', 'explore', 'Early agent');
+  insertAgent.run('agent-late', 'sid-agents', 'coder', 'Late agent');
+  const insertMessage = db.prepare(`
+    INSERT INTO messages (uuid,session_id,type,role,text,timestamp,agent_id)
+    VALUES (?,?,?,?,?,?,?)
+  `);
+  insertMessage.run('m-early-1', 'sid-agents', 'assistant', 'assistant', 'early start', '2026-06-01T10:00:00Z', 'agent-early');
+  insertMessage.run('m-early-2', 'sid-agents', 'assistant', 'assistant', 'early end', '2026-06-01T10:05:00Z', 'agent-early');
+  insertMessage.run('m-late-1', 'sid-agents', 'assistant', 'assistant', 'late start', '2026-06-03T10:00:00Z', 'agent-late');
+  const api = createQueryApi(db);
+
+  assert.deepEqual(
+    api.subagents({ after: '2026-06-02T00:00:00Z' }).map((row) => row.agent_id),
+    ['agent-late'],
+  );
+  assert.deepEqual(
+    api.subagents({ before: '2026-06-02T00:00:00Z' }).map((row) => row.agent_id),
+    ['agent-early'],
+  );
+  assert.deepEqual(
+    api.subagents({ after: '2026-06-01T09:00:00Z', before: '2026-06-04T00:00:00Z' }).map((row) => row.agent_id).sort(),
+    ['agent-early', 'agent-late'],
+  );
+
+  db.close();
+});


### PR DESCRIPTION
## Summary

Fixes #43. `subagents()` mapped the `buildWhere` timestamp alias to `sa.session_id`, so `after`/`before` filters compared session ID strings against ISO time bounds and silently returned arbitrary rows.

One deviation from the issue's suggested fix: `sa.timestamp` does not exist — the `subagents` table has no timestamp column at all. Instead, time filters are framed as the subagent's **activity interval** derived from its own message timeline:

- `after` matches subagents still active past the bound (latest message `MAX(timestamp) > after`);
- `before` matches subagents already started by the bound (earliest message `MIN(timestamp) < before`);
- combined bounds therefore select every subagent active during the window, including ones whose activity spans it.

`buildWhere` gains optional per-direction timestamp aliases (`timestampAfter`/`timestampBefore`) to support this; all other helpers keep their existing single-column semantics. No schema migration. Subagents with no messages are excluded when a time bound is set (their interval is unknown).

- `packages/core/src/query.ts` — per-direction aliases + interval subqueries for `subagents()`.
- `skill-doc/references/api-reference.md` — document `opts.after` / `opts.before` for `subagents()` with the interval semantics.
- `tests/query.test.mjs` — regression test with early/late/window-spanning subagents, asserting `after`, `before`, and combined bounds, including a window inside a spanning agent's interval.

## Verification

- `npm test` — 426/426 passed
- `npm run typecheck` — passed
- `npm run lint` — 0 errors (4 existing warnings)
- `git diff --check` — passed
