### PR TITLE
fix(app): back off incomplete inventory retries

### DIFF
--- a/app/src/main/indexer-service.ts
+++ b/app/src/main/indexer-service.ts
@@ -9,6 +9,7 @@ const DEFAULT_STABILITY_MS = 500;
 const DEFAULT_HEARTBEAT_MS = 30000;
 const DEFAULT_WATCH_RETRY_MS = 5000;
 const DEFAULT_DEFERRED_RETRY_MS = 250;
+const MAX_INVENTORY_RETRY_MS = 10 * 60 * 1000;
 
 type TimerHandle = ReturnType<typeof setTimeout>;
 
@@ -144,6 +145,7 @@ function createIndexerService({
   let lastReason: string | null = null;
   let changedPaths = new Set<string>();
   let fullInventoryPending = false;
+  let nextInventoryRetryMs = heartbeatMs;
   let idlePromise = Promise.resolve();
 
   const requestFullInventory = () => {
@@ -201,15 +203,25 @@ function createIndexerService({
         }
       }
       const incompleteInventory = (result?.inventoryIssues?.length ?? 0) > 0;
+      if (!result?.deferred && !incompleteInventory && buildChangedPaths === undefined) {
+        nextInventoryRetryMs = heartbeatMs;
+      }
       if (result?.deferred || incompleteInventory) {
         if (incompleteInventory || buildChangedPaths === undefined) requestFullInventory();
         else addChangedPath(buildChangedPaths);
         if (!stopped && !retryTimer) {
           const retryReason = result?.deferred ? 'writer-lease' : 'incomplete-inventory';
+          const retryMs = result?.deferred ? deferredRetryMs : nextInventoryRetryMs;
           retryTimer = timers.setTimeout(() => {
             retryTimer = null;
             runBuildNow(retryReason);
-          }, result?.deferred ? deferredRetryMs : heartbeatMs);
+          }, retryMs);
+          if (!result?.deferred) {
+            nextInventoryRetryMs = Math.min(nextInventoryRetryMs * 2, Math.max(
+              heartbeatMs,
+              MAX_INVENTORY_RETRY_MS,
+            ));
+          }
         }
         if (result?.deferred) return;
       }
@@ -298,6 +310,7 @@ function createIndexerService({
     watchRetryTimer = null;
     if (retryTimer) timers.clearTimeout(retryTimer);
     retryTimer = null;
+    nextInventoryRetryMs = heartbeatMs;
     if (heartbeatTimer && typeof timers.clearInterval === 'function') timers.clearInterval(heartbeatTimer);
     heartbeatTimer = null;
     if (watcher?.close) watcher.close();

--- a/tests/app-indexer-service.test.mjs
+++ b/tests/app-indexer-service.test.mjs
@@ -10,9 +10,12 @@ import { createIndexerService } from '../app/src/main/indexer-service.ts';
 
 function manualTimers() {
   const timers = new Set();
+  const delays = [];
   return {
-    setTimeout(fn) {
+    delays,
+    setTimeout(fn, ms) {
       timers.add(fn);
+      delays.push(ms);
       return fn;
     },
     clearTimeout(fn) {
@@ -230,6 +233,44 @@ test('an incomplete inventory schedules a full retry', async () => {
     { reason: 'watch', changedPaths: ['/tmp/pi/session.jsonl'] },
     { reason: 'incomplete-inventory', changedPaths: undefined },
   ]);
+});
+
+test('incomplete inventory retries back off to ten minutes and reset after recovery', async () => {
+  const timers = manualTimers();
+  let incomplete = true;
+  const service = createIndexerService({
+    buildIndex: async () => incomplete
+      ? {
+          complete: false,
+          inventoryIssues: [{
+            provider: 'pi',
+            path: '/tmp/pi/locked',
+            error: 'EACCES: permission denied',
+          }],
+        }
+      : { complete: true, inventoryIssues: [] },
+    watchProjects: () => null,
+    writeHeartbeat: () => {},
+    logger: { warn() {} },
+    timers,
+    heartbeatMs: 120_000,
+    stabilityMs: 0,
+  });
+
+  await service.runBuildNow('startup');
+  for (let attempt = 0; attempt < 4; attempt++) {
+    timers.flush();
+    await service.idle();
+  }
+  assert.deepEqual(timers.delays, [120_000, 240_000, 480_000, 600_000, 600_000]);
+
+  incomplete = false;
+  timers.flush();
+  await service.idle();
+  incomplete = true;
+  await service.runBuildNow('manual');
+  assert.equal(timers.delays.at(-1), 120_000);
+  service.stop();
 });
 
 test('a failed unit does not promote its changed-path build to a full retry', async () => {


### PR DESCRIPTION
## Summary

- back off incomplete-inventory retries from 30s to a 10m cap
- reset the delay after a complete inventory or service stop
- keep writer-lease retries unchanged

Closes #40

## Tests

- `npm test` — 427/427
- `npm run typecheck`
- `npm run lint` — 0 errors, 4 existing warnings