### PR TITLE
test: remove temp dirs on test process exit

### DIFF
--- a/tests/app-file-reference.test.mjs
+++ b/tests/app-file-reference.test.mjs
@@ -1,6 +1,5 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import {
@@ -9,9 +8,10 @@ import {
   normalizeRoots,
   resolveFileReference,
 } from '../app/src/main/file-reference.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 function tempProject() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'obelisk-file-ref-'));
+  const root = makeTempDir('obelisk-file-ref-');
   fs.mkdirSync(path.join(root, 'src'), { recursive: true });
   fs.writeFileSync(path.join(root, 'src', 'app.ts'), 'export const a = 1;\n');
   return fs.realpathSync(root);
@@ -41,7 +41,7 @@ test('resolves a relative reference against the message cwd', () => {
 
 test('refuses paths outside the session roots', () => {
   const root = tempProject();
-  const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'obelisk-outside-'));
+  const outside = makeTempDir('obelisk-outside-');
   fs.writeFileSync(path.join(outside, 'secret.txt'), 'nope\n');
   assert.equal(resolveFileReference({ rawPath: path.join(outside, 'secret.txt'), cwd: root }), null);
   assert.equal(resolveFileReference({ rawPath: '../../etc/hosts', cwd: root }), null);
@@ -49,7 +49,7 @@ test('refuses paths outside the session roots', () => {
 
 test('refuses a symlink that escapes the session roots', () => {
   const root = tempProject();
-  const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'obelisk-outside-'));
+  const outside = makeTempDir('obelisk-outside-');
   const secret = path.join(outside, 'secret.txt');
   fs.writeFileSync(secret, 'nope\n');
   fs.symlinkSync(secret, path.join(root, 'escape.txt'));

--- a/tests/app-indexer-service.test.mjs
+++ b/tests/app-indexer-service.test.mjs
@@ -1,9 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 import { createIndexerService } from '../app/src/main/indexer-service.ts';
@@ -387,7 +387,7 @@ test('indexer service publishes daemon ownership as soon as it starts', () => {
 });
 
 test('indexer service watches Claude JSON files through chokidar', async () => {
-  const projectsDir = mkdtempSync(join(tmpdir(), 'obelisk-chokidar-projects-'));
+  const projectsDir = makeTempDir('obelisk-chokidar-projects-');
   const timers = manualTimers();
   const calls = [];
   let watchArgs = null;
@@ -438,7 +438,7 @@ test('indexer service watches Claude JSON files through chokidar', async () => {
 });
 
 test('indexer service passes changed JSONL paths to the build worker', async () => {
-  const projectsDir = mkdtempSync(join(tmpdir(), 'obelisk-changed-paths-'));
+  const projectsDir = makeTempDir('obelisk-changed-paths-');
   const timers = manualTimers();
   const calls = [];
   const handlers = {};
@@ -480,8 +480,8 @@ test('indexer service passes changed JSONL paths to the build worker', async () 
 });
 
 test('indexer service watches Claude projects and Codex sessions for app-side indexing', async () => {
-  const claudeProjectsDir = mkdtempSync(join(tmpdir(), 'obelisk-watch-claude-'));
-  const codexSessionsDir = mkdtempSync(join(tmpdir(), 'obelisk-watch-codex-sessions-'));
+  const claudeProjectsDir = makeTempDir('obelisk-watch-claude-');
+  const codexSessionsDir = makeTempDir('obelisk-watch-codex-sessions-');
   const timers = manualTimers();
   const calls = [];
   const watchers = [];
@@ -529,8 +529,8 @@ test('indexer service watches Claude projects and Codex sessions for app-side in
 });
 
 test('indexer service starts watching a configured root that appears after startup', async () => {
-  const existingRoot = mkdtempSync(join(tmpdir(), 'obelisk-watch-existing-'));
-  const parent = mkdtempSync(join(tmpdir(), 'obelisk-watch-late-parent-'));
+  const existingRoot = makeTempDir('obelisk-watch-existing-');
+  const parent = makeTempDir('obelisk-watch-late-parent-');
   const lateRoot = join(parent, 'nested', 'sessions');
   const timers = manualTimers();
   const calls = [];

--- a/tests/app-indexer.test.mjs
+++ b/tests/app-indexer.test.mjs
@@ -1,9 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { appendFileSync, mkdtempSync, mkdirSync, statSync, utimesSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { appendFileSync, mkdirSync, statSync, utimesSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 import { buildIndex } from '../app/src/main/indexer.ts';
@@ -33,7 +33,7 @@ class TestDatabase {
 }
 
 test('app indexer records build success without claiming daemon ownership', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-indexer-'));
+  const home = makeTempDir('obelisk-app-indexer-');
   const claudeDir = join(home, '.claude');
   const projectDir = join(claudeDir, 'projects', '-tmp-obelisk-app');
   mkdirSync(projectDir, { recursive: true });
@@ -91,7 +91,7 @@ test('app indexer records build success without claiming daemon ownership', () =
 });
 
 test('app indexer refreshes unchanged Claude usage when input token semantics change', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-indexer-token-semantics-'));
+  const home = makeTempDir('obelisk-app-indexer-token-semantics-');
   const claudeDir = join(home, '.claude');
   const projectDir = join(claudeDir, 'projects', '-tmp-obelisk-app');
   mkdirSync(projectDir, { recursive: true });
@@ -146,7 +146,7 @@ test('app indexer refreshes unchanged Claude usage when input token semantics ch
 });
 
 test('force rebuild ignores stale JSONL index_state rows after session tables were cleared', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-indexer-force-'));
+  const home = makeTempDir('obelisk-app-indexer-force-');
   const claudeDir = join(home, '.claude');
   const projectDir = join(claudeDir, 'projects', '-tmp-obelisk-app');
   mkdirSync(projectDir, { recursive: true });
@@ -181,7 +181,7 @@ test('force rebuild ignores stale JSONL index_state rows after session tables we
 });
 
 test('force rebuild bypasses stale message FTS delete triggers', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-indexer-force-fts-'));
+  const home = makeTempDir('obelisk-app-indexer-force-fts-');
   const claudeDir = join(home, '.claude');
   const projectDir = join(claudeDir, 'projects', '-tmp-obelisk-app');
   mkdirSync(projectDir, { recursive: true });
@@ -223,7 +223,7 @@ test('force rebuild bypasses stale message FTS delete triggers', () => {
 });
 
 test('force rebuild into a new database preserves existing memories', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-indexer-force-preserve-'));
+  const home = makeTempDir('obelisk-app-indexer-force-preserve-');
   const claudeDir = join(home, '.claude');
   const projectDir = join(claudeDir, 'projects', '-tmp-obelisk-app');
   mkdirSync(projectDir, { recursive: true });
@@ -279,7 +279,7 @@ test('force rebuild into a new database preserves existing memories', () => {
 });
 
 test('app indexer reports changed workflow JSON as an affected session', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-indexer-workflow-'));
+  const home = makeTempDir('obelisk-app-indexer-workflow-');
   const claudeDir = join(home, '.claude');
   const project = '-tmp-obelisk-app';
   const sessionId = 'session-workflow-1';
@@ -319,7 +319,7 @@ test('app indexer reports changed workflow JSON as an affected session', () => {
 });
 
 test('app indexer marks UI-fallback control messages as meta at ingest time', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-indexer-meta-'));
+  const home = makeTempDir('obelisk-app-indexer-meta-');
   const claudeDir = join(home, '.claude');
   const projectDir = join(claudeDir, 'projects', '-tmp-obelisk-app');
   mkdirSync(projectDir, { recursive: true });
@@ -358,7 +358,7 @@ test('app indexer marks UI-fallback control messages as meta at ingest time', ()
 });
 
 test('app indexer loads Codex root sessions into the shared schema', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-indexer-codex-'));
+  const home = makeTempDir('obelisk-app-indexer-codex-');
   const claudeDir = join(home, '.claude');
   const codexDir = join(home, '.codex');
   const codexSessionDir = join(codexDir, 'sessions', '2026', '06', '15');
@@ -449,7 +449,7 @@ test('app indexer loads Codex root sessions into the shared schema', () => {
 });
 
 test('app indexer accepts Codex changed paths relative to the sessions directory', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-indexer-codex-sessions-change-'));
+  const home = makeTempDir('obelisk-app-indexer-codex-sessions-change-');
   const claudeDir = join(home, '.claude');
   const codexDir = join(home, '.codex');
   const codexSessionDir = join(codexDir, 'sessions', '2026', '06', '15');
@@ -497,7 +497,7 @@ test('app indexer accepts Codex changed paths relative to the sessions directory
 });
 
 test('app indexer uses Codex response_item messages only when no visible event message exists', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-indexer-codex-response-message-'));
+  const home = makeTempDir('obelisk-app-indexer-codex-response-message-');
   const claudeDir = join(home, '.claude');
   const codexDir = join(home, '.codex');
   const codexSessionDir = join(codexDir, 'sessions', '2026', '06', '15');
@@ -567,7 +567,7 @@ test('app indexer uses Codex response_item messages only when no visible event m
 });
 
 test('app indexer skips Codex guardian review threads', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-indexer-codex-guardian-'));
+  const home = makeTempDir('obelisk-app-indexer-codex-guardian-');
   const claudeDir = join(home, '.claude');
   const codexDir = join(home, '.codex');
   const codexSessionDir = join(codexDir, 'sessions', '2026', '06', '15');
@@ -619,7 +619,7 @@ test('app indexer skips Codex guardian review threads', () => {
 });
 
 test('app indexer removes stale Codex guardian rows when the JSONL was already indexed', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-indexer-codex-guardian-stale-'));
+  const home = makeTempDir('obelisk-app-indexer-codex-guardian-stale-');
   const claudeDir = join(home, '.claude');
   const codexDir = join(home, '.codex');
   const codexSessionDir = join(codexDir, 'sessions', '2026', '06', '15');
@@ -679,7 +679,7 @@ test('app indexer removes stale Codex guardian rows when the JSONL was already i
 });
 
 test('app indexer maps Codex subagent threads onto parent sessions', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-indexer-codex-subagent-'));
+  const home = makeTempDir('obelisk-app-indexer-codex-subagent-');
   const claudeDir = join(home, '.claude');
   const codexDir = join(home, '.codex');
   const codexSessionDir = join(codexDir, 'sessions', '2026', '06', '15');

--- a/tests/app-kimi-index.test.mjs
+++ b/tests/app-kimi-index.test.mjs
@@ -1,12 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { buildIndex } from '../app/src/main/indexer.ts';
 import { createKimiProvider } from '../packages/core/src/providers/kimi.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
@@ -88,7 +88,7 @@ function writePlaceholderSession(kimiDir, { userPrompt = false } = {}) {
 }
 
 test('app build indexes Kimi sessions through the provider registry without changing schema', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-kimi-index-'));
+  const home = makeTempDir('obelisk-kimi-index-');
   const claudeDir = join(home, '.claude');
   const codexDir = join(home, '.codex');
   const kimiDir = join(home, '.kimi-code');
@@ -128,7 +128,7 @@ test('app build indexes Kimi sessions through the provider registry without chan
 });
 
 test('app build excludes never-started Kimi placeholder sessions', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-kimi-placeholder-'));
+  const home = makeTempDir('obelisk-kimi-placeholder-');
   const kimiDir = join(home, '.kimi-code');
   const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
   writePlaceholderSession(kimiDir);
@@ -150,7 +150,7 @@ test('app build excludes never-started Kimi placeholder sessions', () => {
 });
 
 test('app build keeps a prompted Kimi session while placeholder metadata catches up', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-kimi-prompted-placeholder-'));
+  const home = makeTempDir('obelisk-kimi-prompted-placeholder-');
   const kimiDir = join(home, '.kimi-code');
   const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
   writePlaceholderSession(kimiDir, { userPrompt: true });
@@ -172,7 +172,7 @@ test('app build keeps a prompted Kimi session while placeholder metadata catches
 });
 
 test('Kimi marker upgrade retracts previously indexed placeholder sessions', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-kimi-placeholder-replay-'));
+  const home = makeTempDir('obelisk-kimi-placeholder-replay-');
   const kimiDir = join(home, '.kimi-code');
   const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
   const { wirePath } = writePlaceholderSession(kimiDir);
@@ -207,7 +207,7 @@ test('Kimi marker upgrade retracts previously indexed placeholder sessions', () 
 });
 
 test('Kimi undo and clear replace the indexed session instead of leaving stale rows', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-kimi-replay-'));
+  const home = makeTempDir('obelisk-kimi-replay-');
   const claudeDir = join(home, '.claude');
   const codexDir = join(home, '.codex');
   const kimiDir = join(home, '.kimi-code');
@@ -250,7 +250,7 @@ test('Kimi undo and clear replace the indexed session instead of leaving stale r
 });
 
 test('Kimi canonical transcript marker replays unchanged sessions once', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-kimi-prompt-marker-'));
+  const home = makeTempDir('obelisk-kimi-prompt-marker-');
   const claudeDir = join(home, '.claude');
   const codexDir = join(home, '.codex');
   const kimiDir = join(home, '.kimi-code');

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -4,10 +4,10 @@ import { createRequire } from 'node:module';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { acquireWriterLease } from '../packages/core/src/writer-lease.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
@@ -120,7 +120,7 @@ function defaultIndexerWorkerClient() {
 async function loadMainForWindowFlags(flags, { settingsText } = {}) {
   const originalArgv = process.argv;
   const originalHome = process.env.HOME;
-  const home = join(tmpdir(), `obelisk-window-flags-${Date.now()}-${Math.random()}`);
+  const home = makeTempDir(`obelisk-window-flags-${Date.now()}-${Math.random()}`);
   mkdirSync(join(home, '.obelisk'), { recursive: true });
   writeFileSync(join(home, '.obelisk', 'obelisk.sqlite'), '');
   if (settingsText !== undefined) {
@@ -209,7 +209,7 @@ test('malformed settings keep the desktop recovery window available', async () =
 
 test('main process watches every root declared by the built-in provider registry', async () => {
   const originalHome = process.env.HOME;
-  const home = join(tmpdir(), `obelisk-main-watch-dirs-${Date.now()}`);
+  const home = makeTempDir(`obelisk-main-watch-dirs-${Date.now()}`);
   const claudeDir = join(home, '.claude');
   const codexDir = join(home, '.codex');
   mkdirSync(join(claudeDir, 'projects'), { recursive: true });
@@ -298,7 +298,7 @@ test('main process watches every root declared by the built-in provider registry
 
 test('main process forwards committed IDs without reopening after a deferred build', async () => {
   const originalHome = process.env.HOME;
-  const home = join(tmpdir(), `obelisk-main-deferred-build-${Date.now()}`);
+  const home = makeTempDir(`obelisk-main-deferred-build-${Date.now()}`);
   mkdirSync(join(home, '.claude', 'projects'), { recursive: true });
   mkdirSync(join(home, '.codex', 'sessions'), { recursive: true });
   mkdirSync(join(home, '.obelisk'), { recursive: true });
@@ -407,7 +407,7 @@ test('main process forwards committed IDs without reopening after a deferred bui
 
 test('session IPC hides Codex rows by default and supports explicit source opt-in', async () => {
   const originalHome = process.env.HOME;
-  const home = join(tmpdir(), `obelisk-main-source-filter-${Date.now()}`);
+  const home = makeTempDir(`obelisk-main-source-filter-${Date.now()}`);
   mkdirSync(join(home, '.obelisk'), { recursive: true });
   writeFileSync(join(home, '.obelisk', 'obelisk.sqlite'), '');
   process.env.HOME = home;
@@ -499,7 +499,7 @@ test('session IPC hides Codex rows by default and supports explicit source opt-i
 
 test('usage IPC aggregates normalized tokens across all indexed providers', async () => {
   const originalHome = process.env.HOME;
-  const home = join(tmpdir(), `obelisk-main-usage-${Date.now()}`);
+  const home = makeTempDir(`obelisk-main-usage-${Date.now()}`);
   const obeliskDir = join(home, '.obelisk');
   mkdirSync(obeliskDir, { recursive: true });
   process.env.HOME = home;
@@ -617,7 +617,7 @@ test('usage IPC aggregates normalized tokens across all indexed providers', asyn
 
 test('main process migrates an existing app database before source-filtered IPC queries', async () => {
   const originalHome = process.env.HOME;
-  const home = join(tmpdir(), `obelisk-main-db-migration-${Date.now()}`);
+  const home = makeTempDir(`obelisk-main-db-migration-${Date.now()}`);
   const obeliskDir = join(home, '.obelisk');
   mkdirSync(obeliskDir, { recursive: true });
   process.env.HOME = home;
@@ -701,7 +701,7 @@ test('main process migrates an existing app database before source-filtered IPC 
 
 test('main process keeps schema and memory mutations behind the writer lease', async () => {
   const originalHome = process.env.HOME;
-  const home = join(tmpdir(), `obelisk-main-migration-lease-${Date.now()}`);
+  const home = makeTempDir(`obelisk-main-migration-lease-${Date.now()}`);
   const obeliskDir = join(home, '.obelisk');
   const dbPath = join(obeliskDir, 'obelisk.sqlite');
   mkdirSync(obeliskDir, { recursive: true });
@@ -766,7 +766,7 @@ test('main process keeps schema and memory mutations behind the writer lease', a
 test('closing the last macOS window releases background resources until activation', async () => {
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
   const originalHome = process.env.HOME;
-  const home = join(tmpdir(), `obelisk-main-window-${Date.now()}`);
+  const home = makeTempDir(`obelisk-main-window-${Date.now()}`);
   mkdirSync(join(home, '.obelisk'), { recursive: true });
   writeFileSync(join(home, '.obelisk', 'obelisk.sqlite'), '');
   process.env.HOME = home;
@@ -876,7 +876,7 @@ test('closing the last macOS window releases background resources until activati
 });
 
 test('settings rebuild reopens the database from the configured Claude path', async () => {
-  const home = join(tmpdir(), `obelisk-main-settings-${Date.now()}`);
+  const home = makeTempDir(`obelisk-main-settings-${Date.now()}`);
   const defaultClaudeDir = join(home, '.claude');
   const customClaudeDir = join(home, 'custom-claude');
   const customCodexDir = join(home, 'custom-codex');
@@ -1052,7 +1052,7 @@ test('settings rebuild reopens the database from the configured Claude path', as
 });
 
 test('settings rebuild keeps the existing database after a worker failure', async () => {
-  const home = join(tmpdir(), `obelisk-main-settings-rebuild-failure-${Date.now()}`);
+  const home = makeTempDir(`obelisk-main-settings-rebuild-failure-${Date.now()}`);
   const customClaudeDir = join(home, 'custom-claude');
   const customCodexDir = join(home, 'custom-codex');
   mkdirSync(customClaudeDir, { recursive: true });
@@ -1162,7 +1162,7 @@ test('settings rebuild keeps the existing database after a worker failure', asyn
 });
 
 test('settings rebuild cancels an in-flight background build instead of waiting for it', async () => {
-  const home = join(tmpdir(), `obelisk-main-settings-rebuild-cancel-${Date.now()}`);
+  const home = makeTempDir(`obelisk-main-settings-rebuild-cancel-${Date.now()}`);
   const customClaudeDir = join(home, 'custom-claude');
   const customCodexDir = join(home, 'custom-codex');
   mkdirSync(customClaudeDir, { recursive: true });
@@ -1265,7 +1265,7 @@ test('settings rebuild cancels an in-flight background build instead of waiting 
 });
 
 test('settings changes during rebuild keep one watcher and re-enable with a catch-up build', async () => {
-  const home = join(tmpdir(), `obelisk-main-settings-rebuild-race-${Date.now()}`);
+  const home = makeTempDir(`obelisk-main-settings-rebuild-race-${Date.now()}`);
   mkdirSync(join(home, '.obelisk'), { recursive: true });
   writeFileSync(join(home, '.obelisk', 'obelisk.sqlite'), '');
   writeFileSync(join(home, '.obelisk', 'settings.json'), JSON.stringify({ autoRefresh: true }));

--- a/tests/app-pi-index.test.mjs
+++ b/tests/app-pi-index.test.mjs
@@ -4,14 +4,12 @@ import { createRequire } from 'node:module';
 import {
   chmodSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   readdirSync,
   renameSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 import { buildIndex } from '../app/src/main/indexer.ts';
@@ -21,6 +19,7 @@ import {
   PI_CANONICAL_TRANSCRIPT_MARKER,
 } from '../packages/core/src/providers/pi.ts';
 import { createProviderRegistry } from '../packages/core/src/providers/registry.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
@@ -69,7 +68,7 @@ function indexOptions(home, piDir) {
 }
 
 test('app build indexes Pi through the registry and replays complete session snapshots', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-index-'));
+  const home = makeTempDir('obelisk-pi-index-');
   const piDir = join(home, 'pi-sessions');
   const sessionPath = writeFixture(piDir);
   const options = indexOptions(home, piDir);
@@ -110,7 +109,7 @@ test('app build indexes Pi through the registry and replays complete session sna
 test('an unreadable Pi directory does not block readable sessions on a fresh index', {
   skip: process.platform === 'win32',
 }, (t) => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-partial-inventory-'));
+  const home = makeTempDir('obelisk-pi-partial-inventory-');
   const piDir = join(home, 'pi-sessions');
   writeFixture(piDir);
   const lockedDir = join(piDir, 'locked');
@@ -159,7 +158,7 @@ test('an unreadable Pi directory does not block readable sessions on a fresh ind
 test('an incomplete Pi identity census preserves committed provenance over a readable copy', {
   skip: process.platform === 'win32',
 }, (t) => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-partial-copy-'));
+  const home = makeTempDir('obelisk-pi-partial-copy-');
   const piDir = join(home, 'pi-sessions');
   const lockedDir = join(piDir, 'locked');
   const committedPath = join(lockedDir, 'session.jsonl');
@@ -227,7 +226,7 @@ test('an incomplete Pi identity census preserves committed provenance over a rea
 });
 
 test('Pi canonical marker forces one provider-owned replay after projection changes', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-marker-'));
+  const home = makeTempDir('obelisk-pi-marker-');
   const piDir = join(home, 'pi-sessions');
   writeFixture(piDir);
   const options = indexOptions(home, piDir);
@@ -256,7 +255,7 @@ test('Pi canonical marker forces one provider-owned replay after projection chan
 });
 
 test('a structurally invalid Pi file retries alone after a canonical replay', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-marker-retry-'));
+  const home = makeTempDir('obelisk-pi-marker-retry-');
   const piDir = join(home, 'pi-sessions');
   const validPath = writeFixture(piDir);
   const options = {
@@ -320,7 +319,7 @@ test('a structurally invalid Pi file retries alone after a canonical replay', ()
 });
 
 test('a failed Pi unit rolls back a force rebuild to the last complete snapshot', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-force-rollback-'));
+  const home = makeTempDir('obelisk-pi-force-rollback-');
   const piDir = join(home, 'pi-sessions');
   const sessionPath = writeFixture(piDir);
   const options = {
@@ -362,7 +361,7 @@ test('a failed Pi unit rolls back a force rebuild to the last complete snapshot'
 });
 
 test('a temp force rebuild uses live Pi provenance before publishing an empty snapshot', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-temp-provenance-'));
+  const home = makeTempDir('obelisk-pi-temp-provenance-');
   const piDir = join(home, 'pi-sessions');
   writeFixture(piDir);
   const options = indexOptions(home, piDir);
@@ -388,7 +387,7 @@ test('a temp force rebuild uses live Pi provenance before publishing an empty sn
 });
 
 test('an unavailable Pi root keeps replay pending on the missing session cursor', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-incomplete-marker-'));
+  const home = makeTempDir('obelisk-pi-incomplete-marker-');
   const piDir = join(home, 'pi-sessions');
   const sessionPath = writeFixture(piDir);
   const options = indexOptions(home, piDir);
@@ -448,7 +447,7 @@ test('an unavailable Pi root keeps replay pending on the missing session cursor'
 });
 
 test('an unresolved Pi root keeps replay pending on the unresolved session cursor', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-unresolved-marker-'));
+  const home = makeTempDir('obelisk-pi-unresolved-marker-');
   const piDir = join(home, 'pi-sessions');
   const sessionPath = writeFixture(piDir);
   const options = indexOptions(home, piDir);
@@ -499,7 +498,7 @@ test('an unresolved Pi root keeps replay pending on the unresolved session curso
 });
 
 test('Pi identity marker retracts a legacy id through a non-selected identical copy', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-identity-marker-'));
+  const home = makeTempDir('obelisk-pi-identity-marker-');
   const piDir = join(home, 'pi-sessions');
   const selectedPath = writeFixture(piDir);
   const copiedPath = join(piDir, 'z-copy', 'session.jsonl');
@@ -531,7 +530,7 @@ test('Pi identity marker retracts a legacy id through a non-selected identical c
 });
 
 test('app replay keeps Pi identity stable across migration and retracts replacement and unlink', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-provenance-'));
+  const home = makeTempDir('obelisk-pi-provenance-');
   const piDir = join(home, 'pi-sessions');
   const sessionPath = writeFixture(piDir);
   const options = indexOptions(home, piDir);
@@ -580,7 +579,7 @@ test('app replay keeps Pi identity stable across migration and retracts replacem
 });
 
 test('a failed Pi identity replacement preserves the prior session snapshot', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-replacement-rollback-'));
+  const home = makeTempDir('obelisk-pi-replacement-rollback-');
   const piDir = join(home, 'pi-sessions');
   const sessionPath = writeFixture(piDir);
   const options = indexOptions(home, piDir);
@@ -609,7 +608,7 @@ test('a failed Pi identity replacement preserves the prior session snapshot', ()
 });
 
 test('passive Pi inventory retracts deleted sessions when its configured root remains readable', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-passive-delete-'));
+  const home = makeTempDir('obelisk-pi-passive-delete-');
   const piDir = join(home, 'pi-sessions');
   const sessionPath = writeFixture(piDir);
   const options = indexOptions(home, piDir);
@@ -625,7 +624,7 @@ test('passive Pi inventory retracts deleted sessions when its configured root re
 });
 
 test('a terminal malformed line follows Pi by publishing the valid replacement prefix', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-torn-replacement-'));
+  const home = makeTempDir('obelisk-pi-torn-replacement-');
   const piDir = join(home, 'pi-sessions');
   const sessionPath = writeFixture(piDir);
   const options = indexOptions(home, piDir);

--- a/tests/app-provider-indexer.test.mjs
+++ b/tests/app-provider-indexer.test.mjs
@@ -1,12 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { buildIndex } from '../app/src/main/indexer.ts';
 import { createProviderRegistry } from '../packages/core/src/providers/registry.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
@@ -20,7 +19,7 @@ class TestDatabase {
 }
 
 test('app indexer persists every provider through one registry-driven loop', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-provider-indexer-'));
+  const home = makeTempDir('obelisk-provider-indexer-');
   const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
   const registry = createProviderRegistry([{
     name: 'alpha',
@@ -79,7 +78,7 @@ test('app indexer persists every provider through one registry-driven loop', () 
 });
 
 test('serialized invalid provider settings stay disabled when the worker rebuilds the registry', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-provider-settings-worker-'));
+  const home = makeTempDir('obelisk-provider-settings-worker-');
   const result = buildIndex({
     providerSettings: {
       providerRoots: {
@@ -101,7 +100,7 @@ test('serialized invalid provider settings stay disabled when the worker rebuild
 });
 
 test('an invalid provider root cannot erase a previously indexed source snapshot', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-provider-settings-preserve-'));
+  const home = makeTempDir('obelisk-provider-settings-preserve-');
   const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
   const sourcePath = join(home, '.claude', 'projects', 'session.jsonl');
   const registry = createProviderRegistry([{
@@ -154,7 +153,7 @@ test('an invalid provider root cannot erase a previously indexed source snapshot
 });
 
 test('an incomplete canonical inventory converges without replaying readable units forever', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-provider-incomplete-replay-'));
+  const home = makeTempDir('obelisk-provider-incomplete-replay-');
   const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
   const marker = '__alpha_canonical_v1__';
   let incomplete = true;
@@ -237,7 +236,7 @@ test('an incomplete canonical inventory converges without replaying readable uni
 });
 
 test('marker replay invalidates provider unit keys that differ from source paths', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-provider-unit-key-replay-'));
+  const home = makeTempDir('obelisk-provider-unit-key-replay-');
   const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
   const unitKey = 'alpha:session-unit';
   const sourcePath = '/alpha/session/agents/main/wire.jsonl';
@@ -294,7 +293,7 @@ test('marker replay invalidates provider unit keys that differ from source paths
 });
 
 test('a provider can withhold inventory-dependent tombstones from a partial census', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-provider-incomplete-tombstone-'));
+  const home = makeTempDir('obelisk-provider-incomplete-tombstone-');
   const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
   const marker = '__alpha_canonical_v1__';
   let removeSession = false;
@@ -363,7 +362,7 @@ test('a provider can withhold inventory-dependent tombstones from a partial cens
 });
 
 test('force rebuild resets arbitrary provider keys and rewrites arbitrary provider markers', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-provider-force-keys-'));
+  const home = makeTempDir('obelisk-provider-force-keys-');
   const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
   const unitKey = '__remote-1__';
   const marker = 'alpha-v1';
@@ -412,7 +411,7 @@ test('force rebuild resets arbitrary provider keys and rewrites arbitrary provid
 });
 
 test('force rebuild keeps legacy providers without inventory certification compatible', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-provider-force-certification-'));
+  const home = makeTempDir('obelisk-provider-force-certification-');
   const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
   const unitKey = 'alpha:unit';
   const marker = 'alpha-marker';

--- a/tests/app-rollback-guard.test.mjs
+++ b/tests/app-rollback-guard.test.mjs
@@ -5,9 +5,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 import { buildIndex } from '../app/src/main/indexer.ts';
@@ -57,7 +57,7 @@ function makeDbClass(shouldPoison) {
 }
 
 function twoFileHome(alphaContent, betaContent) {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-tx-'));
+  const home = makeTempDir('obelisk-tx-');
   const projectDir = join(home, '.claude', 'projects', '-tmp-proj');
   mkdirSync(projectDir, { recursive: true });
   mkdirSync(join(home, '.obelisk'), { recursive: true });
@@ -71,7 +71,7 @@ function twoFileHome(alphaContent, betaContent) {
 }
 
 function subagentHome(description = 'first description') {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-meta-tx-'));
+  const home = makeTempDir('obelisk-meta-tx-');
   const projectDir = join(home, '.claude', 'projects', '-tmp-proj');
   const subagentDir = join(projectDir, 'session', 'subagents');
   const dbPath = join(home, '.obelisk', 'obelisk.sqlite');

--- a/tests/app-writer-lease.test.mjs
+++ b/tests/app-writer-lease.test.mjs
@@ -1,12 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { buildIndex } from '../app/src/main/indexer.ts';
 import { acquireWriterLease, writerLockPathFor } from '../packages/core/src/writer-lease.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
@@ -23,7 +23,7 @@ class TestDatabase {
 }
 
 test('an app build defers without opening the target database when another writer owns the lease', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-writer-lease-'));
+  const home = makeTempDir('obelisk-app-writer-lease-');
   const claudeDir = join(home, '.claude');
   const projectsDir = join(claudeDir, 'projects');
   const projectDir = join(projectsDir, '-tmp-project');
@@ -59,7 +59,7 @@ test('an app build defers without opening the target database when another write
 });
 
 test('a failed force cleanup leaves the existing index intact', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-app-force-atomic-'));
+  const home = makeTempDir('obelisk-app-force-atomic-');
   const claudeDir = join(home, '.claude');
   const projectsDir = join(claudeDir, 'projects');
   const projectDir = join(projectsDir, '-tmp-project');

--- a/tests/claude-parse.test.mjs
+++ b/tests/claude-parse.test.mjs
@@ -4,19 +4,19 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, statSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, readFileSync, writeFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
 import { createClaudeProvider, parse } from '../packages/core/src/providers/claude.ts';
 import { assembleSessionDetail } from '../packages/core/src/session-detail.ts';
 import { persist } from '../packages/core/src/persist.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
 
 function writeFixture() {
-  const dir = mkdtempSync(join(tmpdir(), 'obelisk-claude-parse-'));
+  const dir = makeTempDir('obelisk-claude-parse-');
   const path = join(dir, 'sid-x.jsonl');
   const lines = [
     { type: 'ai-title', aiTitle: 'My Session' },
@@ -101,7 +101,7 @@ test('claude parse() resumes from a cursor, skipping already-indexed lines', () 
 });
 
 test('claude provider emits workflow artifacts with an explicit canonical tool edge', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-claude-workflow-'));
+  const root = makeTempDir('obelisk-claude-workflow-');
   const projectDir = join(root, 'projects', '-proj');
   const workflowDir = join(projectDir, 'sid-workflow', 'workflows');
   const workflowAgentDir = join(projectDir, 'sid-workflow', 'subagents', 'workflows', 'run-workflow');

--- a/tests/cli-bootstrap-install.test.mjs
+++ b/tests/cli-bootstrap-install.test.mjs
@@ -4,13 +4,12 @@ import { spawnSync } from 'node:child_process';
 import {
   chmodSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   writeFileSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { delimiter, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -47,7 +46,7 @@ test('README presents agent-led installation before manual npm setup', () => {
 });
 
 test('install.sh installs and verifies only the CLI', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-install-script-'));
+  const home = makeTempDir('obelisk-install-script-');
   const fakeBin = join(home, 'bin');
   const npmCapture = join(home, 'npm-args');
   const obeliskCapture = join(home, 'obelisk-args');

--- a/tests/cli-package.test.mjs
+++ b/tests/cli-package.test.mjs
@@ -1,17 +1,17 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { delimiter, join } from 'node:path';
 
 import { repoRoot, runCli } from './cli-test-helpers.mjs';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const cliPackage = JSON.parse(readFileSync(join(repoRoot, 'packages', 'cli', 'package.json'), 'utf8'));
 
 test('the packaged obelisk command preserves the runtime query envelope', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-cli-package-'));
+  const home = makeTempDir('obelisk-cli-package-');
   const query = join(home, 'query.mjs');
   writeFileSync(query, 'return { answer: 42 };');
 
@@ -31,7 +31,7 @@ test('obelisk --version reports the installed CLI package version', () => {
 });
 
 test('CLI test process suppresses only Node ExperimentalWarning output', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-cli-warning-'));
+  const home = makeTempDir('obelisk-cli-warning-');
   const preload = join(home, 'warnings.cjs');
   writeFileSync(preload, `
     process.emitWarning('simulated SQLite warning', 'ExperimentalWarning');
@@ -49,7 +49,7 @@ test('CLI test process suppresses only Node ExperimentalWarning output', () => {
 });
 
 test('obelisk install delegates official skill installation to the skills CLI', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-cli-install-'));
+  const home = makeTempDir('obelisk-cli-install-');
   const fakeBin = join(home, 'bin');
   const capture = join(home, 'args.json');
   const captureScript = join(home, 'capture.mjs');
@@ -88,7 +88,7 @@ test('obelisk install delegates official skill installation to the skills CLI', 
 });
 
 test('npm pack installs one platform-neutral CLI with its schema resource', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-cli-pack-'));
+  const root = makeTempDir('obelisk-cli-pack-');
   const packDir = join(root, 'pack');
   const prefix = join(root, 'prefix');
   const npmCache = join(root, 'npm-cache');

--- a/tests/codex-index.test.mjs
+++ b/tests/codex-index.test.mjs
@@ -6,11 +6,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync, utimesSync, statSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, writeFileSync, appendFileSync, utimesSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { runCli } from './cli-test-helpers.mjs';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
@@ -47,7 +47,7 @@ function codexCounts(home) {
 }
 
 test('codex full build then incremental rebuild replaces the total count without duplicates', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-codex-idx-'));
+  const home = makeTempDir('obelisk-codex-idx-');
   const dir = join(home, '.codex', 'sessions', '2026', '06', '15');
   mkdirSync(dir, { recursive: true });
   const jsonl = join(dir, `rollout-2026-06-15T10-00-00-${ID}.jsonl`);

--- a/tests/codex-parse.test.mjs
+++ b/tests/codex-parse.test.mjs
@@ -5,14 +5,14 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { createCodexProvider, parse } from '../packages/core/src/providers/codex.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 function writeFixture(lines) {
-  const dir = mkdtempSync(join(tmpdir(), 'obelisk-codex-parse-'));
+  const dir = makeTempDir('obelisk-codex-parse-');
   const path = join(dir, 'rollout.jsonl');
   writeFileSync(path, lines.map(l => JSON.stringify(l)).join('\n') + '\n');
   return path;
@@ -86,7 +86,7 @@ test('codex parse() retracts a guardian thread via delete-session and emits noth
 });
 
 test('codex provider folds session_index metadata into its canonical session record', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-codex-index-meta-'));
+  const root = makeTempDir('obelisk-codex-index-meta-');
   const sessionsDir = join(root, 'sessions', '2026', '06', '10');
   mkdirSync(sessionsDir, { recursive: true });
   const path = join(sessionsDir, `rollout-${META.id}.jsonl`);

--- a/tests/codex-replay-tool-identity.test.mjs
+++ b/tests/codex-replay-tool-identity.test.mjs
@@ -1,13 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { DatabaseSync } from 'node:sqlite';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { assembleSessionDetail } from '../app/src/shared/session-detail-assembly.mjs';
 import { persist } from '../packages/core/src/persist.ts';
 import { parse } from '../packages/core/src/providers/codex.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
 const PARENT_ID = '019ed000-0000-7000-8000-000000000101';
@@ -30,7 +30,7 @@ function writeRollout(path, meta, source) {
 }
 
 test('a replayed Codex call cannot steal the visible message tool association', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'obelisk-codex-replay-'));
+  const dir = makeTempDir('obelisk-codex-replay-');
   const parentPath = join(dir, 'parent.jsonl');
   const replayPath = join(dir, 'replay.jsonl');
   writeRollout(parentPath, {

--- a/tests/contract-helper-shapes.test.mjs
+++ b/tests/contract-helper-shapes.test.mjs
@@ -19,11 +19,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { createQueryApi, createAttuneApi } from '../packages/core/src/query.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
@@ -184,7 +184,7 @@ test('forget() result shape matches api-reference.md', () => {
 });
 
 test('raw() shape matches api-reference.md', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'obelisk-raw-'));
+  const dir = makeTempDir('obelisk-raw-');
   const jsonlPath = join(dir, 'session.jsonl');
   const line = JSON.stringify({ uuid: 'm-raw', type: 'user', message: { role: 'user', content: 'raw line body' } });
   writeFileSync(jsonlPath, line + '\n');

--- a/tests/daemon-arbitration.test.mjs
+++ b/tests/daemon-arbitration.test.mjs
@@ -1,18 +1,18 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { acquireWriterLease, writerLockPathFor } from '../packages/core/src/writer-lease.ts';
 import { runCli } from './cli-test-helpers.mjs';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
 
 test('a passive query does not mutate the index while a fresh daemon owns writes', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-daemon-arbitration-'));
+  const home = makeTempDir('obelisk-daemon-arbitration-');
   const obeliskDir = join(home, '.obelisk');
   const dbPath = join(obeliskDir, 'obelisk.sqlite');
   mkdirSync(obeliskDir, { recursive: true });
@@ -37,7 +37,7 @@ test('a passive query does not mutate the index while a fresh daemon owns writes
 });
 
 test('a passive query reports when a daemon blocks its schema upgrade', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-daemon-schema-'));
+  const home = makeTempDir('obelisk-daemon-schema-');
   const obeliskDir = join(home, '.obelisk');
   const dbPath = join(obeliskDir, 'obelisk.sqlite');
   mkdirSync(obeliskDir, { recursive: true });
@@ -77,7 +77,7 @@ test('a passive query reports when a daemon blocks its schema upgrade', () => {
 });
 
 test('attune refuses to mutate the index while a fresh daemon owns writes', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-daemon-attune-'));
+  const home = makeTempDir('obelisk-daemon-attune-');
   const obeliskDir = join(home, '.obelisk');
   const dbPath = join(obeliskDir, 'obelisk.sqlite');
   mkdirSync(obeliskDir, { recursive: true });
@@ -101,7 +101,7 @@ test('attune refuses to mutate the index while a fresh daemon owns writes', () =
 });
 
 test('a passive query stays read-only when another process holds the writer lease', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-writer-owned-'));
+  const home = makeTempDir('obelisk-writer-owned-');
   const obeliskDir = join(home, '.obelisk');
   const dbPath = join(obeliskDir, 'obelisk.sqlite');
   mkdirSync(obeliskDir, { recursive: true });
@@ -131,7 +131,7 @@ test('a passive query stays read-only when another process holds the writer leas
 });
 
 test('a passive query fails closed when daemon ownership cannot be read', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-daemon-ownership-error-'));
+  const home = makeTempDir('obelisk-daemon-ownership-error-');
   const obeliskDir = join(home, '.obelisk');
   const dbPath = join(obeliskDir, 'obelisk.sqlite');
   mkdirSync(obeliskDir, { recursive: true });

--- a/tests/incremental-index.test.mjs
+++ b/tests/incremental-index.test.mjs
@@ -8,11 +8,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync, utimesSync, statSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, writeFileSync, appendFileSync, utimesSync, statSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { runCli } from './cli-test-helpers.mjs';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
@@ -39,7 +39,7 @@ function counts(home) {
 }
 
 test('incremental buildIndex resumes from cursor and accumulates message_count', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-incr-'));
+  const home = makeTempDir('obelisk-incr-');
   const projDir = join(home, '.claude', 'projects', '-tmp-proj');
   mkdirSync(projDir, { recursive: true });
   const jsonl = join(projDir, 'sess.jsonl');
@@ -67,7 +67,7 @@ test('incremental buildIndex resumes from cursor and accumulates message_count',
 });
 
 test('force build purges sessions for deleted files and preserves memories', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-force-'));
+  const home = makeTempDir('obelisk-force-');
   const projDir = join(home, '.claude', 'projects', '-tmp-proj');
   mkdirSync(projDir, { recursive: true });
   const keep = join(projDir, 'keep.jsonl');

--- a/tests/indexer-upsert-drift.test.mjs
+++ b/tests/indexer-upsert-drift.test.mjs
@@ -7,19 +7,19 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { parse } from '../packages/core/src/providers/claude.ts';
 import { persist } from '../packages/core/src/persist.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
 const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
 
 function fixtureUnit() {
-  const dir = mkdtempSync(join(tmpdir(), 'obelisk-drift-'));
+  const dir = makeTempDir('obelisk-drift-');
   const jsonlPath = join(dir, 'sess.jsonl');
   const lines = [
     { uuid: 'u-1', type: 'user', timestamp: '2026-06-10T10:00:00Z', cwd: '/tmp/proj', message: { role: 'user', content: 'first question' } },

--- a/tests/invoking-session.test.mjs
+++ b/tests/invoking-session.test.mjs
@@ -12,8 +12,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 import { spawn, spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -21,6 +20,7 @@ import { createQueryApi } from '../packages/core/src/query.ts';
 import { resolveInvokingSessionId, resolveInvokingSessionIdWithWait } from '../packages/core/src/core.ts';
 import { acquireWriterLease, writerLockPathFor } from '../packages/core/src/writer-lease.ts';
 import { cliEntry, repoRoot, runCli } from './cli-test-helpers.mjs';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
@@ -32,7 +32,7 @@ const NONCE = 'obq-7f3c9a2e-4b1d-8e5f-unique';
 const FIXTURE_NOW_MS = Date.parse('2026-08-11T10:00:10Z');
 
 function tempHome(prefix) {
-  const home = mkdtempSync(join(tmpdir(), prefix));
+  const home = makeTempDir(prefix);
   mkdirSync(join(home, '.claude'), { recursive: true });
   return home;
 }
@@ -222,7 +222,7 @@ test('unknown invocation marks nothing and leaves results unchanged', () => {
 });
 
 test('cli --search --nonce marks the invoking session end to end', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-invoking-home-'));
+  const home = makeTempDir('obelisk-invoking-home-');
   const projectDir = join(home, '.claude', 'projects', '-tmp-invoking');
   mkdirSync(projectDir, { recursive: true });
   const nonce = 'obq-e2e-91c2-live-invocation';
@@ -269,7 +269,7 @@ test('wait helper skips the recovery build and poll on an immediate hit', () => 
 });
 
 test('wait helper re-resolves after the recovery build publishes the nonce', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'obelisk-invoking-build-'));
+  const dir = makeTempDir('obelisk-invoking-build-');
   const dbPath = join(dir, 'obelisk.sqlite');
   const seed = new DatabaseSync(dbPath);
   seed.exec(SCHEMA);
@@ -299,7 +299,7 @@ test('wait helper never runs the recovery build on an uninitialized index', () =
   // Schema setup under a fresh daemon heartbeat stays read-only (ADR 0006):
   // with only index_state present, the carve-out build must not run; the poll
   // fallback resolves honest null.
-  const dir = mkdtempSync(join(tmpdir(), 'obelisk-invoking-noschema-'));
+  const dir = makeTempDir('obelisk-invoking-noschema-');
   const dbPath = join(dir, 'obelisk.sqlite');
   const seed = new DatabaseSync(dbPath);
   seed.exec('CREATE TABLE index_state (jsonl_path TEXT PRIMARY KEY, mtime REAL, lines_processed INTEGER)');
@@ -320,7 +320,7 @@ test('wait helper never runs the recovery build on an uninitialized index', () =
 });
 
 test('wait helper returns null within the cap when the nonce never appears', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'obelisk-invoking-timeout-'));
+  const dir = makeTempDir('obelisk-invoking-timeout-');
   const dbPath = join(dir, 'obelisk.sqlite');
   const seed = new DatabaseSync(dbPath);
   seed.exec(SCHEMA);

--- a/tests/kimi-parse.test.mjs
+++ b/tests/kimi-parse.test.mjs
@@ -1,12 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { createKimiProvider } from '../packages/core/src/providers/kimi.ts';
 import { assembleSessionDetail } from '../packages/core/src/session-detail.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 function drain(gen) {
   const values = [];
@@ -19,7 +19,7 @@ function drain(gen) {
 }
 
 function writeKimiFixture() {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-kimi-'));
+  const root = makeTempDir('obelisk-kimi-');
   const sessionDir = join(root, 'sessions', 'workspace-1', 'session-native-1');
   const mainDir = join(sessionDir, 'agents', 'main');
   const childDir = join(sessionDir, 'agents', 'agent-7');
@@ -146,7 +146,7 @@ test('kimi provider ignores a torn final wire line until it is completed', () =>
 });
 
 test('kimi provider normalizes think parts and drops empty thinking placeholders', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-kimi-think-'));
+  const root = makeTempDir('obelisk-kimi-think-');
   const sessionDir = join(root, 'sessions', 'workspace-1', 'session-think-1');
   const mainDir = join(sessionDir, 'agents', 'main');
   const wirePath = join(mainDir, 'wire.jsonl');
@@ -192,7 +192,7 @@ test('kimi provider normalizes think parts and drops empty thinking placeholders
 });
 
 test('kimi provider replays clear and undo markers with Kimi transcript semantics', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-kimi-undo-'));
+  const root = makeTempDir('obelisk-kimi-undo-');
   const sessionDir = join(root, 'sessions', 'workspace-1', 'session-undo-1');
   const mainDir = join(sessionDir, 'agents', 'main');
   mkdirSync(mainDir, { recursive: true });
@@ -224,7 +224,7 @@ test('kimi provider replays clear and undo markers with Kimi transcript semantic
 });
 
 test('kimi provider scopes changed-path discovery to one session and bypasses an unchanged cursor', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-kimi-changed-path-'));
+  const root = makeTempDir('obelisk-kimi-changed-path-');
   const firstDir = join(root, 'sessions', 'workspace-1', 'session-1');
   const secondDir = join(root, 'sessions', 'workspace-1', 'session-2');
   for (const sessionDir of [firstDir, secondDir]) {
@@ -245,7 +245,7 @@ test('kimi provider scopes changed-path discovery to one session and bypasses an
 });
 
 test('kimi provider presents user-slash activations as real user prompts', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-kimi-user-slash-'));
+  const root = makeTempDir('obelisk-kimi-user-slash-');
   const sessionDir = join(root, 'sessions', 'workspace-1', 'session-user-slash-1');
   const mainDir = join(sessionDir, 'agents', 'main');
   mkdirSync(mainDir, { recursive: true });
@@ -295,7 +295,7 @@ test('kimi provider presents user-slash activations as real user prompts', () =>
 });
 
 test('kimi provider maps protocol-1.0 embedded tool calls and results', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-kimi-legacy-tools-'));
+  const root = makeTempDir('obelisk-kimi-legacy-tools-');
   const sessionDir = join(root, 'sessions', 'workspace-1', 'session-tools-1');
   const mainDir = join(sessionDir, 'agents', 'main');
   mkdirSync(mainDir, { recursive: true });

--- a/tests/kimi-runtime.test.mjs
+++ b/tests/kimi-runtime.test.mjs
@@ -1,13 +1,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
+import { makeTempDir } from './temp-dirs.mjs';
 
 test('passive-pull runtime indexes Kimi sessions from the default home', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-kimi-runtime-'));
+  const home = makeTempDir('obelisk-kimi-runtime-');
   const sessionDir = join(home, '.kimi-code', 'sessions', 'workspace-1', 'session-runtime-1');
   const mainDir = join(sessionDir, 'agents', 'main');
   mkdirSync(mainDir, { recursive: true });

--- a/tests/persist.test.mjs
+++ b/tests/persist.test.mjs
@@ -5,20 +5,20 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { parse } from '../packages/core/src/providers/claude.ts';
 import { persist } from '../packages/core/src/persist.ts';
 import { storedProviderCursor } from '../packages/core/src/provider-indexing.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
 const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
 
 function fixtureUnit() {
-  const dir = mkdtempSync(join(tmpdir(), 'obelisk-persist-'));
+  const dir = makeTempDir('obelisk-persist-');
   const path = join(dir, 'sid-p.jsonl');
   const lines = [
     { type: 'ai-title', aiTitle: 'Persist Session' },

--- a/tests/pi-parse.test.mjs
+++ b/tests/pi-parse.test.mjs
@@ -2,7 +2,6 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   renameSync,
   statSync,
@@ -11,7 +10,6 @@ import {
   utimesSync,
   writeFileSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
@@ -24,6 +22,7 @@ import { createProviderRegistry } from '../packages/core/src/providers/registry.
 import { assembleSessionDetail } from '../packages/core/src/session-detail.ts';
 import { persist } from '../packages/core/src/persist.ts';
 import { createQueryApi } from '../packages/core/src/query.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
 const FIXTURES = new URL('./fixtures/pi/', import.meta.url);
@@ -43,7 +42,7 @@ function fixture(name) {
 }
 
 function writeSession(content, { root, relativePath = 'project/session.jsonl' } = {}) {
-  const sessionRoot = root ?? mkdtempSync(join(tmpdir(), 'obelisk-pi-'));
+  const sessionRoot = root ?? makeTempDir('obelisk-pi-');
   const path = join(sessionRoot, relativePath);
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, content);
@@ -83,7 +82,7 @@ function userEntry(id, parentId, text, timestamp = '2026-08-02T10:00:01.000Z') {
 }
 
 test('Pi root resolution follows official precedence and rejects ambiguous relative roots', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-home-'));
+  const home = makeTempDir('obelisk-pi-home-');
   const projectCwd = join(home, 'project');
   mkdirSync(projectCwd, { recursive: true });
   assert.deepEqual(resolveDefaultPiRoot({ env: {}, homeDir: home, cwd: projectCwd }), {
@@ -154,7 +153,7 @@ test('Pi root resolution follows official precedence and rejects ambiguous relat
 });
 
 test('Pi project settings override global sessionDir using the official launch cwd', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-project-settings-'));
+  const home = makeTempDir('obelisk-pi-project-settings-');
   const agentDir = join(home, 'agent');
   const projectCwd = join(home, 'project');
   const globalSessions = join(home, 'global-sessions');
@@ -189,7 +188,7 @@ test('Pi project settings override global sessionDir using the official launch c
 });
 
 test('malformed Pi settings fall back to the remaining official settings scope', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-malformed-settings-'));
+  const home = makeTempDir('obelisk-pi-malformed-settings-');
   const agentDir = join(home, 'agent');
   const projectCwd = join(home, 'project');
   const projectSettingsDir = join(projectCwd, '.pi');
@@ -236,7 +235,7 @@ test('malformed Pi settings fall back to the remaining official settings scope',
 });
 
 test('non-string Pi sessionDir values never select the default corpus', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-invalid-settings-'));
+  const home = makeTempDir('obelisk-pi-invalid-settings-');
   const agentDir = join(home, 'agent');
   const projectCwd = join(home, 'project');
   mkdirSync(join(projectCwd, '.pi'), { recursive: true });
@@ -256,7 +255,7 @@ test('non-string Pi sessionDir values never select the default corpus', () => {
 });
 
 test('Pi discovery never certifies an invalid session root as empty', () => {
-  const parent = mkdtempSync(join(tmpdir(), 'obelisk-pi-invalid-root-'));
+  const parent = makeTempDir('obelisk-pi-invalid-root-');
   const root = join(parent, 'sessions');
   writeFileSync(root, 'not a directory');
   let status = 'unknown';
@@ -1735,7 +1734,7 @@ test('missing parents form official Pi orphan roots without exposing inactive br
 });
 
 test('discovery deduplicates identical same-project copies and rejects divergent copies', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-pi-copies-'));
+  const root = makeTempDir('obelisk-pi-copies-');
   const original = fixture('tool-session.jsonl');
   writeSession(original, { root, relativePath: 'a/session.jsonl' });
   writeSession(original, { root, relativePath: 'b/session.jsonl' });
@@ -1764,7 +1763,7 @@ test('discovery follows readable Pi JSONL file symlinks without retracting prove
   const provider = createPiProvider({ rootDir: written.root });
   const original = provider.discover({ lastCursor: () => null })[0];
   const parsed = drain(provider.parse(original, null));
-  const targetDir = mkdtempSync(join(tmpdir(), 'obelisk-pi-symlink-target-'));
+  const targetDir = makeTempDir('obelisk-pi-symlink-target-');
   const target = join(targetDir, 'session.jsonl');
   renameSync(written.path, target);
   symlinkSync(target, written.path);
@@ -1789,7 +1788,7 @@ test('discovery follows readable Pi JSONL file symlinks without retracting prove
 });
 
 test('a malformed Pi file does not force unrelated unchanged sessions to reparse', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-pi-bad-file-scope-'));
+  const root = makeTempDir('obelisk-pi-bad-file-scope-');
   const damaged = writeSession(jsonl([
     header({ id: 'damaged-session' }),
     userEntry('damaged-user', null, 'damaged source'),
@@ -1848,7 +1847,7 @@ test('a moved session with an unreadable identity cannot retract its last good s
 });
 
 test('a bad selected copy forces an unchanged valid duplicate to refresh provenance', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-pi-bad-copy-'));
+  const root = makeTempDir('obelisk-pi-bad-copy-');
   const content = fixture('tool-session.jsonl');
   const second = writeSession(content, { root, relativePath: 'b/session.jsonl' });
   const provider = createPiProvider({ rootDir: root });
@@ -1884,7 +1883,7 @@ test('a bad selected copy forces an unchanged valid duplicate to refresh provena
 });
 
 test('the same official project-local session id remains distinct across cwd namespaces', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-pi-project-ids-'));
+  const root = makeTempDir('obelisk-pi-project-ids-');
   const firstHeader = header({ id: 'shared-custom-id', cwd: '/tmp/pi-project-a' });
   const secondHeader = header({ id: 'shared-custom-id', cwd: '/tmp/pi-project-b' });
   writeSession(jsonl([
@@ -1916,7 +1915,7 @@ test('the same official project-local session id remains distinct across cwd nam
 });
 
 test('identity migration retracts a legacy row attached to a non-selected identical copy', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-pi-identity-migration-'));
+  const root = makeTempDir('obelisk-pi-identity-migration-');
   const content = fixture('tool-session.jsonl');
   const first = writeSession(content, { root, relativePath: 'a/session.jsonl' });
   const second = writeSession(content, { root, relativePath: 'b/session.jsonl' });
@@ -1943,7 +1942,7 @@ test('identity migration retracts a legacy row attached to a non-selected identi
 });
 
 test('unlinking a deduplicated Pi copy reparses the surviving source instead of deleting the session', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-pi-copy-move-'));
+  const root = makeTempDir('obelisk-pi-copy-move-');
   const content = fixture('tool-session.jsonl');
   const first = writeSession(content, { root, relativePath: 'a/session.jsonl' });
   const second = writeSession(content, { root, relativePath: 'b/session.jsonl' });
@@ -1967,7 +1966,7 @@ test('unlinking a deduplicated Pi copy reparses the surviving source instead of 
 });
 
 test('replacing one Pi copy preserves the original identity when another copy survives', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-pi-copy-replace-'));
+  const root = makeTempDir('obelisk-pi-copy-replace-');
   const content = fixture('tool-session.jsonl');
   const first = writeSession(content, { root, relativePath: 'a/session.jsonl' });
   const second = writeSession(content, { root, relativePath: 'b/session.jsonl' });
@@ -2055,7 +2054,7 @@ test('Pi snapshot cursors detect same-identity and replacement writes that prese
 });
 
 test('incomplete Pi inventories never infer deletion from changed paths', () => {
-  const parent = mkdtempSync(join(tmpdir(), 'obelisk-pi-incomplete-'));
+  const parent = makeTempDir('obelisk-pi-incomplete-');
   const unreadableRoot = join(parent, 'sessions');
   writeFileSync(unreadableRoot, 'not a directory');
   const indexedPath = join(unreadableRoot, 'project', 'session.jsonl');

--- a/tests/pi-randomized-differential.test.mjs
+++ b/tests/pi-randomized-differential.test.mjs
@@ -1,7 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import { createPiProvider } from '../packages/core/src/providers/pi.ts';
@@ -14,6 +13,7 @@ import {
   pi083LeafId,
   projectCanonicalEvidence,
 } from './fixtures/pi/pi-0.83.0-context-oracle.mjs';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const CASES = 512;
 const SEED = 0x5eedc0de;
@@ -167,7 +167,7 @@ function createCase(random, caseIndex, totals) {
 test('fixed-seed randomized differential matches vendored Pi 0.83.0 context oracles', () => {
   assert.equal(PI_CONTEXT_ORACLE_VERSION, '0.83.0');
   const random = randomGenerator(SEED);
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-pi-randomized-differential-'));
+  const root = makeTempDir('obelisk-pi-randomized-differential-');
   const generated = [];
   const totals = {
     cases: CASES,

--- a/tests/pi-runtime.test.mjs
+++ b/tests/pi-runtime.test.mjs
@@ -1,7 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
@@ -9,9 +8,10 @@ import { DatabaseSync } from 'node:sqlite';
 
 import { piSessionId } from '../packages/core/src/providers/pi.ts';
 import { runCli } from './cli-test-helpers.mjs';
+import { makeTempDir } from './temp-dirs.mjs';
 
 test('passive-pull runtime indexes Pi sessions from the default home', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-runtime-'));
+  const home = makeTempDir('obelisk-pi-runtime-');
   const sessionPath = join(
     home,
     '.pi',
@@ -55,7 +55,7 @@ test('passive-pull runtime indexes Pi sessions from the default home', () => {
 });
 
 test('passive-pull runtime honors the same persisted Pi root as the app', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-custom-runtime-'));
+  const home = makeTempDir('obelisk-pi-custom-runtime-');
   const defaultRoot = join(home, '.pi', 'agent', 'sessions');
   const customRoot = join(home, 'custom-pi-sessions');
   const sessionPath = join(customRoot, '--tmp-pi-real-tool--', 'session.jsonl');
@@ -95,7 +95,7 @@ test('passive-pull runtime honors the same persisted Pi root as the app', () => 
 
 test('passive CLI operations report an incomplete Pi inventory without hiding partial results', () => {
   for (const command of ['search', 'query', 'attune']) {
-    const home = mkdtempSync(join(tmpdir(), `obelisk-pi-partial-${command}-`));
+    const home = makeTempDir(`obelisk-pi-partial-${command}-`);
     const piRoot = join(home, '.pi', 'agent', 'sessions');
     mkdirSync(dirname(piRoot), { recursive: true });
     writeFileSync(piRoot, 'not a directory');
@@ -127,7 +127,7 @@ test('passive CLI operations report an incomplete Pi inventory without hiding pa
 });
 
 test('CLI force rebuild rejects a structurally invalid Pi snapshot and preserves the last good index', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-cli-force-'));
+  const home = makeTempDir('obelisk-pi-cli-force-');
   const sessionPath = join(home, '.pi', 'agent', 'sessions', 'project', 'session.jsonl');
   mkdirSync(dirname(sessionPath), { recursive: true });
   const fixture = readFileSync(new URL('./fixtures/pi/tool-session.jsonl', import.meta.url), 'utf8');
@@ -173,7 +173,7 @@ test('CLI force rebuild rejects a structurally invalid Pi snapshot and preserves
 });
 
 test('CLI force rebuild rejects an incomplete provider inventory and preserves the last good index', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-cli-incomplete-force-'));
+  const home = makeTempDir('obelisk-pi-cli-incomplete-force-');
   const piRoot = join(home, '.pi', 'agent', 'sessions');
   const sessionPath = join(piRoot, 'project', 'session.jsonl');
   mkdirSync(dirname(sessionPath), { recursive: true });
@@ -213,7 +213,7 @@ test('CLI force rebuild rejects an incomplete provider inventory and preserves t
 });
 
 test('malformed official Pi settings use Pi 0.83 default-root fallback', () => {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-pi-cli-settings-'));
+  const home = makeTempDir('obelisk-pi-cli-settings-');
   const agentDir = join(home, '.pi', 'agent');
   const customRoot = join(home, 'custom-pi-sessions');
   const customPath = join(customRoot, 'project', 'custom.jsonl');

--- a/tests/provider-inventory.test.mjs
+++ b/tests/provider-inventory.test.mjs
@@ -1,12 +1,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { createClaudeProvider } from '../packages/core/src/providers/claude.ts';
 import { createCodexProvider } from '../packages/core/src/providers/codex.ts';
 import { createKimiProvider } from '../packages/core/src/providers/kimi.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const providers = [
   ['claude', createClaudeProvider, 'projects'],
@@ -16,7 +17,7 @@ const providers = [
 
 for (const [name, createProvider, inventoryDir] of providers) {
   test(`${name} reports directory enumeration failures`, () => {
-    const root = mkdtempSync(join(tmpdir(), `obelisk-${name}-inventory-`));
+    const root = makeTempDir(`obelisk-${name}-inventory-`);
     const sourcePath = join(root, inventoryDir);
     writeFileSync(sourcePath, 'not a directory');
     let issue;
@@ -34,7 +35,7 @@ for (const [name, createProvider, inventoryDir] of providers) {
   });
 
   test(`${name} treats a missing source as incomplete only when prior sessions exist`, () => {
-    const root = join(mkdtempSync(join(tmpdir(), `obelisk-${name}-missing-`)), 'absent');
+    const root = join(makeTempDir(`obelisk-${name}-missing-`), 'absent');
     const provider = createProvider({ rootDir: root });
     const issues = [];
     const context = {

--- a/tests/provider-session-detail.test.mjs
+++ b/tests/provider-session-detail.test.mjs
@@ -1,18 +1,18 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
 import { assembleSessionDetail } from '../packages/core/src/session-detail.ts';
 import { persist } from '../packages/core/src/persist.ts';
 import { parse as parseCodex } from '../packages/core/src/providers/codex.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
 
 function writeCodexFixture(lines) {
-  const dir = mkdtempSync(join(tmpdir(), 'obelisk-provider-detail-'));
+  const dir = makeTempDir('obelisk-provider-detail-');
   const path = join(dir, 'rollout.jsonl');
   writeFileSync(path, `${lines.map(line => JSON.stringify(line)).join('\n')}\n`);
   return path;

--- a/tests/provider-settings.test.mjs
+++ b/tests/provider-settings.test.mjs
@@ -1,7 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import {
@@ -14,6 +13,7 @@ import {
   resolveProviderRoots,
   setPersistedSetting,
 } from '../app/src/main/provider-settings.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 function provider(id, defaultRoot, color, descriptor = {}) {
   return {
@@ -172,7 +172,7 @@ test('relative provider roots never depend on the Obelisk process cwd', () => {
 });
 
 test('an invalid persisted root disables that provider instead of selecting its default', () => {
-  const rawDir = mkdtempSync(join(tmpdir(), 'obelisk-disabled-provider-'));
+  const rawDir = makeTempDir('obelisk-disabled-provider-');
   const rawPath = join(rawDir, 'session.jsonl');
   writeFileSync(rawPath, '{"uuid":"raw-message","message":{"content":"preserved"}}\n');
   const runtime = createConfiguredBuiltinProviderRuntime({
@@ -226,7 +226,7 @@ test('malformed provider root containers cannot select defaults and are repairab
 });
 
 test('settings reader rejects malformed provider root containers', () => {
-  const directory = mkdtempSync(join(tmpdir(), 'obelisk-provider-settings-'));
+  const directory = makeTempDir('obelisk-provider-settings-');
   const settingsPath = join(directory, 'settings.json');
   try {
     for (const providerRoots of [[], 'invalid']) {

--- a/tests/publish-skill-layout.test.mjs
+++ b/tests/publish-skill-layout.test.mjs
@@ -4,21 +4,20 @@ import { spawnSync } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   readdirSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const stageScript = join(repoRoot, 'packaging', 'stage-skill-repo.sh');
 
 test('skill release staging produces the npx skills repository layout', () => {
-  const root = mkdtempSync(join(tmpdir(), 'obelisk-skill-release-'));
+  const root = makeTempDir('obelisk-skill-release-');
   const artifact = join(root, 'artifact');
   const target = join(root, 'repo');
   try {

--- a/tests/query.test.mjs
+++ b/tests/query.test.mjs
@@ -1,11 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { createQueryApi, createAttuneApi } from '../packages/core/src/query.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
@@ -542,7 +542,7 @@ test('attune api exposes only memory mutation helpers', () => {
 });
 
 test('remember stores absolute project-relative memory path', () => {
-  const projectDir = mkdtempSync(join(tmpdir(), 'obelisk-memory-project-'));
+  const projectDir = makeTempDir('obelisk-memory-project-');
   const memoryDir = join(projectDir, '.obelisk', 'memories');
   mkdirSync(memoryDir, { recursive: true });
   const memoryPath = join(memoryDir, 'decision.md');
@@ -562,7 +562,7 @@ test('remember stores absolute project-relative memory path', () => {
 });
 
 test('remember updates FTS recall for the registered memory immediately', () => {
-  const projectDir = mkdtempSync(join(tmpdir(), 'obelisk-memory-project-'));
+  const projectDir = makeTempDir('obelisk-memory-project-');
   const memoryDir = join(projectDir, '.obelisk', 'memories');
   mkdirSync(memoryDir, { recursive: true });
   const memoryPath = join(memoryDir, 'query-plan.md');
@@ -604,7 +604,7 @@ test('forget soft-deletes memory records from active recall', () => {
 });
 
 test('remember requires English summaries', () => {
-  const projectDir = mkdtempSync(join(tmpdir(), 'obelisk-memory-project-'));
+  const projectDir = makeTempDir('obelisk-memory-project-');
   const memoryDir = join(projectDir, '.obelisk', 'memories');
   mkdirSync(memoryDir, { recursive: true });
   const memoryPath = join(memoryDir, 'decision.md');
@@ -625,7 +625,7 @@ test('remember requires English summaries', () => {
 });
 
 test('remember rejects missing memory files', () => {
-  const projectDir = mkdtempSync(join(tmpdir(), 'obelisk-memory-project-'));
+  const projectDir = makeTempDir('obelisk-memory-project-');
   const db = memoryDb({ projectPath: projectDir });
   const api = createAttuneApi(db);
 

--- a/tests/runtime-cli-envelope.test.mjs
+++ b/tests/runtime-cli-envelope.test.mjs
@@ -14,14 +14,14 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { runCli as runRuntime } from './cli-test-helpers.mjs';
+import { makeTempDir } from './temp-dirs.mjs';
 
 function tempHome() {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-cli-envelope-'));
+  const home = makeTempDir('obelisk-cli-envelope-');
   mkdirSync(join(home, '.claude'), { recursive: true });
   return home;
 }

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1,17 +1,17 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdtempSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join, normalize } from 'node:path';
 
 import { runCli as runRuntime } from './cli-test-helpers.mjs';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
 
 function tempHome() {
-  const home = mkdtempSync(join(tmpdir(), 'obelisk-runtime-home-'));
+  const home = makeTempDir('obelisk-runtime-home-');
   mkdirSync(join(home, '.claude'), { recursive: true });
   return home;
 }

--- a/tests/temp-dirs.mjs
+++ b/tests/temp-dirs.mjs
@@ -1,0 +1,25 @@
+// Tests create throwaway directories with mkdtempSync but never deleted them,
+// leaking hundreds of MB into $TMPDIR over repeated runs (this caused ENOSPC).
+// makeTempDir records every directory it creates and removes them all when the
+// test-file process exits (node --test spawns one process per file).
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const created = new Set();
+
+process.on('exit', () => {
+  for (const dir of created) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup: keep going so one bad dir does not skip the rest.
+    }
+  }
+});
+
+export function makeTempDir(prefix) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  created.add(dir);
+  return dir;
+}

--- a/tests/write-transaction.test.mjs
+++ b/tests/write-transaction.test.mjs
@@ -1,12 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { nodeSqliteTransactionAdapter, runWriteTransaction } from '../packages/core/src/tx.ts';
 import { hasUnusableTransaction, isBeginBusyFailure, isRetryableWriteFailure } from '../packages/core/src/write-coordinator.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
@@ -124,7 +123,7 @@ test('node:sqlite generic error codes preserve BUSY classification from the mess
 });
 
 test('a real node:sqlite BEGIN lock is classified as a deferrable BUSY', () => {
-  const dbPath = join(mkdtempSync(join(tmpdir(), 'obelisk-node-sqlite-busy-')), 'index.sqlite');
+  const dbPath = join(makeTempDir('obelisk-node-sqlite-busy-'), 'index.sqlite');
   const holder = new DatabaseSync(dbPath);
   const contender = new DatabaseSync(dbPath);
   holder.exec('PRAGMA busy_timeout=0; CREATE TABLE test (value TEXT); BEGIN IMMEDIATE');

--- a/tests/writer-lease.test.mjs
+++ b/tests/writer-lease.test.mjs
@@ -1,17 +1,16 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { acquireWriterLease } from '../packages/core/src/writer-lease.ts';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
 
 test('a writer lease excludes another writer until it is released', () => {
-  const lockPath = join(mkdtempSync(join(tmpdir(), 'obelisk-writer-lease-')), 'writer.lock.sqlite');
+  const lockPath = join(makeTempDir('obelisk-writer-lease-'), 'writer.lock.sqlite');
   const openDb = path => new DatabaseSync(path);
 
   const first = acquireWriterLease({ lockPath, openDb });


### PR DESCRIPTION
## Summary

Tests created `mkdtemp` homes under `$TMPDIR` and never deleted them — ~2800 `obelisk-*` dirs (~500 MB) accumulated on the maintainer machine, causing ENOSPC twice during this work.

- New `tests/temp-dirs.mjs`: `makeTempDir(prefix)` registers every created dir and `rmSync`s them all in a `process.on('exit')` handler (correct because `node --test` runs one process per test file).
- 135 call sites converted across 34 files, including 12 non-`mkdtemp` leaks in `app-main-settings.test.mjs` (`join(tmpdir(), ...)` + `mkdirSync`). No test logic, assertions, or prefixes changed.
- One deliberate non-conversion: a pure path string in `provider-inventory.test.mjs` that never creates a directory.

Stacked on #50 (it touches `tests/invoking-session.test.mjs`); retarget to `main` after #50 merges.

## Test plan

- `npm test`: 449/449 pass; `npm run typecheck` clean; `npx eslint tests/` clean (4 pre-existing warnings unchanged).
- After the full suite, zero new `obelisk-*` dirs in `$TMPDIR` (verified with `find -newermt`).

Known limit: killing the test runner mid-flight (SIGINT/SIGKILL) bypasses the exit handler and can still orphan that run's dirs.