### PR TITLE
fix(core): handle remember without session_id

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -713,7 +713,9 @@ function createAttuneApi(db: SqliteDb) {
     const normalizedPath = resolveMemoryPath(memoryPath, session_id);
     const normalizedAnchors = normalizeAnchors(anchors);
     const id = `mem-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    const proj = project || db.prepare('SELECT project FROM sessions WHERE id=?').get(session_id)?.project || null;
+    const proj = project || (session_id
+      ? db.prepare('SELECT project FROM sessions WHERE id=?').get(session_id)?.project || null
+      : null);
     const created_at = new Date().toISOString();
     db.prepare('INSERT OR REPLACE INTO memories (id, session_id, project, message_start, message_end, path, anchors, summary, created_at) VALUES (?,?,?,?,?,?,?,?,?)').run(
       id, session_id || null, proj, message_start || null, message_end || null, normalizedPath, normalizedAnchors, summary, created_at);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -83,7 +83,7 @@ test('malformed Obelisk settings skip refresh without disabling provider-backed 
   assert.match(JSON.parse(attune.stdout).error, /settings.*attune was not applied/i);
 });
 
-test('runtime attune scripts expose only memory mutation helpers', () => {
+test('runtime attune exposes only memory mutation helpers and remembers without session_id', () => {
   const home = tempHome();
   const memoryPath = join(home, 'memory.md');
   const scriptPath = join(home, 'attune.mjs');
@@ -97,7 +97,6 @@ test('runtime attune scripts expose only memory mutation helpers', () => {
       overviewType: typeof overview,
       result: remember({
         path: ${JSON.stringify(memoryPath)},
-        project: 'runtime-test',
         summary: 'Decision: runtime remember exposes only memory registration.'
       })
     };
@@ -113,6 +112,7 @@ test('runtime attune scripts expose only memory mutation helpers', () => {
   assert.equal(payload.sqlType, 'undefined');
   assert.equal(payload.overviewType, 'undefined');
   assert.equal(payload.result.path, memoryPath);
+  assert.equal(payload.result.project, null);
 });
 
 test('runtime rejects removed remember mode', () => {


### PR DESCRIPTION
## Summary

- Skip the session project lookup when remember() is called without session_id.
- Store the optional project and session fields as SQLite NULL when neither is provided.
- Cover the public --attune path with remember({ path, summary }).

## Verification

- npm test: 427 passed, 0 failed.
- npm run typecheck: root and app TypeScript configurations passed.
- npm run lint: 0 errors, 4 pre-existing warnings.

## Scope

No schema, dependency, or app changes.