### PR TITLE
feat(core): identify the invoking session in query results

### DIFF
--- a/docs/adr/0001-parse-core-and-persist-layers.md
+++ b/docs/adr/0001-parse-core-and-persist-layers.md
@@ -66,6 +66,9 @@ binding-agnostic and does not need a per-binding implementation.
 the index fresh) and **passive pull mode** (a CLI command indexes on invocation
 when no daemon is active). They never write concurrently — passive mode detects
 a fresh daemon via heartbeat markers in `index_state` (**daemon arbitration**).
+One narrow exception: the invocation-nonce freshness build may index
+incrementally under a fresh daemon heartbeat, arbitrated by the writer lease
+(see the 2026-08-11 amendment in ADR-0006).
 
 **Consequences.** Golden tests anchor on each adapter's `parse` output (feed
 fixture JSONL, assert the yielded record sequence) — independent of binding and

--- a/docs/adr/0006-write-transaction-rollback-and-concurrency.md
+++ b/docs/adr/0006-write-transaction-rollback-and-concurrency.md
@@ -96,7 +96,10 @@ database: a CLI incremental build and later daemon builds read and advance the
 same cursors. The carve-out build never selects the force full-republish path,
 and it runs only against an already-initialized index: schema setup under a
 fresh heartbeat remains the daemon's job, so a CLI query against an
-uninitialized index stays read-only and falls back to the bounded poll.
+uninitialized index stays read-only and falls back to the bounded poll. The
+gate enforces this with `coreSchemaNeedsMigration`, so a legacy schema whose
+tables exist but whose columns predate the current version also blocks the
+carve-out build.
 Note that `openDb()` always applies the shared `schema.sql` idempotently, so
 additive `IF NOT EXISTS` statements (for example a new index) may also be
 applied by a carve-out build while holding the lease; this is safe because

--- a/docs/adr/0006-write-transaction-rollback-and-concurrency.md
+++ b/docs/adr/0006-write-transaction-rollback-and-concurrency.md
@@ -74,3 +74,35 @@ overlap when policy information races or is stale. A single bad transcript can
 still be skipped so the index self-heals on a later build; structural/finalize
 failures remain visible. Longer timeouts must not replace the transaction and
 ownership rules recorded here.
+
+**Amendment (2026-08-11): invocation-nonce freshness carve-out.** The original
+decision makes a fresh `__app_heartbeat__` policy ownership for every CLI write
+path. One narrow exception is now granted: the invocation-nonce freshness
+build — the single incremental build a query runs when its invocation nonce is
+not yet indexed (`buildIndex({ ignoreRecentBuild: true, ignoreDaemonOwnership:
+true })`) — may ignore daemon policy ownership. Without the carve-out, nonce
+resolution in daemon mode could never succeed: the pre-query refresh always
+skips with `daemon_active`, and the daemon's watcher-driven build lags the
+just-written tool-call record by seconds.
+
+The heartbeat's job is unchanged; the writer lease remains the sole arbitrator
+of who actually writes. The carve-out build acquires the lease non-blocking, so
+it can never overlap a daemon build. Loser paths are unchanged: on
+`writer_busy` the CLI falls back to the existing bounded poll of freshly opened
+read snapshots and then to honest null, and the daemon's indexer service keeps
+its defer-and-retry on lease contention with changed paths retained.
+Consistency holds because incremental cursors live in `index_state` inside the
+database: a CLI incremental build and later daemon builds read and advance the
+same cursors. The carve-out build never selects the force full-republish path,
+and it runs only against an already-initialized index: schema setup under a
+fresh heartbeat remains the daemon's job, so a CLI query against an
+uninitialized index stays read-only and falls back to the bounded poll.
+Note that `openDb()` always applies the shared `schema.sql` idempotently, so
+additive `IF NOT EXISTS` statements (for example a new index) may also be
+applied by a carve-out build while holding the lease; this is safe because
+the daemon applies the identical shared schema on its own builds. What the
+carve-out never does is initialize or migrate a missing/legacy schema.
+
+Every other CLI write path keeps the original rule: the regular pre-query
+refresh, `attune`, migrations, schema setup, and checkpoints all remain
+read-only under a fresh heartbeat.

--- a/docs/adr/0008-invocation-relative-session-identity.md
+++ b/docs/adr/0008-invocation-relative-session-identity.md
@@ -1,0 +1,83 @@
+# Invocation-relative session identity via nonce self-search
+
+**Context.** Obelisk deliberately refreshes its index before each query, so the
+session invoking that query is indexed and returned beside genuine historical
+sessions with identical shape (#45). Agents then miscount their own live
+session as independent evidence. The obvious identity channels all fail: the
+agent (the LLM) does not know its own session id, so skill instructions cannot
+have it pass one; provider runtimes cannot be modified by this project; and
+several agents may query concurrently, so "current" must mean *the session
+invoking this retrieval*, never "every recently active session".
+
+Two facts opened a better channel. First, the CLI runs as a descendant of the
+agent runtime, and every provider flushes the tool-call record to its
+transcript **before the tool finishes executing** — verified for Kimi Code
+(live `wire.jsonl` inspection), Claude Code (`tool_use`/`tool_result`
+timestamp deltas), Codex (rollout `function_call` vs `function_call_output`
+deltas), and Pi (source: `agent-loop.ts` persists `message_end` via
+synchronous `appendFileSync` before `executeToolCalls`). Second, the pre-query
+refresh therefore indexes the CLI's own invocation record before the resolver
+runs.
+
+**Decision.** Identify the invoking session by **nonce self-search**, with no
+agent cooperation and no provider changes.
+
+- The CLI carries a per-invocation unique nonce in its own argv: the as-typed
+  query file path for `--query` (skill docs prescribe unique temp names), and
+  an explicit `--nonce <token>` for `--search` (never part of the FTS text).
+  Skill docs use `mktemp`/`uuidgen` with shell-builtin fallbacks.
+- `resolveInvokingSessionId` searches the freshly refreshed index for the
+  nonce: FTS over message text, plus a LIKE over `tool_calls.input_json` for
+  providers that record tool input separately. Both legs are bounded by a
+  15-minute recency window (`INVOCATION_RECENCY_MS`) — the invoking record is
+  always written "now" — which keeps the scan off the full `tool_calls` table
+  and keeps weeks-old fixed-path reuse out of the candidate set. A
+  `messages(timestamp)` index (`idx_messages_time`) plus a `CROSS JOIN`
+  planner hint keep the bounded scan index-driven.
+- Multi-match resolution is **newest-wins**: matches far apart in time are
+  unrelated history, not ambiguity. Only when the two newest matching records
+  (necessarily different sessions) fall within `INVOCATION_COLLISION_MS`
+  (10 s) is it a genuine concurrent collision. Zero matches, a collision, or
+  an unparseable timestamp resolve to **honest null** — nothing is marked.
+  Newest-wins also absorbs the false-poisoning case where another session
+  merely quotes the command in text: the quote is older than the real
+  execution and loses.
+- Resolved identity is annotation, not filtering: `search()` hit sessions and
+  `sessions()` rows gain `is_invoking: true` (omitted otherwise), and
+  `overview().current.session_id` exposes the id (null when unresolved).
+  Ordinary query semantics are unchanged.
+- Freshness recovery (`resolveInvokingSessionIdWithWait`): on a first miss,
+  run one incremental build (`ignoreRecentBuild`, never the force
+  full-republish path) — allowed under a fresh daemon heartbeat via the narrow
+  ADR-0006 carve-out (`ignoreDaemonOwnership`) — then poll freshly opened
+  read snapshots (~300 ms, ~4 s cap) as the lease-contention fallback. Still
+  unresolved is honest null. Queries without a nonce or with an immediate hit
+  pay zero added latency.
+
+Rejected alternatives: agent-supplied session id (the agent does not know it);
+an explicit env/flag override channel (deferred — real need only for MCP
+transports and tests, and it must never be documented for agents to fill in);
+ancestor-pid registry lookup (only Claude Code ships a pid→session registry
+today; remains a possible future optimization, not a second mechanism);
+scanning transcript files directly (duplicates provider path knowledge and
+file→session mapping in the resolver); classifying recently active sessions
+as current (violates the meaning of "current").
+
+**Verification.** Flush-timing evidence per provider as above. Dedicated
+suite `tests/invoking-session.test.mjs` covers resolution via both legs,
+missing/unknown nonces, newest-wins vs collision epsilon vs
+quote-loses-execution, the recency boundary, incremental-vs-force recovery
+builds, the daemon-heartbeat carve-out, the legacy-schema gate, and the
+writer-busy poll fallback, plus CLI end-to-end runs. Live smoke on a
+daemon-owning machine resolves the invoking session correctly. The schema
+canary in `provider-schema-stability.test.mjs` records the additive index as
+an explicit decision.
+
+**Consequences.** The retrieval contract gains invocation-relative identity
+without changing result sets. Agents must treat an `is_invoking` session as
+their own current context, not corroborating evidence. Non-unique invocation
+signatures degrade safely: worst case is a concurrent-collision null, never a
+mis-mark. #17's `excludeSession` composes on top once the invoking id is
+known. If an MCP transport is added, it will need an explicit identity
+channel (the deferred override), since a long-lived server shares no fresh
+process ancestry with each caller.

--- a/packages/cli/src/obelisk.ts
+++ b/packages/cli/src/obelisk.ts
@@ -58,11 +58,25 @@ async function main() {
     return;
   }
   if (args[0] === '--search' && args[1]) {
-    try { emit(searchText(args.slice(1).join(' '))); } catch (error) { fail(error); }
+    try {
+      // --nonce <token> marks this invocation in the transcript so the query
+      // layer can identify the invoking session; it is not part of the FTS text.
+      let nonce: string | undefined;
+      const textParts: string[] = [];
+      const rest = args.slice(1);
+      for (let i = 0; i < rest.length; i++) {
+        if (rest[i] === '--nonce' && rest[i + 1]) { nonce = rest[i + 1]; i++; } else { textParts.push(rest[i]); }
+      }
+      emit(searchText(textParts.join(' '), undefined, { invocationNonce: nonce }));
+    } catch (error) { fail(error); }
     return;
   }
   if (args[0] === '--query' && args[1]) {
-    try { emit(await executeQuery(readFileSync(resolve(args[1]), 'utf8'))); } catch (error) { fail(error); }
+    try {
+      // The nonce is the query file path as typed (not resolved): the
+      // transcript records what the agent typed.
+      emit(await executeQuery(readFileSync(resolve(args[1]), 'utf8'), { invocationNonce: args[1] }));
+    } catch (error) { fail(error); }
     return;
   }
   if (args[0] === '--attune' && args[1]) {
@@ -84,7 +98,7 @@ async function main() {
     }
     return;
   }
-  process.stderr.write('Usage:\n  obelisk install [skills options]\n  obelisk --build\n  obelisk --search "text"\n  obelisk --query <file.js>\n  obelisk --attune <file.js>\n');
+  process.stderr.write('Usage:\n  obelisk install [skills options]\n  obelisk --build\n  obelisk --search "text" [--nonce <token>]\n  obelisk --query <file.js>\n  obelisk --attune <file.js>\n');
   process.exitCode = 1;
 }
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -170,12 +170,18 @@ export function resolveInvokingSessionId(
   // from messages (idx_messages_time) and probe tool_calls by message_uuid;
   // a plain JOIN lets SQLite drive from a 150k-row tool_calls scan instead.
   if (indexedTables.has('tool_calls') && indexedTables.has('messages')) {
-    const like = `%${nonce.replace(/[\\%_]/g, '\\$&')}%`;
+    // input_json is JSON-encoded, so a nonce containing JSON-escaped
+    // characters (notably backslashes in Windows paths) is stored in escaped
+    // form; match both the raw and the JSON-escaped spelling.
+    const likePattern = (value: string): string => `%${value.replace(/[\\%_]/g, '\\$&')}%`;
+    const jsonEscaped = JSON.stringify(nonce).slice(1, -1);
+    const patterns = jsonEscaped === nonce ? [likePattern(nonce)] : [likePattern(nonce), likePattern(jsonEscaped)];
+    const likeClause = patterns.map(() => "tc.input_json LIKE ? ESCAPE '\\'").join(' OR ');
     const toolRows = db.prepare(`
       SELECT tc.session_id AS session_id, m.timestamp AS timestamp
       FROM messages m CROSS JOIN tool_calls tc ON tc.message_uuid = m.uuid
-      WHERE m.timestamp >= ? AND tc.input_json LIKE ? ESCAPE '\\'
-    `).all(cutoff, like);
+      WHERE m.timestamp >= ? AND (${likeClause})
+    `).all(cutoff, ...patterns);
     for (const row of toolRows) {
       track(row.session_id, row.timestamp);
     }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -12,17 +12,23 @@ import { createContext, runInNewContext } from 'node:vm';
 
 import { DB_PATH, openDb, openReadDb, openWriterLeaseDb } from './db.ts';
 import { buildIndex, ensureReadableSchema, shouldSkipBuild } from './indexer.ts';
+import { coreSchemaNeedsMigration } from './schema-migrations.ts';
 import {
   createConfiguredBuiltinProviderRuntime,
   readPersistedProviderSettings,
 } from './provider-settings.ts';
 import type { ProviderRegistry } from './providers/registry.ts';
 import { createQueryApi, createAttuneApi } from './query.ts';
+import type { SqliteDb } from './sqlite-types.ts';
 import { acquireWriterLease, writerLockPathFor } from './writer-lease.ts';
 
 export { buildIndex, DB_PATH };
 
 type SandboxApi = Record<string, unknown>;
+
+interface InvocationOptions {
+  invocationNonce?: string;
+}
 
 interface InventoryIssue {
   provider?: unknown;
@@ -83,13 +89,212 @@ function runInSandbox(api: SandboxApi, scriptContent: string): Promise<unknown> 
   return runInNewContext(`(async()=>{${scriptContent}})()`, ctx, { timeout: 30000 });
 }
 
+// Recency bound for the tool_calls leg below: `input_json LIKE '%nonce%'` is
+// otherwise a full table scan, but the nonce's tool-call record is by
+// definition written at invocation time — always recent. Bounding the scan by
+// the joined message timestamp keeps resolution fast on large indexes. A
+// nonce older than the window resolves to honest null, which only affects
+// stale/replayed nonces, never the live invoking session.
+const INVOCATION_RECENCY_MS = 15 * 60 * 1000;
+
+// Epsilon for genuine concurrent collisions: concurrent same-nonce invocations
+// land within seconds of each other, while sequential nonce reuses (a replayed
+// command line, a reused query-file path) are typically minutes or more apart.
+const INVOCATION_COLLISION_MS = 10_000;
+
+interface InvocationResolveOptions {
+  nowMs?: number;
+  recencyMs?: number;
+  collisionMs?: number;
+}
+
+// Resolve the session that invoked this query via a unique nonce embedded in
+// the CLI's argv (a uuidgen token for --search, the as-typed query file path
+// for --query). Every provider writes the tool-call record before the tool
+// finishes, so once the nonce reaches the index it identifies the invoking
+// session. Both legs are bounded to the last INVOCATION_RECENCY_MS (see
+// above), which keeps weeks-old fixed-path reuse out of the candidate set and
+// makes cross-leg timestamps comparable.
+//
+// The invoking record is always written "now", so matches far apart in time
+// are unrelated history, not ambiguity: each session tracks its newest
+// matching record and the overall newest wins. Two newest records within
+// INVOCATION_COLLISION_MS of each other are a genuine concurrent collision
+// and resolve to null (honest unknown), as does zero matches or an
+// unparseable timestamp. Newest-wins also fixes a false-poisoning case: a
+// session merely QUOTING an obelisk command in message text (not executing
+// it) is older than the real execution and loses naturally. This is a
+// single-shot lookup against one snapshot; freshness retries live in
+// resolveInvokingSessionIdWithWait below.
+export function resolveInvokingSessionId(
+  db: SqliteDb,
+  nonce: string | null | undefined,
+  { nowMs = Date.now(), recencyMs = INVOCATION_RECENCY_MS, collisionMs = INVOCATION_COLLISION_MS }: InvocationResolveOptions = {},
+): string | null {
+  if (!nonce) return null;
+  // The query path is read-only and may face a partially built index (for
+  // example only index_state exists while a writer lease is held). A missing
+  // schema simply means the nonce cannot resolve: honest unknown.
+  const indexedTables = new Set(
+    db.prepare("SELECT name FROM sqlite_master WHERE name IN ('messages_fts', 'messages', 'tool_calls')").all()
+      .map(row => row.name),
+  );
+  const cutoff = new Date(nowMs - recencyMs).toISOString();
+  // session_id → newest matching record timestamp (ISO-8601 text).
+  const newestBySession = new Map<string, string>();
+  const track = (sessionId: unknown, timestamp: unknown): void => {
+    if (typeof sessionId !== 'string' || typeof timestamp !== 'string') return;
+    const prev = newestBySession.get(sessionId);
+    if (prev === undefined || timestamp > prev) newestBySession.set(sessionId, timestamp);
+  };
+  // FTS narrows to candidate messages; exact containment then filters out
+  // tokenizer false positives (hyphenated nonces are split into tokens).
+  const ftsQuery = (nonce.match(/[\p{Letter}\p{Number}]+/gu) || [])
+    .slice(0, 12)
+    .map(token => `"${token}"`)
+    .join(' ');
+  if (ftsQuery && indexedTables.has('messages_fts') && indexedTables.has('messages')) {
+    const rows = db.prepare(`
+      SELECT m.session_id AS session_id, m.text AS text, m.timestamp AS timestamp
+      FROM messages_fts mf JOIN messages m ON m.uuid = mf.uuid
+      WHERE mf.text MATCH ? AND m.timestamp >= ?
+    `).all(ftsQuery, cutoff);
+    for (const row of rows) {
+      if (typeof row.text === 'string' && row.text.includes(nonce)) track(row.session_id, row.timestamp);
+    }
+  }
+  // The obelisk command line lands in tool_calls.input_json for providers that
+  // record tool input separately from message text. The LIKE scan is bounded
+  // to recent rows via the joined message timestamp (ISO-8601 text, so a
+  // lexicographic cutoff is valid). CROSS JOIN forces the planner to drive
+  // from messages (idx_messages_time) and probe tool_calls by message_uuid;
+  // a plain JOIN lets SQLite drive from a 150k-row tool_calls scan instead.
+  if (indexedTables.has('tool_calls') && indexedTables.has('messages')) {
+    const like = `%${nonce.replace(/[\\%_]/g, '\\$&')}%`;
+    const toolRows = db.prepare(`
+      SELECT tc.session_id AS session_id, m.timestamp AS timestamp
+      FROM messages m CROSS JOIN tool_calls tc ON tc.message_uuid = m.uuid
+      WHERE m.timestamp >= ? AND tc.input_json LIKE ? ESCAPE '\\'
+    `).all(cutoff, like);
+    for (const row of toolRows) {
+      track(row.session_id, row.timestamp);
+    }
+  }
+  if (newestBySession.size === 0) return null;
+  const ranked = [...newestBySession.entries()]
+    .map(([sessionId, timestamp]) => ({ sessionId, ms: Date.parse(timestamp) }))
+    .sort((a, b) => b.ms - a.ms);
+  // An unparseable timestamp makes ordering unreliable: lean null.
+  if (ranked.some(r => Number.isNaN(r.ms))) return null;
+  if (ranked.length > 1 && ranked[0].ms - ranked[1].ms <= collisionMs) return null;
+  return ranked[0].sessionId;
+}
+
+// Poll bounds for the nonce freshness fallback. The poll runs only when the
+// incremental recovery build loses the writer lease (writer_busy); the cap
+// gives a concurrent build — the daemon's watcher-driven build is chokidar
+// debounced ~2s plus 0.5s write stability — time to publish the nonce.
+const INVOCATION_POLL_INTERVAL_MS = 300;
+const INVOCATION_POLL_CAP_MS = 4000;
+
+interface InvocationWaitOptions {
+  openRead?: () => SqliteDb;
+  build?: () => unknown;
+  pollIntervalMs?: number;
+  pollCapMs?: number;
+  resolveOpts?: InvocationResolveOptions;
+}
+
+// Block the current thread; the sync searchText path cannot await.
+function sleepSync(ms: number): void {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  } catch {
+    // If synchronous sleeping is unavailable, the deadline below still bounds
+    // the poll loop.
+  }
+}
+
+// Resolve the invoking session, closing the index-freshness gap first: the
+// pre-query refresh skips when a recent build or the app daemon owns writes,
+// so the current invocation's tool-call record may not be indexed yet. On a
+// first miss, run one incremental recovery build that bypasses both the
+// recent-build debounce and — as a narrow carve-out (ADR 0006 amendment) —
+// daemon policy ownership. The carve-out is incremental-only: it runs against
+// an already-initialized index and never performs schema setup, which stays
+// read-only under a fresh daemon heartbeat. The writer lease remains the sole
+// arbitrator: if another writer holds it, the build skips with writer_busy and
+// the poll loop below waits for that writer (the daemon or a concurrent
+// agent's build) to publish the nonce. Still unresolved after the cap is
+// honest null. Queries without a nonce or with an immediate hit pay zero
+// added latency.
+export function resolveInvokingSessionIdWithWait(
+  nonce: string | null | undefined,
+  providerRegistry: ProviderRegistry,
+  {
+    openRead = openReadDb,
+    build = () => buildIndex({ ignoreRecentBuild: true, ignoreDaemonOwnership: true, providerRegistry }),
+    pollIntervalMs = INVOCATION_POLL_INTERVAL_MS,
+    pollCapMs = INVOCATION_POLL_CAP_MS,
+    resolveOpts,
+  }: InvocationWaitOptions = {},
+): string | null {
+  if (!nonce) return null;
+  // Open a fresh read snapshot per attempt: another writer (the daemon or a
+  // concurrent agent's build) may publish a newer index between ticks.
+  const tryResolve = (): string | null => {
+    const db = openRead();
+    try {
+      return resolveInvokingSessionId(db, nonce, resolveOpts);
+    } finally {
+      db.close();
+    }
+  };
+  const schemaReady = (): boolean => {
+    const db = openRead();
+    try {
+      const tablesReady = db.prepare(
+        "SELECT COUNT(*) AS c FROM sqlite_master WHERE name IN ('messages_fts', 'messages', 'tool_calls')",
+      ).get()?.c === 3;
+      if (!tablesReady) return false;
+      // The carve-out build must not perform a schema upgrade: migrating a
+      // legacy schema under a fresh daemon heartbeat remains daemon-owned
+      // (ADR 0006). Unreadable migration state also fails closed.
+      try {
+        return !coreSchemaNeedsMigration(db);
+      } catch {
+        return false;
+      }
+    } finally {
+      db.close();
+    }
+  };
+  const immediate = tryResolve();
+  if (immediate) return immediate;
+  if (schemaReady()) {
+    reportIncompleteInventory(build());
+    const afterBuild = tryResolve();
+    if (afterBuild) return afterBuild;
+  }
+  const deadline = Date.now() + pollCapMs;
+  while (Date.now() < deadline) {
+    sleepSync(pollIntervalMs);
+    const hit = tryResolve();
+    if (hit) return hit;
+  }
+  return null;
+}
+
 // FTS search over indexed message text. Refreshes the index, then queries.
-export function searchText(text: string, opts?: Record<string, unknown>): unknown {
+export function searchText(text: string, opts?: Record<string, unknown>, invocation?: InvocationOptions): unknown {
   const providerRegistry = refreshQueryIndex();
+  const invokingSessionId = resolveInvokingSessionIdWithWait(invocation?.invocationNonce, providerRegistry);
+  // Query against a freshly opened snapshot so results reflect the latest
+  // published index.
   const db = openReadDb();
   try {
     try {
-      return createQueryApi(db, { providerRegistry }).search(text, opts);
+      return createQueryApi(db, { providerRegistry, invokingSessionId }).search(text, opts);
     } catch (error) {
       return rethrowUnlessSchemaBlocked(error);
     }
@@ -99,12 +304,13 @@ export function searchText(text: string, opts?: Record<string, unknown>): unknow
 }
 
 // Execute a read-only CodeAct query script and resolve its returned value.
-export async function executeQuery(scriptContent: string): Promise<unknown> {
+export async function executeQuery(scriptContent: string, invocation?: InvocationOptions): Promise<unknown> {
   const providerRegistry = refreshQueryIndex();
+  const invokingSessionId = resolveInvokingSessionIdWithWait(invocation?.invocationNonce, providerRegistry);
   const db = openReadDb();
   try {
     try {
-      return await runInSandbox(createQueryApi(db, { providerRegistry }), scriptContent);
+      return await runInSandbox(createQueryApi(db, { providerRegistry, invokingSessionId }), scriptContent);
     } catch (error) {
       return rethrowUnlessSchemaBlocked(error);
     }

--- a/packages/core/src/indexer.ts
+++ b/packages/core/src/indexer.ts
@@ -30,10 +30,21 @@ interface SkippedFile {
 interface BuildCheckOptions {
   now?: number;
   ignoreRecentBuild?: boolean;
+  ignoreDaemonOwnership?: boolean;
 }
 
 interface BuildIndexOptions {
   force?: boolean;
+  // Bypass the recent-build debounce without selecting the force full-republish
+  // path: the build stays incremental. Used by the invocation-nonce freshness
+  // recovery, which needs the just-written transcript indexed cheaply.
+  ignoreRecentBuild?: boolean;
+  // Bypass the daemon-ownership policy check (fresh __app_heartbeat__). Narrow
+  // carve-out for the invocation-nonce freshness build: the writer lease
+  // remains the sole write arbitrator, and the build stays incremental so
+  // daemon and CLI cursors in index_state stay consistent. force does NOT
+  // imply this; the carve-out is always explicit (ADR 0006 amendment).
+  ignoreDaemonOwnership?: boolean;
   providerRegistry?: ProviderRegistry;
 }
 
@@ -61,10 +72,12 @@ function refreshSessionProjectPaths(db: NodeSqliteDb): void {
 const BUILD_DEBOUNCE_MS = 30000;
 const APP_HEARTBEAT_FRESH_MS = 60000;
 
-function shouldSkipBuild(db: NodeSqliteDb, { now = Date.now(), ignoreRecentBuild = false }: BuildCheckOptions = {}) {
-  const appHeartbeat = db.prepare("SELECT mtime FROM index_state WHERE jsonl_path='__app_heartbeat__'").get();
-  if (appHeartbeat && now - appHeartbeat.mtime < APP_HEARTBEAT_FRESH_MS) {
-    return { skip: true, reason: 'daemon_active' };
+function shouldSkipBuild(db: NodeSqliteDb, { now = Date.now(), ignoreRecentBuild = false, ignoreDaemonOwnership = false }: BuildCheckOptions = {}) {
+  if (!ignoreDaemonOwnership) {
+    const appHeartbeat = db.prepare("SELECT mtime FROM index_state WHERE jsonl_path='__app_heartbeat__'").get();
+    if (appHeartbeat && now - appHeartbeat.mtime < APP_HEARTBEAT_FRESH_MS) {
+      return { skip: true, reason: 'daemon_active' };
+    }
   }
   if (!ignoreRecentBuild) {
     const last = db.prepare("SELECT mtime FROM index_state WHERE jsonl_path='__last_build__'").get();
@@ -80,11 +93,11 @@ function isMissingIndexStateTable(error: unknown): boolean {
   return /no such table:\s*(?:main\.)?index_state\b/i.test(message);
 }
 
-function inspectBuildOwnership({ force = false }: { force?: boolean } = {}) {
+function inspectBuildOwnership({ force = false, ignoreRecentBuild = false, ignoreDaemonOwnership = false }: { force?: boolean; ignoreRecentBuild?: boolean; ignoreDaemonOwnership?: boolean } = {}) {
   if (!existsSync(DB_PATH)) return { skip: false };
   const db = openReadDb();
   try {
-    const ownership = shouldSkipBuild(db, { ignoreRecentBuild: force });
+    const ownership = shouldSkipBuild(db, { ignoreRecentBuild: force || ignoreRecentBuild, ignoreDaemonOwnership });
     if (!ownership.skip || ownership.reason === 'daemon_active') return ownership;
     return coreSchemaNeedsMigration(db) ? { skip: false } : ownership;
   } catch (error) {
@@ -135,8 +148,8 @@ function ensureReadableSchema(): { ready: boolean; reason?: string } {
   }
 }
 
-function buildIndex({ force = false, providerRegistry }: BuildIndexOptions = {}) {
-  const ownership = inspectBuildOwnership({ force });
+function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwnership = false, providerRegistry }: BuildIndexOptions = {}) {
+  const ownership = inspectBuildOwnership({ force, ignoreRecentBuild, ignoreDaemonOwnership });
   if (ownership.skip) return ownership;
   const lease = acquireWriterLease({
     lockPath: writerLockPathFor(DB_PATH),
@@ -145,7 +158,7 @@ function buildIndex({ force = false, providerRegistry }: BuildIndexOptions = {})
   if (!lease) return { skip: true, reason: 'writer_busy' };
   try {
     // Ownership may change between the first read and lease acquisition.
-    const ownershipAfterLease = inspectBuildOwnership({ force });
+    const ownershipAfterLease = inspectBuildOwnership({ force, ignoreRecentBuild, ignoreDaemonOwnership });
     if (ownershipAfterLease.skip) return ownershipAfterLease;
     let registry = providerRegistry;
     if (registry === undefined) {

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -138,7 +138,10 @@ function buildSafeFtsQuery(text: unknown): string {
 
 function createQueryApi(
   db: SqliteDb,
-  { providerRegistry = createBuiltinProviderRegistry() }: { providerRegistry?: ProviderRegistry } = {},
+  {
+    providerRegistry = createBuiltinProviderRegistry(),
+    invokingSessionId = null,
+  }: { providerRegistry?: ProviderRegistry; invokingSessionId?: string | null } = {},
 ) {
   const q = (sql: string, ...p: any[]) => {
     assertReadOnlySql(sql);
@@ -208,6 +211,10 @@ function createQueryApi(
         .map(withVisibility)
         .sort((a: DbRow, b: DbRow) => a.timestamp < b.timestamp ? -1 : 1);
       const sourceValue = r.m_source || r.s_source || 'claude';
+      const session: DbRow = { id: r.s_id, title: r.s_title, project: r.s_project, started_at: r.s_started, source: r.s_source || sourceValue };
+      // is_invoking marks the session that ran this query; it is the agent's
+      // own live context, not independent historical evidence.
+      if (invokingSessionId && r.s_id === invokingSessionId) session.is_invoking = true;
       return {
         message: {
           uuid: r.uuid,
@@ -221,7 +228,7 @@ function createQueryApi(
           visibility: normalizedVisibility(r.visibility),
           source: sourceValue,
         },
-        session: { id: r.s_id, title: r.s_title, project: r.s_project, started_at: r.s_started, source: r.s_source || sourceValue },
+        session,
         rank: r.rank,
         context: ctx,
       };
@@ -397,7 +404,8 @@ function createQueryApi(
     const { limit = 50 } = opts;
     const { where, params } = buildWhere(opts, { sessionId: 's.id', project: 's.project', timestamp: 's.started_at', branch: 's.git_branch', source: 's.source' });
     params.push(limit);
-    return db.prepare(`SELECT * FROM sessions s WHERE ${where} ORDER BY ended_at DESC LIMIT ?`).all(...params);
+    return db.prepare(`SELECT * FROM sessions s WHERE ${where} ORDER BY ended_at DESC LIMIT ?`).all(...params)
+      .map((row: DbRow) => invokingSessionId && row.id === invokingSessionId ? { ...row, is_invoking: true } : row);
   };
 
   const recent = (n = 10) => sessions({ limit: n });
@@ -582,6 +590,9 @@ function createQueryApi(
       current: {
         cwd,
         project: currentProject,
+        // The session that invoked this query, when the invocation nonce
+        // resolved to exactly one indexed session; null when unknown.
+        session_id: invokingSessionId || null,
       },
       current_project,
       projects,

--- a/packages/core/src/schema.sql
+++ b/packages/core/src/schema.sql
@@ -54,6 +54,7 @@ END;
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);
 CREATE INDEX IF NOT EXISTS idx_messages_agent ON messages(agent_id);
 CREATE INDEX IF NOT EXISTS idx_messages_ts ON messages(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_messages_time ON messages(timestamp);
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_messages_source ON messages(source);
 CREATE INDEX IF NOT EXISTS idx_tc_session_name ON tool_calls(session_id, name);

--- a/skill-doc/SKILL.md
+++ b/skill-doc/SKILL.md
@@ -31,19 +31,26 @@ sessions by default.
 
 ## Quick Start
 
-Fast keyword search:
+Fast keyword search (pass a unique nonce so Obelisk can recognize your own
+session in results):
 
 ```bash
-obelisk --search "keyword"
+obelisk --search "keyword" --nonce "$(uuidgen 2>/dev/null || echo "$$.$RANDOM.$RANDOM")"
 ```
 
 Custom query:
 
-1. Write a bounded JS query to a temp file, for example `/tmp/q.mjs`.
+1. Write a bounded JS query to a unique temp file — the as-typed file path is
+   your invocation nonce:
+
+   ```bash
+   qfile=$(mktemp /tmp/obq.XXXXXX 2>/dev/null || echo "/tmp/obq.$$.$RANDOM.mjs")
+   ```
+
 2. Run:
 
    ```bash
-   obelisk --query /tmp/q.mjs
+   obelisk --query "$qfile"
    ```
 
 3. Parse JSON stdout and answer with concise evidence.
@@ -51,6 +58,18 @@ Custom query:
 The query file runs inside `(async () => { ... })()`. Use `return` to emit JSON.
 Query scripts are read-only: `remember()` and `forget()` are not available, and
 `sql()` only accepts read-only SELECT/WITH queries.
+
+## Your Own Session In Results
+
+Obelisk refreshes the index before each query, so your own live session shows
+up in results. The invocation nonce (`--search --nonce`, or the unique
+`--query` file path) lets Obelisk mark it: session projections in `search()`
+hits and `sessions()` rows carry `is_invoking: true`, and
+`overview().current.session_id` holds the invoking session id when known. Treat
+a session flagged `is_invoking` as your own current context, NOT as independent
+historical evidence. Resolution is newest-wins over recent matches; only a
+near-simultaneous same-nonce collision (or no match at all) leaves nothing
+marked and `current.session_id` null — identity is honestly unknown.
 
 ## Default First Pass
 
@@ -148,10 +167,13 @@ Returns:
 
 ```js
 [{ message: { uuid, text, content_type, is_meta, role, timestamp, model, cwd, visibility, source },
-   session: { id, title, project, started_at, source },
+   session: { id, title, project, started_at, source, is_invoking? },
    rank,
    context }]
 ```
+
+`session.is_invoking` is `true` only when the hit belongs to the session that
+ran this query (see "Your Own Session In Results"); it is omitted otherwise.
 
 `context` here means temporal neighbors: nearby messages in the same session by
 timestamp. It is not the parent chain. Use `context(uuid)` or `trace(uuid)` for
@@ -238,8 +260,8 @@ All list helpers accept a bounded `limit`. Many also accept:
 `references/api-reference.md` or a tiny sample before relying on less common
 filters or return fields.
 
-- `overview(opts?)` -- compact orientation map. Returns current cwd/project if knowable, global project/source counts, and current-project recent sessions plus memory records. It is a map, not evidence.
-- `sessions(opts?)` -- session rows, newest first. `project` is a SQL `LIKE` pattern. `message_count` counts the visible canonical transcript; inactive and hidden records are excluded.
+- `overview(opts?)` -- compact orientation map. Returns current cwd/project if knowable, the invoking session id (`current.session_id`) when the invocation nonce resolved, global project/source counts, and current-project recent sessions plus memory records. It is a map, not evidence.
+- `sessions(opts?)` -- session rows, newest first. `project` is a SQL `LIKE` pattern. `message_count` counts the visible canonical transcript; inactive and hidden records are excluded. The invoking session row carries `is_invoking: true`.
 - `recent(n?)` -- shorthand for recent sessions.
 - `summaries(opts?)` -- summary rows, newest first: `{ id, session_id, timestamp, source, content, visibility, session_title, project }`; inactive rows require `includeInactive: true`, hidden rows are never returned, and `source` is the summary kind rather than the transcript provider.
 - `subagents(opts?)` -- subagent metadata plus `messageCount`.

--- a/skill-doc/references/api-reference.md
+++ b/skill-doc/references/api-reference.md
@@ -12,6 +12,45 @@ Query scripts run inside an async IIFE with a 30-second timeout. Use `return` to
 emit JSON. `--query` scripts are read-only. `--attune` scripts expose only
 memory mutation helpers.
 
+## Invocation Identity
+
+Obelisk refreshes the index before each query, so the invoking agent's own live
+session appears in results. The CLI carries an invocation nonce to identify it:
+
+- `obelisk --search "text" --nonce <token>` — pass a unique token, for example
+  `--nonce "$(uuidgen 2>/dev/null || echo "$$.$RANDOM.$RANDOM")"` (prefers
+  `uuidgen`, falls back to shell builtins). The nonce is never part of the FTS
+  search text.
+- `obelisk --query <file>` — the nonce is the query file path as typed, so use
+  unique temp names such as
+  `$(mktemp /tmp/obq.XXXXXX 2>/dev/null || echo "/tmp/obq.$$.$RANDOM.mjs")`
+  (note: `mktemp` templates must end in the `X` run, so no `.mjs` suffix).
+
+Resolution is newest-wins within a ~15-minute recency window (both the
+message-text and tool-call legs are bounded to it, which keeps weeks-old
+fixed-path reuse such as `/tmp/q.mjs` out of the candidate set). The session
+whose newest matching record is the overall newest is the invoking session:
+`search()` hit sessions and `sessions()` rows for it carry
+`is_invoking: true`, and `overview().current.session_id` holds its id. Treat
+an `is_invoking` session as your own current context, not independent
+historical evidence. Matches far apart in time are unrelated history (an old
+session quoting the same command line loses naturally); only two newest
+records within ~10 seconds of each other count as a genuine concurrent
+collision.
+
+A nonce-carrying query may take a moment to resolve: if the nonce is not yet
+indexed, the runtime runs one incremental recovery build (bypassing the
+recent-build debounce and, as a narrow carve-out, daemon ownership — the writer
+lease stays the sole write arbitrator), then re-checks. Typical recovery is a
+fast incremental build, whether or not the app daemon owns the index. Only when
+the recovery build loses the lease to a concurrent writer does the runtime fall
+back to polling freshly published snapshots, about every 300ms up to a ~4s cap.
+This latency applies only to nonce-carrying queries whose first lookup misses;
+other queries are unaffected. When nothing matches after the cap — or the
+newest records collide within the ~10s epsilon — nothing is marked and
+`current.session_id` is null: invocation identity is honestly unknown, with no
+further fallback.
+
 ## Query API Reference
 
 ### Read Helpers
@@ -66,11 +105,14 @@ Returns:
 ```js
 Array<{
   message: { uuid, text, content_type, is_meta, role, timestamp, model, cwd, visibility, source },
-  session: { id, title, project, started_at, source },
+  session: { id, title, project, started_at, source, is_invoking? },
   rank,
   context
 }>
 ```
+
+`session.is_invoking` is `true` when the hit belongs to the invoking session
+(see Invocation Identity) and omitted otherwise.
 
 `context` is temporal neighbor context in the same session, not a parent chain.
 Hits and neighbors carry `visibility`.
@@ -139,7 +181,8 @@ Passing a string is treated as `project`. Passing a number is treated as
 
 If `opts.project` is absent, `overview()` tries to identify the current project
 from `process.cwd()` against `sessions.project_path`, then from exact
-`messages.cwd` matches. It does not guess the current session.
+`messages.cwd` matches. The current session is identified only through the
+invocation nonce (see Invocation Identity), never guessed from recency.
 
 Returns:
 
@@ -152,7 +195,8 @@ Returns:
       project_path,
       source: 'opts' | 'cwd_project_path' | 'cwd_messages',
       confidence: 'exact' | 'inferred' | 'unknown'
-    } | null
+    } | null,
+    session_id: string | null
   },
   current_project: {
     project,
@@ -206,7 +250,8 @@ Session rows ordered by `ended_at` descending. Passing a number is treated as
 
 Returns `Array<session_row>`.
 `message_count` describes the visible canonical transcript; inactive and hidden
-records do not increase it.
+records do not increase it. The invoking session row carries
+`is_invoking: true` (see Invocation Identity); other rows omit the field.
 
 #### `recent(n?)`
 

--- a/tests/contract-helper-shapes.test.mjs
+++ b/tests/contract-helper-shapes.test.mjs
@@ -168,7 +168,8 @@ test('overview() shape matches api-reference.md', () => {
   const view = createQueryApi(db).overview({ limit: 5 });
 
   exactKeys(view, ['current', 'current_project', 'projects', 'totals'], 'overview()');
-  exactKeys(view.current, ['cwd', 'project'], 'overview() current');
+  exactKeys(view.current, ['cwd', 'project', 'session_id'], 'overview() current');
+  assert.equal(view.current.session_id, null, 'no invocation nonce: session_id is null');
   exactKeys(view.totals, ['projects', 'sessions', 'memories', 'sources'], 'overview() totals');
   db.close();
 });

--- a/tests/invoking-session.test.mjs
+++ b/tests/invoking-session.test.mjs
@@ -89,6 +89,18 @@ test('resolver finds the invoking session via the tool-call command line', () =>
   db.close();
 });
 
+test('resolver matches a JSON-escaped nonce in tool_calls input_json', () => {
+  // Windows-style nonces contain backslashes, which JSON encoding doubles in
+  // stored input_json; the raw LIKE pattern alone would miss the record.
+  const db = invokingDb();
+  const winNonce = 'C:\\tmp\\obq.win789.mjs';
+  db.prepare('INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json) VALUES (?,?,?,?,?)')
+    .run('call-win', 'msg-self-call', 'sid-self', 'Bash', JSON.stringify({ command: `obelisk --query ${winNonce}` }));
+
+  assert.equal(resolveInvokingSessionId(db, winNonce, { nowMs: FIXTURE_NOW_MS }), 'sid-self');
+  db.close();
+});
+
 test('resolver finds the invoking session via message text', () => {
   const db = invokingDb();
   db.prepare('INSERT INTO messages (uuid, session_id, type, role, text, timestamp) VALUES (?,?,?,?,?,?)')

--- a/tests/invoking-session.test.mjs
+++ b/tests/invoking-session.test.mjs
@@ -1,0 +1,548 @@
+// Nonce self-search: the CLI embeds a unique invocation nonce in its argv
+// (--search --nonce <token>, or the as-typed --query file path). Providers
+// write the tool-call record before the tool finishes, so after the pre-query
+// index refresh the nonce is in the fresh index. The session with the newest
+// matching record is the invoking session; matches far apart in time are
+// unrelated history (newest wins), while a near-simultaneous collision or no
+// match at all resolves to null.
+// When the first lookup misses, one incremental recovery build plus a bounded
+// poll close the index-freshness gap before falling back to honest null.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { createQueryApi } from '../packages/core/src/query.ts';
+import { resolveInvokingSessionId, resolveInvokingSessionIdWithWait } from '../packages/core/src/core.ts';
+import { acquireWriterLease, writerLockPathFor } from '../packages/core/src/writer-lease.ts';
+import { cliEntry, repoRoot, runCli } from './cli-test-helpers.mjs';
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require('node:sqlite');
+const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+
+const NONCE = 'obq-7f3c9a2e-4b1d-8e5f-unique';
+// The unit fixtures below use fixed timestamps in this era; pin nowMs to it so
+// the resolver's recency window (default 15min) keeps them in scope.
+const FIXTURE_NOW_MS = Date.parse('2026-08-11T10:00:10Z');
+
+function tempHome(prefix) {
+  const home = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(home, '.claude'), { recursive: true });
+  return home;
+}
+
+function runCliAsync(args, { home }) {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(process.execPath, [
+      '--disable-warning=ExperimentalWarning',
+      cliEntry,
+      ...args,
+    ], {
+      cwd: repoRoot,
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+      encoding: 'utf8',
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', chunk => { stdout += chunk; });
+    child.stderr.on('data', chunk => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', status => resolveRun({ status, stdout, stderr }));
+  });
+}
+
+function invokingDb() {
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  const insertSession = db.prepare(`
+    INSERT INTO sessions (id, title, project, started_at, ended_at)
+    VALUES (?, ?, ?, ?, ?)
+  `);
+  insertSession.run('sid-self', 'Invoking session', 'quiet-zero', '2026-08-11T10:00:00Z', null);
+  insertSession.run('sid-history', 'Historical session', 'quiet-zero', '2026-08-01T10:00:00Z', '2026-08-01T11:00:00Z');
+  const insertMessage = db.prepare(`
+    INSERT INTO messages (uuid, session_id, type, role, text, timestamp, visibility, source)
+    VALUES (?,?,?,?,?,?,?,?)
+  `);
+  // The invoking session holds the obelisk tool call whose command line
+  // contains the nonce, plus ordinary needle evidence in both sessions.
+  insertMessage.run('msg-self-call', 'sid-self', 'assistant', 'assistant', null, '2026-08-11T10:00:01Z', 'visible', 'claude');
+  insertMessage.run('msg-self', 'sid-self', 'assistant', 'assistant', 'self needle reply', '2026-08-11T10:00:02Z', 'visible', 'claude');
+  insertMessage.run('msg-history', 'sid-history', 'assistant', 'assistant', 'historical needle reply', '2026-08-01T10:00:01Z', 'visible', 'claude');
+  db.prepare(`
+    INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json)
+    VALUES (?,?,?,?,?)
+  `).run('call-self', 'msg-self-call', 'sid-self', 'Bash', JSON.stringify({ command: `obelisk --search "needle" --nonce ${NONCE}` }));
+  return db;
+}
+
+test('resolver finds the invoking session via the tool-call command line', () => {
+  const db = invokingDb();
+
+  assert.equal(resolveInvokingSessionId(db, NONCE, { nowMs: FIXTURE_NOW_MS }), 'sid-self');
+  db.close();
+});
+
+test('resolver finds the invoking session via message text', () => {
+  const db = invokingDb();
+  db.prepare('INSERT INTO messages (uuid, session_id, type, role, text, timestamp) VALUES (?,?,?,?,?,?)')
+    .run('msg-self-nonce', 'sid-self', 'user', 'user', `ran obelisk --query /tmp/obq.${NONCE}.mjs`, '2026-08-11T10:00:03Z');
+
+  assert.equal(resolveInvokingSessionId(db, `/tmp/obq.${NONCE}.mjs`, { nowMs: FIXTURE_NOW_MS }), 'sid-self');
+  db.close();
+});
+
+test('resolver returns null for missing or unknown nonces', () => {
+  const db = invokingDb();
+
+  assert.equal(resolveInvokingSessionId(db, undefined), null);
+  assert.equal(resolveInvokingSessionId(db, null), null);
+  assert.equal(resolveInvokingSessionId(db, ''), null);
+  assert.equal(resolveInvokingSessionId(db, 'obq-never-appears-anywhere'), null);
+  db.close();
+});
+
+test('same nonce far apart in time resolves to the newest session', () => {
+  // Matches far apart are unrelated history (a replayed command line), not
+  // ambiguity: the invoking record is always written "now", so newest wins.
+  const db = invokingDb();
+  db.prepare('INSERT INTO messages (uuid, session_id, type, role, text, timestamp) VALUES (?,?,?,?,?,?)')
+    .run('msg-history-call', 'sid-history', 'assistant', 'assistant', null, '2026-08-11T09:50:05Z');
+  db.prepare('INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json) VALUES (?,?,?,?,?)')
+    .run('call-history', 'msg-history-call', 'sid-history', 'Bash', JSON.stringify({ command: `obelisk --search "needle" --nonce ${NONCE}` }));
+
+  assert.equal(resolveInvokingSessionId(db, NONCE, { nowMs: FIXTURE_NOW_MS }), 'sid-self');
+  db.close();
+});
+
+test('same nonce within the collision epsilon resolves to null', () => {
+  // Two sessions whose newest matching records land seconds apart are a
+  // genuine concurrent collision: honest unknown.
+  const db = invokingDb();
+  db.prepare('INSERT INTO messages (uuid, session_id, type, role, text, timestamp) VALUES (?,?,?,?,?,?)')
+    .run('msg-history-call', 'sid-history', 'assistant', 'assistant', null, '2026-08-11T10:00:06Z');
+  db.prepare('INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json) VALUES (?,?,?,?,?)')
+    .run('call-history', 'msg-history-call', 'sid-history', 'Bash', JSON.stringify({ command: `obelisk --search "needle" --nonce ${NONCE}` }));
+
+  // sid-self at 10:00:01 vs sid-history at 10:00:06: 5s apart, within 10s.
+  assert.equal(resolveInvokingSessionId(db, NONCE, { nowMs: FIXTURE_NOW_MS }), null);
+  db.close();
+});
+
+test('a session merely quoting the command loses to the real execution', () => {
+  // sid-history mentions the nonce in message text two minutes BEFORE sid-self
+  // executed it: the quote is older than the real execution, so newest-wins
+  // resolves to the executing session instead of poisoning to null.
+  const db = invokingDb();
+  db.prepare('INSERT INTO messages (uuid, session_id, type, role, text, timestamp) VALUES (?,?,?,?,?,?)')
+    .run('msg-history-quote', 'sid-history', 'user', 'user', `what does obelisk --search "needle" --nonce ${NONCE} do?`, '2026-08-11T09:58:01Z');
+
+  assert.equal(resolveInvokingSessionId(db, NONCE, { nowMs: FIXTURE_NOW_MS }), 'sid-self');
+  db.close();
+});
+
+test('resolver bounds the tool_calls scan to the recency window', () => {
+  const db = invokingDb();
+
+  // In window (9s after the tool call): resolves.
+  assert.equal(resolveInvokingSessionId(db, NONCE, { nowMs: FIXTURE_NOW_MS }), 'sid-self');
+  // Older than the 15-minute window: honest null — only stale/replayed nonces.
+  assert.equal(resolveInvokingSessionId(db, NONCE, { nowMs: FIXTURE_NOW_MS + 20 * 60 * 1000 }), null);
+  // An explicit wider window still reaches the older record.
+  assert.equal(
+    resolveInvokingSessionId(db, NONCE, { nowMs: FIXTURE_NOW_MS + 20 * 60 * 1000, recencyMs: 30 * 60 * 1000 }),
+    'sid-self',
+  );
+  db.close();
+});
+
+test('resolver tolerates a partially built index', () => {
+  // A read-only query can face a DB with only index_state (writer lease held,
+  // schema never published). The nonce cannot resolve: honest null, no throw.
+  const db = new DatabaseSync(':memory:');
+  db.exec('CREATE TABLE index_state (jsonl_path TEXT PRIMARY KEY, mtime REAL, lines_processed INTEGER)');
+
+  assert.equal(resolveInvokingSessionId(db, NONCE), null);
+  db.close();
+});
+
+test('search hits and sessions rows mark only the invoking session', () => {
+  const db = invokingDb();
+  const api = createQueryApi(db, { invokingSessionId: 'sid-self' });
+
+  const hits = api.search('needle', { limit: 10 });
+  const byId = Object.fromEntries(hits.map(h => [h.session.id, h.session]));
+  assert.equal(byId['sid-self'].is_invoking, true);
+  assert.equal(byId['sid-history'].is_invoking, undefined);
+
+  const rows = api.sessions({ limit: 10 });
+  const rowById = Object.fromEntries(rows.map(r => [r.id, r]));
+  assert.equal(rowById['sid-self'].is_invoking, true);
+  assert.equal(rowById['sid-history'].is_invoking, undefined);
+  db.close();
+});
+
+test('overview exposes the invoking session in the current section', () => {
+  const db = invokingDb();
+
+  assert.equal(createQueryApi(db, { invokingSessionId: 'sid-self' }).overview().current.session_id, 'sid-self');
+  db.close();
+});
+
+test('unknown invocation marks nothing and leaves results unchanged', () => {
+  for (const opts of [{}, { invokingSessionId: null }]) {
+    const db = invokingDb();
+    const api = createQueryApi(db, opts);
+
+    const hits = api.search('needle', { limit: 10 });
+    assert.equal(hits.length, 2);
+    assert.ok(hits.every(h => h.session.is_invoking === undefined));
+    assert.ok(api.sessions({ limit: 10 }).every(r => r.is_invoking === undefined));
+    assert.equal(api.overview().current.session_id, null);
+    db.close();
+  }
+});
+
+test('cli --search --nonce marks the invoking session end to end', () => {
+  const home = mkdtempSync(join(tmpdir(), 'obelisk-invoking-home-'));
+  const projectDir = join(home, '.claude', 'projects', '-tmp-invoking');
+  mkdirSync(projectDir, { recursive: true });
+  const nonce = 'obq-e2e-91c2-live-invocation';
+  // Fresh timestamps: the CLI process resolves in real time, and the
+  // resolver's recency window only reaches recent tool-call records.
+  const now = new Date().toISOString();
+  const lines = [
+    {
+      uuid: 'e2e-user', type: 'user', timestamp: now, cwd: '/tmp/invoking',
+      message: { role: 'user', content: 'find the e2e needle evidence' },
+    },
+    {
+      uuid: 'e2e-call', type: 'assistant', timestamp: now, cwd: '/tmp/invoking',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_e2e', name: 'Bash', input: { command: `obelisk --search "e2e needle" --nonce ${nonce}` } }] },
+    },
+  ];
+  writeFileSync(join(projectDir, 'e2e-invoking-session.jsonl'), lines.map(l => JSON.stringify(l)).join('\n') + '\n');
+
+  const withNonce = runCli(['--search', 'e2e needle', '--nonce', nonce], { home });
+  assert.equal(withNonce.status, 0, withNonce.stderr || withNonce.stdout);
+  const hits = JSON.parse(withNonce.stdout);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].session.id, 'e2e-invoking-session');
+  assert.equal(hits[0].session.is_invoking, true);
+
+  // Without the nonce the same hit is ordinary historical evidence.
+  const withoutNonce = runCli(['--search', 'e2e needle'], { home });
+  assert.equal(withoutNonce.status, 0, withoutNonce.stderr || withoutNonce.stdout);
+  const plainHits = JSON.parse(withoutNonce.stdout);
+  assert.equal(plainHits.length, 1);
+  assert.equal(plainHits[0].session.is_invoking, undefined);
+});
+
+test('wait helper skips the recovery build and poll on an immediate hit', () => {
+  const result = resolveInvokingSessionIdWithWait(NONCE, null, {
+    openRead: () => invokingDb(),
+    build: () => { throw new Error('build must not run on an immediate hit'); },
+    pollIntervalMs: 5,
+    pollCapMs: 20,
+    resolveOpts: { nowMs: FIXTURE_NOW_MS },
+  });
+
+  assert.equal(result, 'sid-self');
+});
+
+test('wait helper re-resolves after the recovery build publishes the nonce', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'obelisk-invoking-build-'));
+  const dbPath = join(dir, 'obelisk.sqlite');
+  const seed = new DatabaseSync(dbPath);
+  seed.exec(SCHEMA);
+  seed.close();
+
+  const result = resolveInvokingSessionIdWithWait(NONCE, null, {
+    openRead: () => new DatabaseSync(dbPath, { readOnly: true }),
+    build: () => {
+      // The recovery build indexes the transcript that carries the nonce. The
+      // tool-call join needs a message row with a fresh (real-time) timestamp.
+      const db = new DatabaseSync(dbPath);
+      db.prepare('INSERT INTO messages (uuid, session_id, type, role, text, timestamp) VALUES (?,?,?,?,?,?)')
+        .run('msg-built', 'sid-self', 'assistant', 'assistant', null, new Date().toISOString());
+      db.prepare('INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json) VALUES (?,?,?,?,?)')
+        .run('call-built', 'msg-built', 'sid-self', 'Bash', JSON.stringify({ command: `obelisk --search "needle" --nonce ${NONCE}` }));
+      db.close();
+      return {};
+    },
+    pollIntervalMs: 5,
+    pollCapMs: 20,
+  });
+
+  assert.equal(result, 'sid-self');
+});
+
+test('wait helper never runs the recovery build on an uninitialized index', () => {
+  // Schema setup under a fresh daemon heartbeat stays read-only (ADR 0006):
+  // with only index_state present, the carve-out build must not run; the poll
+  // fallback resolves honest null.
+  const dir = mkdtempSync(join(tmpdir(), 'obelisk-invoking-noschema-'));
+  const dbPath = join(dir, 'obelisk.sqlite');
+  const seed = new DatabaseSync(dbPath);
+  seed.exec('CREATE TABLE index_state (jsonl_path TEXT PRIMARY KEY, mtime REAL, lines_processed INTEGER)');
+  seed.close();
+
+  const result = resolveInvokingSessionIdWithWait(NONCE, null, {
+    openRead: () => new DatabaseSync(dbPath, { readOnly: true }),
+    build: () => { throw new Error('recovery build must not run schema setup'); },
+    pollIntervalMs: 10,
+    pollCapMs: 25,
+  });
+
+  assert.equal(result, null);
+  const check = new DatabaseSync(dbPath, { readOnly: true });
+  const tables = check.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all().map(row => row.name);
+  check.close();
+  assert.deepEqual(tables, ['index_state'], 'the index was not mutated');
+});
+
+test('wait helper returns null within the cap when the nonce never appears', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'obelisk-invoking-timeout-'));
+  const dbPath = join(dir, 'obelisk.sqlite');
+  const seed = new DatabaseSync(dbPath);
+  seed.exec(SCHEMA);
+  seed.close();
+
+  const startedAt = Date.now();
+  const result = resolveInvokingSessionIdWithWait('obq-never-indexed', null, {
+    openRead: () => new DatabaseSync(dbPath, { readOnly: true }),
+    build: () => ({ skip: true, reason: 'daemon_active' }),
+    pollIntervalMs: 15,
+    pollCapMs: 40,
+  });
+
+  assert.equal(result, null);
+  assert.ok(Date.now() - startedAt < 2000, 'shrunk poll timings keep the test fast');
+});
+
+test('cli runs one incremental recovery build when the recent-build debounce skips the refresh', () => {
+  const home = tempHome('obelisk-invoking-fresh-');
+  const projectDir = join(home, '.claude', 'projects', '-tmp-fresh');
+  mkdirSync(projectDir, { recursive: true });
+  // Warm the index so __last_build__ is fresh and the normal pre-query refresh
+  // skips via the 30s recent-build debounce.
+  const warm = runCli(['--search', 'warmup'], { home });
+  assert.equal(warm.status, 0, warm.stderr || warm.stdout);
+
+  // The transcript appears only after the warm build, so just the recovery
+  // build can index the nonce.
+  const nonce = 'obq-fresh-after-debounce';
+  const now = new Date().toISOString();
+  const lines = [
+    {
+      uuid: 'fresh-user', type: 'user', timestamp: now, cwd: '/tmp/fresh',
+      message: { role: 'user', content: 'find the fresh needle evidence' },
+    },
+    {
+      uuid: 'fresh-call', type: 'assistant', timestamp: now, cwd: '/tmp/fresh',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_fresh', name: 'Bash', input: { command: `obelisk --search "fresh needle" --nonce ${nonce}` } }] },
+    },
+  ];
+  writeFileSync(join(projectDir, 'fresh-invoking-session.jsonl'), lines.map(l => JSON.stringify(l)).join('\n') + '\n');
+
+  const result = runCli(['--search', 'fresh needle', '--nonce', nonce], { home });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const hits = JSON.parse(result.stdout);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].session.id, 'fresh-invoking-session');
+  assert.equal(hits[0].session.is_invoking, true);
+});
+
+test('cli polls fresh snapshots until a concurrent writer indexes the nonce', async () => {
+  const home = tempHome('obelisk-invoking-poll-');
+  const warm = runCli(['--search', 'warmup'], { home });
+  assert.equal(warm.status, 0, warm.stderr || warm.stdout);
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+
+  // Hold the writer lease so the CLI's recovery build skips with writer_busy.
+  // The nonce enters the index only through the delayed insert below, so a
+  // resolved mark can only come from the bounded poll.
+  const lease = acquireWriterLease({
+    lockPath: writerLockPathFor(dbPath),
+    openDb: path => new DatabaseSync(path),
+  });
+  assert.ok(lease);
+  const nonce = 'obq-polled-by-concurrent-writer';
+  try {
+    const pending = runCliAsync(['--search', 'polled needle', '--nonce', nonce], { home });
+    await new Promise(resolveWait => setTimeout(resolveWait, 800));
+    const now = new Date().toISOString();
+    const db = new DatabaseSync(dbPath);
+    db.exec('PRAGMA busy_timeout=2000');
+    db.prepare('INSERT INTO sessions (id, title, project, started_at) VALUES (?,?,?,?)')
+      .run('sid-polled', 'Polled session', 'quiet-zero', now);
+    db.prepare(`
+      INSERT INTO messages (uuid, session_id, type, role, text, timestamp, visibility, source)
+      VALUES (?,?,?,?,?,?,?,?)
+    `).run('msg-polled', 'sid-polled', 'assistant', 'assistant', 'polled needle reply', now, 'visible', 'claude');
+    db.prepare('INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json) VALUES (?,?,?,?,?)')
+      .run('call-polled', 'msg-polled', 'sid-polled', 'Bash', JSON.stringify({ command: `obelisk --search "polled needle" --nonce ${nonce}` }));
+    db.close();
+
+    const result = await pending;
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const hits = JSON.parse(result.stdout);
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].session.id, 'sid-polled');
+    assert.equal(hits[0].session.is_invoking, true);
+  } finally {
+    lease.release();
+  }
+});
+
+// Run a script against core source in a child process with an isolated HOME:
+// DB_PATH is fixed at module load, so in-process buildIndex calls would touch
+// the real ~/.obelisk. Same pattern as tests/pi-runtime.test.mjs.
+function runCoreScript(home, script, env = {}) {
+  const coreUrl = pathToFileURL(join(repoRoot, 'packages/core/src/core.ts')).href;
+  const run = spawnSync(process.execPath, [
+    '--experimental-strip-types',
+    '--disable-warning=ExperimentalWarning',
+    '--input-type=module',
+    '-e',
+    script,
+  ], {
+    cwd: repoRoot,
+    env: { ...process.env, HOME: home, USERPROFILE: home, OBELISK_CORE_URL: coreUrl, ...env },
+    encoding: 'utf8',
+  });
+  assert.equal(run.status, 0, run.stderr);
+  return JSON.parse(run.stdout);
+}
+
+function claudeTextLine(uuid, type, ts) {
+  return JSON.stringify({ uuid, type, timestamp: ts, cwd: '/tmp/proj', message: { role: type, content: `${type} ${uuid}` } });
+}
+
+test('ignoreRecentBuild keeps the recovery build incremental and indexes new lines', () => {
+  const home = tempHome('obelisk-invoking-incremental-');
+  const projectDir = join(home, '.claude', 'projects', '-tmp-proj');
+  mkdirSync(projectDir, { recursive: true });
+  const jsonl = join(projectDir, 'sess.jsonl');
+  writeFileSync(jsonl, [
+    claudeTextLine('u1', 'user', '2026-08-11T10:00:00Z'),
+    claudeTextLine('a1', 'assistant', '2026-08-11T10:00:05Z'),
+  ].join('\n') + '\n');
+
+  const out = runCoreScript(home, `
+    import { appendFileSync, statSync, utimesSync } from 'node:fs';
+    import { DatabaseSync } from 'node:sqlite';
+    const core = await import(process.env.OBELISK_CORE_URL);
+    const jsonl = process.env.OBELISK_TEST_JSONL;
+    const out = {};
+    const first = core.buildIndex();
+    out.first = { skip: first.skip === true, complete: first.complete === true };
+    // Sentinel: a full republish deletes and re-inserts every row, wiping
+    // direct edits; an incremental build leaves unchanged files untouched.
+    const db = new DatabaseSync(core.DB_PATH);
+    db.prepare("UPDATE messages SET model='sentinel-model' WHERE uuid='a1'").run();
+    db.close();
+    const debounced = core.buildIndex();
+    out.debounceSkipReason = debounced.reason || null;
+    appendFileSync(jsonl, [
+      ${JSON.stringify(claudeTextLine('u2', 'user', '2026-08-11T10:01:00Z'))},
+      ${JSON.stringify(claudeTextLine('a2', 'assistant', '2026-08-11T10:01:05Z'))},
+    ].join('\\n') + '\\n');
+    const t = statSync(jsonl).mtimeMs / 1000 + 10;
+    utimesSync(jsonl, t, t);
+    const incremental = core.buildIndex({ ignoreRecentBuild: true });
+    out.incremental = { skip: incremental.skip === true, reason: incremental.reason || null, complete: incremental.complete === true };
+    const check = new DatabaseSync(core.DB_PATH, { readOnly: true });
+    out.messageCount = check.prepare('SELECT COUNT(*) AS c FROM messages').get().c;
+    out.sentinel = check.prepare("SELECT model FROM messages WHERE uuid='a1'").get().model;
+    out.cursor = check.prepare("SELECT lines_processed FROM index_state WHERE jsonl_path LIKE '%sess.jsonl'").get().lines_processed;
+    check.close();
+    process.stdout.write(JSON.stringify(out));
+  `, { OBELISK_TEST_JSONL: jsonl });
+
+  assert.deepEqual(out.first, { skip: false, complete: true });
+  assert.equal(out.debounceSkipReason, 'recent_build', 'plain rebuild stays debounced');
+  assert.deepEqual(out.incremental, { skip: false, reason: null, complete: true });
+  assert.equal(out.messageCount, 4, 'the appended lines were indexed');
+  assert.equal(out.sentinel, 'sentinel-model', 'unchanged file was not wiped and republished');
+  assert.equal(out.cursor, 4, 'cursor resumed and advanced to 4 lines');
+});
+
+test('ignoreDaemonOwnership builds under a fresh heartbeat; default still skips daemon_active', () => {
+  const home = tempHome('obelisk-invoking-carveout-');
+  const projectDir = join(home, '.claude', 'projects', '-tmp-proj');
+  mkdirSync(projectDir, { recursive: true });
+  const jsonl = join(projectDir, 'sess.jsonl');
+  writeFileSync(jsonl, claudeTextLine('u1', 'user', '2026-08-11T10:00:00Z') + '\n');
+
+  const out = runCoreScript(home, `
+    import { appendFileSync, statSync, utimesSync } from 'node:fs';
+    import { DatabaseSync } from 'node:sqlite';
+    const core = await import(process.env.OBELISK_CORE_URL);
+    const jsonl = process.env.OBELISK_TEST_JSONL;
+    const out = {};
+    core.buildIndex();
+    const db = new DatabaseSync(core.DB_PATH);
+    db.prepare("INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES ('__app_heartbeat__', ?, 0)").run(Date.now());
+    db.close();
+    appendFileSync(jsonl, ${JSON.stringify(claudeTextLine('u2', 'user', '2026-08-11T10:01:00Z'))} + '\\n');
+    const t = statSync(jsonl).mtimeMs / 1000 + 10;
+    utimesSync(jsonl, t, t);
+    // ignoreRecentBuild isolates the heartbeat gate from the debounce.
+    const held = core.buildIndex({ ignoreRecentBuild: true });
+    out.heldReason = held.reason || null;
+    const carveOut = core.buildIndex({ ignoreRecentBuild: true, ignoreDaemonOwnership: true });
+    out.carveOut = { skip: carveOut.skip === true, reason: carveOut.reason || null, complete: carveOut.complete === true };
+    const check = new DatabaseSync(core.DB_PATH, { readOnly: true });
+    out.messageCount = check.prepare('SELECT COUNT(*) AS c FROM messages').get().c;
+    check.close();
+    process.stdout.write(JSON.stringify(out));
+  `, { OBELISK_TEST_JSONL: jsonl });
+
+  assert.equal(out.heldReason, 'daemon_active', 'default keeps the daemon_active skip');
+  assert.deepEqual(out.carveOut, { skip: false, reason: null, complete: true });
+  assert.equal(out.messageCount, 2, 'the carve-out build indexed the appended line');
+});
+
+test('cli resolves the nonce via the carve-out build under a fresh daemon heartbeat', () => {
+  const home = tempHome('obelisk-invoking-daemon-');
+  const warm = runCli(['--search', 'warmup'], { home });
+  assert.equal(warm.status, 0, warm.stderr || warm.stdout);
+
+  // A fresh heartbeat makes the pre-query refresh skip with daemon_active.
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  const db = new DatabaseSync(dbPath);
+  db.prepare("INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES ('__app_heartbeat__', ?, 0)").run(Date.now());
+  db.close();
+
+  // The transcript appears only after the warm build, so just the carve-out
+  // recovery build can index the nonce.
+  const projectDir = join(home, '.claude', 'projects', '-tmp-daemon');
+  mkdirSync(projectDir, { recursive: true });
+  const nonce = 'obq-daemon-mode-carve-out';
+  const now = new Date().toISOString();
+  const lines = [
+    {
+      uuid: 'daemon-user', type: 'user', timestamp: now, cwd: '/tmp/daemon',
+      message: { role: 'user', content: 'find the daemon needle evidence' },
+    },
+    {
+      uuid: 'daemon-call', type: 'assistant', timestamp: now, cwd: '/tmp/daemon',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_daemon', name: 'Bash', input: { command: `obelisk --search "daemon needle" --nonce ${nonce}` } }] },
+    },
+  ];
+  writeFileSync(join(projectDir, 'daemon-invoking-session.jsonl'), lines.map(l => JSON.stringify(l)).join('\n') + '\n');
+
+  const result = runCli(['--search', 'daemon needle', '--nonce', nonce], { home });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const hits = JSON.parse(result.stdout);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].session.id, 'daemon-invoking-session');
+  assert.equal(hits[0].session.is_invoking, true);
+});

--- a/tests/provider-schema-stability.test.mjs
+++ b/tests/provider-schema-stability.test.mjs
@@ -7,6 +7,8 @@ test('canonical transcript persistence schema changes only by explicit decision'
   const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url));
   assert.equal(
     createHash('sha256').update(schema).digest('hex'),
-    '0218f39cb41dabd055eed895cd08906d9f93a856fc2a30850d2d6cb8ee63e1cf',
+    // 2026-08-11: added idx_messages_time on messages(timestamp) so the
+    // invocation-nonce resolver can bound its tool_calls scan to recent rows.
+    '712df79e346a09f753deeb951f975c36f0148bfe047df68830fbc7e172aec09a',
   );
 });

--- a/tests/skill-doc-artifact.test.mjs
+++ b/tests/skill-doc-artifact.test.mjs
@@ -25,7 +25,7 @@ test('build:skill produces a docs-only skill that delegates execution to the CLI
   const skill = readFileSync(join(artifact, 'SKILL.md'), 'utf8');
   const schema = readFileSync(join(artifact, 'references', 'schema.md'), 'utf8');
   assert.match(skill, /Bash\(obelisk:\*\)/);
-  assert.match(skill, /obelisk --query \/tmp\/q\.mjs/);
+  assert.match(skill, /obelisk --query "\$qfile"/);
   assert.match(skill, /obelisk --attune \/tmp\/register-memory\.mjs/);
   assert.doesNotMatch(skill, /\$SKILL_DIR\/scripts\/runtime\.js/);
   assert.doesNotMatch(`${skill}\n${schema}`, /scripts\//);


### PR DESCRIPTION
## Summary

Implements the invocation-relative session identity decided in #45: query results now distinguish the session that invoked the retrieval from genuine historical sessions.

**Mechanism — nonce self-search (no agent cooperation, no provider changes):** every provider (Claude Code, Codex, Kimi Code, Pi — all verified) flushes the tool-call record to its transcript *before* the tool finishes executing. Since the pre-query refresh indexes that record, the CLI can find its own invocation signature in the fresh index:

- `--query <file>` carries the as-typed file path as the invocation nonce; `--search` accepts an explicit `--nonce <token>` (never part of the FTS text). Skill docs establish uniqueness conventions (`mktemp`/`uuidgen` with shell-builtin fallbacks).
- `resolveInvokingSessionId` searches the fresh index (FTS over message text + bounded LIKE over `tool_calls.input_json`). Resolution is **newest-wins**: matches far apart in time are unrelated history, not ambiguity; only matches within a 10s epsilon are a genuine concurrent collision and resolve to honest null. Both legs are bounded by a 15-minute recency window (the invoking record is always recent), which also keeps the scan off the full 150k-row `tool_calls` table.
- Marking: `search()` hit sessions and `sessions()` rows carry `is_invoking: true`; `overview().current.session_id` exposes the id (null when unresolvable). No marking is ever a guess.

**Freshness recovery** (`resolveInvokingSessionIdWithWait`): on a first miss, one incremental build (`ignoreRecentBuild` — bypasses only the 30s debounce, never the force full-republish path), then a bounded poll (~300ms, ~4s cap) as the lease-contention fallback.

**Daemon carve-out (ADR 0006 amendment):** the freshness build — and only it — may build incrementally under a fresh `__app_heartbeat__` (`ignoreDaemonOwnership`). The writer lease remains the sole write arbitrator; loser paths are unchanged (CLI → poll → honest null; daemon → defer-and-retry). The carve-out never initializes or migrates schema (`coreSchemaNeedsMigration` gate); all other CLI write paths stay read-only under a fresh heartbeat. Without this, the feature could never work for users running the app daemon, since the daemon's watcher-driven builds land ~2.5-3.5s after the transcript write while the CLI resolves immediately.

## Schema

One additive index: `idx_messages_time ON messages(timestamp)` — lets the recency-bounded resolver drive from an index range scan instead of scanning `messages`. Applied idempotently by any writer; the resolver works (slower) before it exists. Canary hash updated in `provider-schema-stability.test.mjs`.

## Test plan

- `tests/invoking-session.test.mjs` (new, 18 tests): resolver via tool_calls/message text, missing/unknown nonces, newest-wins vs 10s collision vs quote-loses-execution, recency boundary, forced-incremental vs full-republish proof, daemon-heartbeat carve-out, schema-migration gate, writer-busy poll fallback, and CLI end-to-end coverage.
- Full suite: 448 pass / 0 fail on current `main`; typecheck and lint clean.

## Notes for review

- `is_invoking` is omitted (not false) on non-invoking rows, matching additive optional-field conventions.
- Latency: nonce-carrying queries pay zero on an immediate hit; worst case is one incremental build or the ~4s poll cap under write contention.
- #17's `excludeSession` composes naturally on top of this once merged.
