### PR TITLE
fix(core): reliable workflow-to-tool-call linking

### DIFF
--- a/app/src/main/indexer.ts
+++ b/app/src/main/indexer.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import { createBuiltinProviderRegistry } from '../../../packages/core/src/providers/builtins.ts';
+import { healWorkflowParentLinks } from '../../../packages/core/src/indexer.ts';
 import type { ProviderRegistry } from '../../../packages/core/src/providers/registry.ts';
 import {
   createConfiguredBuiltinProviderRuntime,
@@ -415,6 +416,7 @@ function buildIndex({
       };
       const finalize = (providerResult) => {
         refreshSessionProjectPaths(db);
+        healWorkflowParentLinks(db);
         if (messageFtsTriggersDropped) installSchema(db, schemaPath);
         ftsRebuilt = ensureFtsReady(db, { force });
         writeIndexMarker(db, '__last_build__');

--- a/packages/core/src/indexer.ts
+++ b/packages/core/src/indexer.ts
@@ -18,7 +18,7 @@ import {
 } from './provider-settings.ts';
 import { coreSchemaNeedsMigration } from './schema-migrations.ts';
 import type { ProviderRegistry } from './providers/registry.ts';
-import type { NodeSqliteDb, SqliteRow } from './sqlite-types.ts';
+import type { NodeSqliteDb, SqliteDb, SqliteRow } from './sqlite-types.ts';
 
 interface SkippedFile {
   provider: string;
@@ -67,6 +67,39 @@ function refreshSessionProjectPaths(db: NodeSqliteDb): void {
     const projectPath = inferProjectPath(session.project, cwds);
     if (projectPath) update.run(projectPath, session.id);
   }
+}
+
+// A workflow unit links to its parent Workflow tool call by matching the unique
+// run id in the tool_result text — but the run json can reach the index before
+// that tool_result lands in the main transcript, leaving parent_tool_use_id
+// null with no later re-parse to fix it (the run json's mtime no longer moves).
+// Once every unit is persisted the tool_results table holds the result text, so
+// the match can be completed in SQL. Runs at every finalize: missed links heal
+// on the next refresh instead of waiting for a force rebuild. instr() is exact
+// substring matching (no LIKE wildcards); unresolvable rows stay null.
+function healWorkflowParentLinks(db: SqliteDb): void {
+  db.prepare(`
+    UPDATE workflows
+    SET parent_tool_use_id = (
+      SELECT tr.tool_use_id
+      FROM tool_results tr
+      JOIN tool_calls tc ON tc.id = tr.tool_use_id AND tc.session_id = tr.session_id
+      WHERE tr.session_id = workflows.session_id
+        AND tc.name = 'Workflow'
+        AND instr(tr.content, workflows.run_id) > 0
+      ORDER BY tr.rowid
+      LIMIT 1
+    )
+    WHERE parent_tool_use_id IS NULL
+      AND EXISTS (
+        SELECT 1
+        FROM tool_results tr
+        JOIN tool_calls tc ON tc.id = tr.tool_use_id AND tc.session_id = tr.session_id
+        WHERE tr.session_id = workflows.session_id
+          AND tc.name = 'Workflow'
+          AND instr(tr.content, workflows.run_id) > 0
+      )
+  `).run();
 }
 
 const BUILD_DEBOUNCE_MS = 30000;
@@ -203,6 +236,7 @@ function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwne
               plan: providerPlan,
             });
             refreshSessionProjectPaths(db);
+            healWorkflowParentLinks(db);
             db.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
             rebuildMemoryFts(db);
             db.prepare("INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES ('__last_build__', ?, 0)").run(Date.now());
@@ -288,6 +322,7 @@ function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwne
       try {
         runRetryableWriteTransaction(txDb, () => {
           refreshSessionProjectPaths(db);
+          healWorkflowParentLinks(db);
           db.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
           rebuildMemoryFts(db);
           db.prepare("INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES ('__last_build__', ?, 0)").run(Date.now());
@@ -323,4 +358,4 @@ function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwne
   }
 }
 
-export { buildIndex, ensureReadableSchema, inferProjectPath, refreshSessionProjectPaths, shouldSkipBuild };
+export { buildIndex, ensureReadableSchema, healWorkflowParentLinks, inferProjectPath, refreshSessionProjectPaths, shouldSkipBuild };

--- a/packages/core/src/providers/claude.ts
+++ b/packages/core/src/providers/claude.ts
@@ -180,7 +180,6 @@ function toolResultText(content: unknown): string {
 function workflowParentToolUseId(
   transcriptPath: string,
   runId: string,
-  workflowName: string | null,
 ): string | null {
   if (!existsSync(transcriptPath)) return null;
   const workflowToolIds = new Set<string>();
@@ -202,7 +201,7 @@ function workflowParentToolUseId(
     for (const block of content) {
       if (block?.type !== 'tool_result' || !workflowToolIds.has(block.tool_use_id)) continue;
       const text = toolResultText(block.content);
-      if (!text.includes(runId) && !(workflowName && text.includes(workflowName))) continue;
+      if (!text.includes(runId)) continue;
       parentToolUseId = block.tool_use_id;
       return false;
     }
@@ -226,7 +225,6 @@ function* parseWorkflow(unit: IndexUnit): Generator<TranscriptRecord, Cursor> {
     parent_tool_use_id: workflowParentToolUseId(
       meta.mainTranscriptPath,
       workflow.runId,
-      workflow.workflowName || null,
     ),
     task_id: workflow.taskId || null,
     script: workflow.script || null,

--- a/tests/claude-parse.test.mjs
+++ b/tests/claude-parse.test.mjs
@@ -162,3 +162,49 @@ test('claude provider emits workflow artifacts with an explicit canonical tool e
   assert.deepEqual(persistedDetail, detail);
   db.close();
 });
+
+test('claude links repeated workflow names by unique run id', () => {
+  const root = makeTempDir('obelisk-claude-workflow-link-');
+  const projectDir = join(root, 'projects', '-proj');
+  const workflowDir = join(projectDir, 'sid-workflow', 'workflows');
+  mkdirSync(workflowDir, { recursive: true });
+  writeFileSync(join(projectDir, 'sid-workflow.jsonl'), [
+    {
+      uuid: 'assistant-old', type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'old-call', name: 'Workflow', input: {} }] },
+    },
+    {
+      uuid: 'old-result', type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'old-call', content: 'Run ID: old-run\nSummary: same-name' }] },
+    },
+    {
+      uuid: 'assistant-new', type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'new-call', name: 'Workflow', input: {} }] },
+    },
+    {
+      uuid: 'new-result', type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'new-call', content: 'Run ID: new-run\nSummary: same-name' }] },
+    },
+  ].map(line => JSON.stringify(line)).join('\n') + '\n');
+  for (const runId of ['old-run', 'new-run']) {
+    writeFileSync(join(workflowDir, `${runId}.json`), JSON.stringify({
+      runId, workflowName: 'same-name', status: 'completed', workflowProgress: [],
+    }));
+  }
+
+  const provider = createClaudeProvider({ rootDir: root });
+  const workflowUnits = provider.discover({ lastCursor: () => null })
+    .filter(unit => unit.meta?.kind === 'workflow');
+  assert.equal(workflowUnits.length, 2);
+
+  // Both runs share the workflow name, so name-based matching would attach the
+  // newer run to the older call; each run must link by its unique run id.
+  const parentByRun = new Map();
+  for (const unit of workflowUnits) {
+    const records = drain(provider.parse(unit, null)).values;
+    const workflow = records.find(record => record.kind === 'workflow');
+    parentByRun.set(workflow.run_id, workflow.parent_tool_use_id);
+  }
+  assert.equal(parentByRun.get('old-run'), 'old-call');
+  assert.equal(parentByRun.get('new-run'), 'new-call');
+});

--- a/tests/indexer.test.mjs
+++ b/tests/indexer.test.mjs
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 
-import { inferProjectPath, refreshSessionProjectPaths, shouldSkipBuild } from '../packages/core/src/indexer.ts';
+import { healWorkflowParentLinks, inferProjectPath, refreshSessionProjectPaths, shouldSkipBuild } from '../packages/core/src/indexer.ts';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
@@ -82,5 +82,52 @@ test('shouldSkipBuild treats a fresh heartbeat alone as daemon write ownership',
 
   assert.equal(shouldSkipBuild(db, { now: 110000 }).skip, false);
   assert.equal(shouldSkipBuild(db, { now: 200000 }).skip, false);
+  db.close();
+});
+
+test('healWorkflowParentLinks links null-parent workflows by unique run id', () => {
+  const db = new DatabaseSync(':memory:');
+  db.exec(`
+    CREATE TABLE tool_calls (
+      id TEXT PRIMARY KEY, message_uuid TEXT, session_id TEXT,
+      name TEXT, presentation TEXT, input_json TEXT, file_path TEXT
+    );
+    CREATE TABLE tool_results (
+      tool_use_id TEXT PRIMARY KEY, message_uuid TEXT, session_id TEXT,
+      content TEXT, file_path TEXT, is_error INTEGER DEFAULT 0
+    );
+    CREATE TABLE workflows (
+      run_id TEXT PRIMARY KEY, session_id TEXT, parent_tool_use_id TEXT, task_id TEXT,
+      script TEXT, result_json TEXT, timestamp TEXT, agent_count INTEGER DEFAULT 0,
+      duration_ms INTEGER, total_tokens INTEGER, status TEXT, workflow_name TEXT
+    );
+  `);
+  const addCall = db.prepare('INSERT INTO tool_calls (id, session_id, name) VALUES (?, ?, ?)');
+  const addResult = db.prepare('INSERT INTO tool_results (tool_use_id, session_id, content) VALUES (?, ?, ?)');
+  const addWorkflow = db.prepare('INSERT INTO workflows (run_id, session_id, parent_tool_use_id, workflow_name) VALUES (?, ?, ?, ?)');
+  // Two same-name runs: only the unique run id may decide the parent.
+  addCall.run('old-call', 'sid-1', 'Workflow');
+  addResult.run('old-call', 'sid-1', 'Run ID: old-run\nSummary: same-name');
+  addCall.run('new-call', 'sid-1', 'Workflow');
+  addResult.run('new-call', 'sid-1', 'Run ID: new-run\nSummary: same-name');
+  addWorkflow.run('old-run', 'sid-1', null, 'same-name');
+  addWorkflow.run('new-run', 'sid-1', null, 'same-name');
+  // Already-linked and unresolvable rows must be left alone.
+  addWorkflow.run('linked-run', 'sid-1', 'existing-call', 'other');
+  addWorkflow.run('orphan-run', 'sid-1', null, 'other');
+  // A non-Workflow tool result mentioning the run id must not match.
+  addCall.run('bash-call', 'sid-1', 'Bash');
+  addResult.run('bash-call', 'sid-1', 'log line mentioning orphan-run');
+  // Cross-session results must not leak into this session's workflows.
+  addCall.run('alien-call', 'sid-2', 'Workflow');
+  addResult.run('alien-call', 'sid-2', 'Run ID: orphan-run');
+
+  healWorkflowParentLinks(db);
+
+  const parentOf = runId => db.prepare('SELECT parent_tool_use_id FROM workflows WHERE run_id=?').get(runId).parent_tool_use_id;
+  assert.equal(parentOf('old-run'), 'old-call');
+  assert.equal(parentOf('new-run'), 'new-call');
+  assert.equal(parentOf('linked-run'), 'existing-call');
+  assert.equal(parentOf('orphan-run'), null);
   db.close();
 });

--- a/tests/workflow-parent-heal.test.mjs
+++ b/tests/workflow-parent-heal.test.mjs
@@ -1,0 +1,69 @@
+// End-to-end regression test for the workflow parent-link race: a workflow run
+// json can be indexed before its Workflow tool_result lands in the main
+// transcript. The workflow unit is then never re-parsed (its file no longer
+// changes), so the finalize-time SQL heal must fill parent_tool_use_id on a
+// later refresh. This drives the real core buildIndex path (the CLI refresh
+// path), which never passes changedPaths.
+//
+// HOME must point at the fixture root BEFORE any core module is imported: the
+// core db path is derived from homedir() at module load time.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { makeTempDir } from './temp-dirs.mjs';
+
+const home = makeTempDir('obelisk-workflow-heal-');
+process.env.HOME = home;
+process.env.USERPROFILE = home;
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require('node:sqlite');
+
+const { buildIndex } = await import('../packages/core/src/indexer.ts');
+const { createClaudeProvider } = await import('../packages/core/src/providers/claude.ts');
+const { createProviderRegistry } = await import('../packages/core/src/providers/registry.ts');
+
+test('a workflow indexed before its tool_result heals its parent link on the next refresh', () => {
+  const claudeDir = join(home, '.claude');
+  const projectDir = join(claudeDir, 'projects', '-proj');
+  const workflowDir = join(projectDir, 'sid-heal', 'workflows');
+  mkdirSync(workflowDir, { recursive: true });
+  const transcriptPath = join(projectDir, 'sid-heal.jsonl');
+  writeFileSync(transcriptPath, [
+    {
+      uuid: 'msg-user', type: 'user', timestamp: '2026-06-10T10:00:00Z',
+      message: { role: 'user', content: 'run the workflow' },
+    },
+    {
+      uuid: 'msg-assistant', type: 'assistant', timestamp: '2026-06-10T10:00:05Z',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'wf-call', name: 'Workflow', input: {} }] },
+    },
+  ].map(line => JSON.stringify(line)).join('\n') + '\n');
+  writeFileSync(join(workflowDir, 'run-1.json'), JSON.stringify({
+    runId: 'run-1', workflowName: 'Review', status: 'running', workflowProgress: [],
+  }));
+
+  const registry = createProviderRegistry([createClaudeProvider({ rootDir: claudeDir })]);
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+
+  const first = buildIndex({ providerRegistry: registry });
+  assert.equal(first.skip, false);
+  const db = new DatabaseSync(dbPath);
+  const parentOf = () => db.prepare('SELECT parent_tool_use_id FROM workflows WHERE run_id=?').get('run-1')?.parent_tool_use_id;
+  // The tool_result has not reached the transcript yet: honest null.
+  assert.equal(parentOf(), null);
+
+  // The tool_result lands only now — the workflow run json does NOT change.
+  appendFileSync(transcriptPath, `${JSON.stringify({
+    uuid: 'msg-result', type: 'user', timestamp: '2026-06-10T10:01:00Z',
+    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'wf-call', content: 'Run ID: run-1\nSummary: done' }] },
+  })}\n`);
+
+  const second = buildIndex({ providerRegistry: registry, ignoreRecentBuild: true });
+  assert.equal(second.skip, false);
+  assert.equal(parentOf(), 'wf-call');
+  db.close();
+});


### PR DESCRIPTION
## What and why

Two related fixes for how Claude workflow runs link to their parent `Workflow` tool call (`workflows.parent_tool_use_id`):

**1. Link by unique run id only.** When a session runs the same workflow name more than once, the workflow-name fallback could attach the newer run to an older Workflow tool call. Matching is now run-id-only; an unresolvable link degrades to an honest null.

**2. Heal missed links at index finalize.** A workflow run json can be indexed before its `Workflow` tool_result lands in the main transcript. The workflow unit is then never re-parsed — its file no longer changes, and the CLI build path never passes `changedPaths`, so the `relationshipChanged` re-parse path never fires there — leaving `parent_tool_use_id` null until a force rebuild. Since `tool_results` holds the result text once every unit is persisted, the run-id match is now completed in SQL at every finalize (core and app indexer). Missed links heal on the next refresh, including rows already null in existing databases. `instr()` keeps exact substring semantics (no LIKE wildcards); matches are restricted to `Workflow` tool calls within the same session.

## Non-breaking

No schema, API, or record-shape change. Provider parse output is unchanged; the heal only fills previously-null values. No index-version bump needed — existing databases heal incrementally on the next refresh.

## Verification

- npm test — 452 passed, 0 failed.
- New unit test: same-name runs link by run id, already-linked rows untouched, non-Workflow results and cross-session results never match.
- New end-to-end regression test driving the real core `buildIndex` path: workflow indexed before its tool_result asserts null, then heals after the next refresh. Red-green verified (fails without the heal call).
- Regression test for repeated workflow names asserts both link directions.
- npm run typecheck — 0 errors; changed files lint-clean.