### PR TITLE
fix(claude): link workflows by unique run id

### DIFF
--- a/packages/core/src/providers/claude.ts
+++ b/packages/core/src/providers/claude.ts
@@ -180,7 +180,6 @@ function toolResultText(content: unknown): string {
 function workflowParentToolUseId(
   transcriptPath: string,
   runId: string,
-  workflowName: string | null,
 ): string | null {
   if (!existsSync(transcriptPath)) return null;
   const workflowToolIds = new Set<string>();
@@ -202,7 +201,7 @@ function workflowParentToolUseId(
     for (const block of content) {
       if (block?.type !== 'tool_result' || !workflowToolIds.has(block.tool_use_id)) continue;
       const text = toolResultText(block.content);
-      if (!text.includes(runId) && !(workflowName && text.includes(workflowName))) continue;
+      if (!text.includes(runId)) continue;
       parentToolUseId = block.tool_use_id;
       return false;
     }
@@ -226,7 +225,6 @@ function* parseWorkflow(unit: IndexUnit): Generator<TranscriptRecord, Cursor> {
     parent_tool_use_id: workflowParentToolUseId(
       meta.mainTranscriptPath,
       workflow.runId,
-      workflow.workflowName || null,
     ),
     task_id: workflow.taskId || null,
     script: workflow.script || null,

--- a/tests/claude-parse.test.mjs
+++ b/tests/claude-parse.test.mjs
@@ -162,3 +162,38 @@ test('claude provider emits workflow artifacts with an explicit canonical tool e
   assert.deepEqual(persistedDetail, detail);
   db.close();
 });
+
+test('claude links repeated workflow names by unique run id', () => {
+  const root = makeTempDir('obelisk-claude-workflow-link-');
+  const projectDir = join(root, 'projects', '-proj');
+  const workflowDir = join(projectDir, 'sid-workflow', 'workflows');
+  mkdirSync(workflowDir, { recursive: true });
+  writeFileSync(join(projectDir, 'sid-workflow.jsonl'), [
+    {
+      uuid: 'assistant-old', type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'old-call', name: 'Workflow', input: {} }] },
+    },
+    {
+      uuid: 'old-result', type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'old-call', content: 'Run ID: old-run\nSummary: same-name' }] },
+    },
+    {
+      uuid: 'assistant-new', type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'new-call', name: 'Workflow', input: {} }] },
+    },
+    {
+      uuid: 'new-result', type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'new-call', content: 'Run ID: new-run\nSummary: same-name' }] },
+    },
+  ].map(line => JSON.stringify(line)).join('\n') + '\n');
+  writeFileSync(join(workflowDir, 'new-run.json'), JSON.stringify({
+    runId: 'new-run', workflowName: 'same-name', status: 'completed', workflowProgress: [],
+  }));
+
+  const provider = createClaudeProvider({ rootDir: root });
+  const workflowUnit = provider.discover({ lastCursor: () => null })
+    .find(unit => unit.meta?.kind === 'workflow');
+  const records = drain(provider.parse(workflowUnit, null)).values;
+
+  assert.equal(records.find(record => record.kind === 'workflow').parent_tool_use_id, 'new-call');
+});


### PR DESCRIPTION
## What and why

When a Claude session runs the same workflow name more than once, the workflow-name fallback can attach the newer workflow record to an older Workflow tool call. This change links workflows only when the tool result contains the unique run ID; workflowName remains available as display metadata.

The regression test exercises the Claude provider through discover() and parse() with two same-name runs and verifies that the newer run links to new-call.

## Verification

- [x] npm test — 450 passed, 0 failed.
- [x] npm run typecheck — 0 errors across root and app configurations.
- [x] npm run lint — 0 errors, 4 pre-existing warnings.
- [x] node --test tests/claude-parse.test.mjs — 5 passed, 0 failed.
- [x] No existing assertion was loosened.
- [x] Re-ran all checks after rebasing onto upstream/main at f8cdb61.

## Provider adapter checks

- [x] Read claude.ts, codex.ts, kimi.ts, ADR-0001, and ADR-0007.
- [x] Regression test calls discover() against the existing Claude workflow directory layout.
- [x] Canonical transcript and SQLite round-trip suites pass.
- [x] No identity, record-shape, visibility, cursor, schema, or version-marker change.

## Deliberately out of scope

No CI workflow change. The repository's current CLI workflow does not include claude-parse.test.mjs.

No schema migration or index-version bump: this corrects selection of an existing parent_tool_use_id field without changing stored row shape.
