### PR TITLE
docs: state the pull request intake policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,8 @@ bottom applies to every PR.
 - **Absorption is a normal outcome.** Sometimes the maintainer lands an
   equivalent change directly instead of merging the PR — when the surrounding
   design is still moving, or the fix touches code with constraints that are
-  faster to apply than to explain. When this happens the closing comment says
-  so explicitly; a PR closed without that note was simply not taken.
+  faster to apply than to explain. When a change is absorbed this way, the
+  closing comment will say so.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,8 @@ bottom applies to every PR.
 - **Absorption is a normal outcome.** Sometimes the maintainer lands an
   equivalent change directly instead of merging the PR — when the surrounding
   design is still moving, or the fix touches code with constraints that are
-  faster to apply than to explain. A closed PR with the underlying change
-  landed is a contribution that made it in.
+  faster to apply than to explain. When this happens the closing comment says
+  so explicitly; a PR closed without that note was simply not taken.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,23 @@ bottom applies to every PR.
 
 ---
 
+## Before you open a pull request
+
+- **Bug reports are always welcome** as issues — no permission needed.
+- **Bugfix PRs may be opened directly**, but state the reproduction and the root
+  cause in the description. Review turnaround is not guaranteed for PRs that did
+  not come out of an issue discussion.
+- **Feature or behavior-change PRs require an issue first.** Unsolicited ones
+  are closed without review — not because the code is bad, but because the
+  design conversation has to happen before the implementation, not after.
+- **Absorption is a normal outcome.** Sometimes the maintainer lands an
+  equivalent change directly instead of merging the PR — when the surrounding
+  design is still moving, or the fix touches code with constraints that are
+  faster to apply than to explain. A closed PR with the underlying change
+  landed is a contribution that made it in.
+
+---
+
 ## Six things that decide whether a PR lands
 
 **1. Run every sentence of your PR description end to end.**


### PR DESCRIPTION
## What and why

Adds a "Before you open a pull request" section at the top of CONTRIBUTING.md:

- Bug reports: always welcome as issues.
- Bugfix PRs: may be opened directly; review turnaround not guaranteed without a prior issue discussion.
- Feature / behavior-change PRs: require an issue first; unsolicited ones are closed without review.
- Absorption (maintainer lands an equivalent change directly) is named as a normal outcome, so a closed PR with the underlying change landed reads as the report having been valuable.

Docs-only change; no code, no tests affected.