### PR TITLE
feat(core): let attune write memories while the daemon owns index writes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,10 @@ interactions, or the full Electron suites.
 
 - **The heartbeat decides who may write.** While a daemon is fresh, the CLI side
   is read-only: no write connection, no schema migration, no PRAGMA change, no
-  checkpoint, no indexing. Guarded by `tests/daemon-arbitration.test.mjs` and
+  checkpoint, no indexing. Two narrow carve-outs, both recorded in ADR 0006:
+  the invocation-nonce freshness build, and memory mutations (`--attune`),
+  which write only the `memories` table and never migrate or configure the
+  index. Guarded by `tests/daemon-arbitration.test.mjs` and
   `tests/app-writer-lease.test.mjs`.
 - **If you add something that needs periodic refresh, prove its refresh point is
   actually called repeatedly.** Hanging a full rebuild off a first-run-only gate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,9 +186,9 @@ interactions, or the full Electron suites.
   is read-only: no write connection, no schema migration, no PRAGMA change, no
   checkpoint, no indexing. Two narrow carve-outs, both recorded in ADR 0006:
   the invocation-nonce freshness build, and memory mutations (`--attune`),
-  which write only the `memories` table and never migrate or configure the
-  index. Guarded by `tests/daemon-arbitration.test.mjs` and
-  `tests/app-writer-lease.test.mjs`.
+  which write only the memory layer (`memories` + `memories_fts` via triggers)
+  and never migrate or configure the index. Guarded by
+  `tests/daemon-arbitration.test.mjs` and `tests/app-writer-lease.test.mjs`.
 - **If you add something that needs periodic refresh, prove its refresh point is
   actually called repeatedly.** Hanging a full rebuild off a first-run-only gate
   means it runs once and never again — and for existing installations, never at

--- a/docs/adr/0006-write-transaction-rollback-and-concurrency.md
+++ b/docs/adr/0006-write-transaction-rollback-and-concurrency.md
@@ -109,3 +109,23 @@ carve-out never does is initialize or migrate a missing/legacy schema.
 Every other CLI write path keeps the original rule: the regular pre-query
 refresh, `attune`, migrations, schema setup, and checkpoints all remain
 read-only under a fresh heartbeat.
+
+**Amendment (2026-08-11, later the same day): memory-mutation carve-out.** The
+blanket rule above listed `attune` among the paths that stay read-only under a
+fresh heartbeat. That was over-broad: `remember()`/`forget()` write only the
+`memories` table (plus its FTS triggers), which index builds — force rebuilds
+included — never delete from, and a memory mutation carries no multi-transaction
+state for the writer lease to protect. Blocking memory writes while the app ran
+made the CLI memory flow unusable in exactly the configuration where it is most
+used. This paragraph supersedes the "attune remains read-only" rule above.
+
+`executeAttune` therefore no longer reads provider settings, builds the index,
+checks daemon ownership, or acquires the writer lease. It opens the existing
+database through `openAttuneDb()`, which never creates, migrates, or configures
+the index and fails honestly when the memory layer is absent. Each mutation runs
+as one short `runRetryableWriteTransaction`. Concurrent mutations need no mutex:
+`remember()` generates unique ids, `forget()` is idempotent, and WAL serializes
+writers — contention surfaces as a bounded busy retry, never as a logical
+conflict. Index builds and memory mutations can still interleave at the SQLite
+level; both orders are consistent because `memories_fts` is maintained either by
+its triggers (attune inserts) or rebuilt from `memories` (index finalize).

--- a/docs/adr/0006-write-transaction-rollback-and-concurrency.md
+++ b/docs/adr/0006-write-transaction-rollback-and-concurrency.md
@@ -120,12 +120,21 @@ made the CLI memory flow unusable in exactly the configuration where it is most
 used. This paragraph supersedes the "attune remains read-only" rule above.
 
 `executeAttune` therefore no longer reads provider settings, builds the index,
-checks daemon ownership, or acquires the writer lease. It opens the existing
-database through `openAttuneDb()`, which never creates, migrates, or configures
-the index and fails honestly when the memory layer is absent. Each mutation runs
-as one short `runRetryableWriteTransaction`. Concurrent mutations need no mutex:
-`remember()` generates unique ids, `forget()` is idempotent, and WAL serializes
-writers — contention surfaces as a bounded busy retry, never as a logical
-conflict. Index builds and memory mutations can still interleave at the SQLite
-level; both orders are consistent because `memories_fts` is maintained either by
-its triggers (attune inserts) or rebuilt from `memories` (index finalize).
+checks daemon ownership, or acquires the writer lease. This supersedes two more
+remnants of the original decision: the lease bullet that lists attune among its
+participants, and — for this path only — the "BEGIN contention is deferred to
+the build scheduler" policy. Attune has no scheduler; its mutations instead run
+on a connection with the ADR-standard 250 ms busy timeout so a contended BEGIN
+fails fast, and the retry layer owns the waiting (`retryOnBeginBusy`, 5 s
+budget). Builds keep the original defer-to-scheduler policy; the coordinator's
+BEGIN-retry stays opt-in. Attune opens the existing database through
+`openAttuneDb()`, which never creates, migrates, or configures the index and
+fails honestly when the memory layer (`memories`, `memories_fts`, or their
+maintenance triggers) is absent or incomplete. Each mutation runs as one short
+`runRetryableWriteTransaction`. Concurrent mutations need no mutex:
+`remember()` generates unique ids, `forget()` is idempotent and reads, decides,
+and updates in a single transaction, and WAL serializes writers — contention
+surfaces as a bounded busy retry, never as a logical conflict. Index builds and
+memory mutations can still interleave at the SQLite level; both orders are
+consistent because `memories_fts` is maintained either by its triggers (attune
+inserts) or rebuilt from `memories` (index finalize).

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -10,8 +10,8 @@
 
 import { createContext, runInNewContext } from 'node:vm';
 
-import { DB_PATH, openDb, openReadDb, openWriterLeaseDb } from './db.ts';
-import { buildIndex, ensureReadableSchema, shouldSkipBuild } from './indexer.ts';
+import { DB_PATH, openAttuneDb, openReadDb } from './db.ts';
+import { buildIndex, ensureReadableSchema } from './indexer.ts';
 import { coreSchemaNeedsMigration } from './schema-migrations.ts';
 import {
   createConfiguredBuiltinProviderRuntime,
@@ -20,7 +20,8 @@ import {
 import type { ProviderRegistry } from './providers/registry.ts';
 import { createQueryApi, createAttuneApi } from './query.ts';
 import type { SqliteDb } from './sqlite-types.ts';
-import { acquireWriterLease, writerLockPathFor } from './writer-lease.ts';
+import { nodeSqliteTransactionAdapter } from './tx.ts';
+import { runRetryableWriteTransaction } from './write-coordinator.ts';
 
 export { buildIndex, DB_PATH };
 
@@ -326,42 +327,19 @@ export async function executeQuery(scriptContent: string, invocation?: Invocatio
 }
 
 // Execute a memory-mutation CodeAct script (remember/forget only).
+// Memory writes are independent of index writes by design: no settings read,
+// no pre-write index build, no daemon-ownership check, no writer lease. The
+// memories table is untouched by index builds (force rebuilds included), each
+// mutation is a single short retryable write transaction, and concurrent
+// attunes cannot collide logically — remember() generates unique ids and
+// forget() is idempotent (ADR 0006 amendment).
 export async function executeAttune(scriptContent: string): Promise<unknown> {
-  const settings = readPersistedProviderSettings();
-  if (!settings.ok) throw new Error(`${settings.error}; attune was not applied`);
-  const providerRegistry = createConfiguredBuiltinProviderRuntime(settings.settings).registry;
-  const build = buildIndex({ providerRegistry }) as { reason?: string } | undefined;
-  reportIncompleteInventory(build);
-  if (build?.reason === 'daemon_active') {
-    throw new Error('Obelisk daemon owns index writes; attune is read-only until the daemon stops');
-  }
-  if (build?.reason === 'writer_busy' || build?.reason === 'database_busy') {
-    throw new Error('Obelisk index writer is busy; attune was not applied');
-  }
-  const lease = acquireWriterLease({
-    lockPath: writerLockPathFor(DB_PATH),
-    openDb: openWriterLeaseDb,
-    waitMs: 1000,
-  });
-  if (!lease) throw new Error('Obelisk index writer is busy; attune was not applied');
+  const db = openAttuneDb();
   try {
-    // Close the heartbeat TOCTOU window after acquiring the hard lease.
-    const ownershipDb = openReadDb();
-    try {
-      const ownership = shouldSkipBuild(ownershipDb, { ignoreRecentBuild: true });
-      if (ownership.reason === 'daemon_active') {
-        throw new Error('Obelisk daemon owns index writes; attune is read-only until the daemon stops');
-      }
-    } finally {
-      ownershipDb.close();
-    }
-    const db = openDb();
-    try {
-      return await runInSandbox(createAttuneApi(db), scriptContent);
-    } finally {
-      db.close();
-    }
+    const txDb = nodeSqliteTransactionAdapter(db);
+    const runMutation = <T>(work: () => T): T => runRetryableWriteTransaction(txDb, work, { label: 'attune' });
+    return await runInSandbox(createAttuneApi(db, runMutation), scriptContent);
   } finally {
-    lease.release();
+    db.close();
   }
 }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -337,7 +337,7 @@ export async function executeAttune(scriptContent: string): Promise<unknown> {
   const db = openAttuneDb();
   try {
     const txDb = nodeSqliteTransactionAdapter(db);
-    const runMutation = <T>(work: () => T): T => runRetryableWriteTransaction(txDb, work, { label: 'attune' });
+    const runMutation = <T>(work: () => T): T => runRetryableWriteTransaction(txDb, work, { label: 'attune' }, { retryOnBeginBusy: true });
     return await runInSandbox(createAttuneApi(db, runMutation), scriptContent);
   } finally {
     db.close();

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -10,7 +10,7 @@
 
 import { createContext, runInNewContext } from 'node:vm';
 
-import { DB_PATH, openAttuneDb, openReadDb } from './db.ts';
+import { DB_PATH, openAttuneDb, openReadDb, probeAttuneMemoryLayer } from './db.ts';
 import { buildIndex, ensureReadableSchema } from './indexer.ts';
 import { coreSchemaNeedsMigration } from './schema-migrations.ts';
 import {
@@ -347,6 +347,11 @@ export async function executeAttune(scriptContent: string): Promise<unknown> {
       // to cap it first (each cycle costs ~250 ms timeout + growing backoff).
       { retryOnBeginBusy: true, budgetMs: 5000, retryDelayMs: 100, maxAttempts: 10 },
     );
+    // Verify the recall half of the memory layer (FTS + triggers) actually
+    // works before accepting mutations. The probe runs inside the same
+    // retryable transaction wrapper, so lock contention is waited out by the
+    // same budget instead of failing the open with a misleading error.
+    runMutation(() => probeAttuneMemoryLayer(db));
     return await runInSandbox(createAttuneApi(db, runMutation), scriptContent);
   } finally {
     db.close();

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -337,7 +337,16 @@ export async function executeAttune(scriptContent: string): Promise<unknown> {
   const db = openAttuneDb();
   try {
     const txDb = nodeSqliteTransactionAdapter(db);
-    const runMutation = <T>(work: () => T): T => runRetryableWriteTransaction(txDb, work, { label: 'attune' }, { retryOnBeginBusy: true });
+    const runMutation = <T>(work: () => T): T => runRetryableWriteTransaction(
+      txDb,
+      work,
+      { label: 'attune' },
+      // The connection's busy_timeout is short (250 ms, per ADR 0006), so a
+      // contended BEGIN fails fast and this layer owns the waiting: retry
+      // within a 5 s budget, BEGIN-busy included (the work never ran, so
+      // replay is safe).
+      { retryOnBeginBusy: true, budgetMs: 5000, retryDelayMs: 100 },
+    );
     return await runInSandbox(createAttuneApi(db, runMutation), scriptContent);
   } finally {
     db.close();

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -342,10 +342,10 @@ export async function executeAttune(scriptContent: string): Promise<unknown> {
       work,
       { label: 'attune' },
       // The connection's busy_timeout is short (250 ms, per ADR 0006), so a
-      // contended BEGIN fails fast and this layer owns the waiting: retry
-      // within a 5 s budget, BEGIN-busy included (the work never ran, so
-      // replay is safe).
-      { retryOnBeginBusy: true, budgetMs: 5000, retryDelayMs: 100 },
+      // contended BEGIN fails fast and this layer owns the waiting. The 5 s
+      // budget is the real bound; maxAttempts just has to be large enough not
+      // to cap it first (each cycle costs ~250 ms timeout + growing backoff).
+      { retryOnBeginBusy: true, budgetMs: 5000, retryDelayMs: 100, maxAttempts: 10 },
     );
     return await runInSandbox(createAttuneApi(db, runMutation), scriptContent);
   } finally {

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -49,6 +49,10 @@ const ATTUNE_MEMORY_COLUMNS = [
   'path', 'anchors', 'summary', 'created_at', 'deleted_at', 'deleted_reason',
 ] as const;
 
+const ATTUNE_MEMORY_TRIGGERS = [
+  'memories_fts_ai', 'memories_fts_ad', 'memories_fts_au',
+] as const;
+
 function openAttuneDb(): NodeSqliteDb {
   if (!existsSync(DB_PATH)) {
     throw new Error('Obelisk index is not initialized; run an index build (obelisk --build) before writing memories');
@@ -58,7 +62,16 @@ function openAttuneDb(): NodeSqliteDb {
   const columns = new Set(
     db.prepare('PRAGMA table_info(memories)').all().map((row) => String(row.name)),
   );
-  if (!ATTUNE_MEMORY_COLUMNS.every((column) => columns.has(column))) {
+  // The FTS table and its maintenance triggers are part of the memory layer:
+  // without them a write "succeeds" but the memory can never be recalled.
+  const objects = new Set(
+    db.prepare("SELECT name FROM sqlite_master WHERE name IN ('memories_fts', 'memories_fts_ai', 'memories_fts_ad', 'memories_fts_au')")
+      .all().map((row) => String(row.name)),
+  );
+  const complete = ATTUNE_MEMORY_COLUMNS.every((column) => columns.has(column))
+    && objects.has('memories_fts')
+    && ATTUNE_MEMORY_TRIGGERS.every((trigger) => objects.has(trigger));
+  if (!complete) {
     db.close();
     throw new Error('Obelisk index predates the memory layer; run an index build (obelisk --build) before writing memories');
   }

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -69,15 +69,20 @@ function openAttuneDb(): NodeSqliteDb {
   );
   // The FTS table and its maintenance triggers are part of the memory layer:
   // without them a write "succeeds" but the memory can never be recalled.
-  const objects = new Set(
-    db.prepare("SELECT name FROM sqlite_master WHERE type IN ('table', 'trigger')")
-      .all().map((row) => String(row.name)),
+  // Names alone are not enough — a plain table or a hollow trigger with the
+  // right name would fool a name check, so verify the definitions too.
+  const definitions = new Map(
+    db.prepare("SELECT name, sql FROM sqlite_master WHERE type IN ('table', 'trigger')")
+      .all().map((row) => [String(row.name), String(row.sql ?? '')]),
   );
+  const ftsSql = definitions.get('memories_fts') ?? '';
+  const ftsOk = /create\s+virtual\s+table/i.test(ftsSql) && /fts5/i.test(ftsSql);
+  const triggersOk = ATTUNE_MEMORY_TRIGGERS.length > 0
+    && ATTUNE_MEMORY_TRIGGERS.every((trigger) => (definitions.get(trigger) ?? '').includes('memories_fts'));
   const complete = ATTUNE_MEMORY_COLUMNS.length > 0
-    && ATTUNE_MEMORY_TRIGGERS.length > 0
     && ATTUNE_MEMORY_COLUMNS.every((column) => columns.has(column))
-    && objects.has('memories_fts')
-    && ATTUNE_MEMORY_TRIGGERS.every((trigger) => objects.has(trigger));
+    && ftsOk
+    && triggersOk;
   if (!complete) {
     db.close();
     throw new Error('Obelisk index predates the memory layer; run an index build (obelisk --build) before writing memories');

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 // node:sqlite lifecycle and migrations for the Core package.
+import { randomUUID } from 'node:crypto';
 import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -84,20 +85,34 @@ function openAttuneDb(): NodeSqliteDb {
 // Names and SQL text prove nothing — a trigger's own name contains
 // 'memories_fts', and a lookalike table can borrow the right DDL — so
 // validate to executability instead. Must run inside a write transaction
-// (executeAttune's retryable mutation wrapper): the probe writes and deletes
-// one row, so a committed probe is net-zero and a failed probe rolls back.
+// (executeAttune's retryable mutation wrapper): the probe writes, updates,
+// and deletes one row, so a committed probe is net-zero and a failed probe
+// rolls back. Id and tokens are random per probe: fixed values could match a
+// legitimate memory and produce a false "incomplete layer" verdict.
 function probeAttuneMemoryLayer(db: SqliteDb): void {
+  const layerError = new Error('Obelisk index predates the memory layer; run an index build (obelisk --build) before writing memories');
+  const probeId = `__attune_probe_${randomUUID()}`;
+  const insertToken = `pins${randomUUID().replaceAll('-', '')}`;
+  const updateToken = `pupd${randomUUID().replaceAll('-', '')}`;
+  // FTS MATCH on the random token, filtered by the probe id: pre-existing
+  // memories can never interfere either way.
+  const matches = (token: string) => db.prepare('SELECT id FROM memories_fts WHERE memories_fts MATCH ? AND id = ?').all(token, probeId).length;
   try {
-    db.prepare("INSERT INTO memories (id, path, summary, created_at) VALUES ('__attune_probe__', '/probe', 'attuneprobetoken marker', '1970-01-01T00:00:00Z')").run();
-    const visible = db.prepare("SELECT id FROM memories_fts WHERE memories_fts MATCH 'attuneprobetoken'").get();
-    db.prepare("DELETE FROM memories WHERE id='__attune_probe__'").run();
-    const gone = db.prepare("SELECT id FROM memories_fts WHERE memories_fts MATCH 'attuneprobetoken'").get();
-    if (!visible || gone) throw new Error('probe mismatch');
-  } catch {
-    // Lock errors cannot occur here: BEGIN IMMEDIATE already holds the write
-    // lock before this probe runs, so any failure is a broken layer, not
-    // contention. Report honestly and let the transaction roll back.
-    throw new Error('Obelisk index predates the memory layer; run an index build (obelisk --build) before writing memories');
+    db.prepare('INSERT INTO memories (id, path, summary, created_at) VALUES (?, ?, ?, ?)').run(probeId, '/probe', `${insertToken} marker`, '1970-01-01T00:00:00Z');
+    if (matches(insertToken) !== 1) throw layerError;
+    db.prepare('UPDATE memories SET summary=? WHERE id=?').run(`${updateToken} marker`, probeId);
+    if (matches(insertToken) !== 0 || matches(updateToken) !== 1) throw layerError;
+    db.prepare('DELETE FROM memories WHERE id=?').run(probeId);
+    if (matches(updateToken) !== 0) throw layerError;
+  } catch (error) {
+    if (error === layerError) throw error;
+    // Translate only the expected schema defects into the honest layer
+    // error; real I/O failures (disk full, SQLITE_IOERR, corruption) must
+    // surface as themselves.
+    if (error instanceof Error && /no such table|no such column|unable to use function MATCH/i.test(error.message)) {
+      throw layerError;
+    }
+    throw error;
   }
 }
 

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -58,14 +58,17 @@ function openAttuneDb(): NodeSqliteDb {
     throw new Error('Obelisk index is not initialized; run an index build (obelisk --build) before writing memories');
   }
   const db = new DatabaseSync(DB_PATH);
-  db.exec('PRAGMA busy_timeout=5000');
+  // Kept short on purpose: lock waiting is owned by the retry layer in
+  // executeAttune (ADR 0006 uses the same 250 ms for index-writer/CLI
+  // connections), so each BEGIN fails fast and retries within that budget.
+  db.exec('PRAGMA busy_timeout=250');
   const columns = new Set(
     db.prepare('PRAGMA table_info(memories)').all().map((row) => String(row.name)),
   );
   // The FTS table and its maintenance triggers are part of the memory layer:
   // without them a write "succeeds" but the memory can never be recalled.
   const objects = new Set(
-    db.prepare("SELECT name FROM sqlite_master WHERE name IN ('memories_fts', 'memories_fts_ai', 'memories_fts_ad', 'memories_fts_au')")
+    db.prepare("SELECT name FROM sqlite_master WHERE type IN ('table', 'trigger')")
       .all().map((row) => String(row.name)),
   );
   const complete = ATTUNE_MEMORY_COLUMNS.every((column) => columns.has(column))

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -39,6 +39,32 @@ function openReadDb(): NodeSqliteDb {
   return db;
 }
 
+// Memory mutations (remember/forget) touch only memories/memories_fts, which
+// index builds never delete from — so attune is independent of daemon write
+// ownership and the writer lease (ADR 0006 amendment). It must still never
+// migrate or configure the index: it opens the existing database as-is and
+// fails honestly when the memory layer is not there yet.
+const ATTUNE_MEMORY_COLUMNS = [
+  'id', 'session_id', 'project', 'message_start', 'message_end',
+  'path', 'anchors', 'summary', 'created_at', 'deleted_at', 'deleted_reason',
+] as const;
+
+function openAttuneDb(): NodeSqliteDb {
+  if (!existsSync(DB_PATH)) {
+    throw new Error('Obelisk index is not initialized; run an index build (obelisk --build) before writing memories');
+  }
+  const db = new DatabaseSync(DB_PATH);
+  db.exec('PRAGMA busy_timeout=5000');
+  const columns = new Set(
+    db.prepare('PRAGMA table_info(memories)').all().map((row) => String(row.name)),
+  );
+  if (!ATTUNE_MEMORY_COLUMNS.every((column) => columns.has(column))) {
+    db.close();
+    throw new Error('Obelisk index predates the memory layer; run an index build (obelisk --build) before writing memories');
+  }
+  return db;
+}
+
 function openWriterLeaseDb(lockPath: string): NodeSqliteDb {
   return new DatabaseSync(lockPath);
 }
@@ -48,4 +74,4 @@ function rebuildMemoryFts(db: SqliteDb): void {
 }
 
 
-export { CLAUDE_DIR, CODEX_DIR, OBELISK_DIR, DB_PATH, TEXT_LIMIT, openDb, openReadDb, openWriterLeaseDb, rebuildMemoryFts, trunc, truncJson, extractText, extractContentType, extractMessageIsMeta, filePath, isDir, readLines };
+export { CLAUDE_DIR, CODEX_DIR, OBELISK_DIR, DB_PATH, TEXT_LIMIT, openDb, openReadDb, openAttuneDb, openWriterLeaseDb, rebuildMemoryFts, trunc, truncJson, extractText, extractContentType, extractMessageIsMeta, filePath, isDir, readLines };

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -43,15 +43,17 @@ function openReadDb(): NodeSqliteDb {
 // index builds never delete from — so attune is independent of daemon write
 // ownership and the writer lease (ADR 0006 amendment). It must still never
 // migrate or configure the index: it opens the existing database as-is and
-// fails honestly when the memory layer is not there yet.
-const ATTUNE_MEMORY_COLUMNS = [
-  'id', 'session_id', 'project', 'message_start', 'message_end',
-  'path', 'anchors', 'summary', 'created_at', 'deleted_at', 'deleted_reason',
-] as const;
+// fails honestly when the memory layer is not there yet. The expected layer
+// shape is derived from the shared schema.sql, not restated, so the two can
+// never drift apart.
+const ATTUNE_MEMORY_COLUMNS = Object.freeze(
+  (/CREATE TABLE IF NOT EXISTS memories \(([^;]+)\);/s.exec(SCHEMA)?.[1] ?? '')
+    .split(',').map(part => part.trim().split(/\s+/)[0]).filter(Boolean),
+);
 
-const ATTUNE_MEMORY_TRIGGERS = [
-  'memories_fts_ai', 'memories_fts_ad', 'memories_fts_au',
-] as const;
+const ATTUNE_MEMORY_TRIGGERS = Object.freeze(
+  [...SCHEMA.matchAll(/CREATE TRIGGER IF NOT EXISTS (memories_fts_\w+)/g)].map(match => match[1]),
+);
 
 function openAttuneDb(): NodeSqliteDb {
   if (!existsSync(DB_PATH)) {
@@ -71,7 +73,9 @@ function openAttuneDb(): NodeSqliteDb {
     db.prepare("SELECT name FROM sqlite_master WHERE type IN ('table', 'trigger')")
       .all().map((row) => String(row.name)),
   );
-  const complete = ATTUNE_MEMORY_COLUMNS.every((column) => columns.has(column))
+  const complete = ATTUNE_MEMORY_COLUMNS.length > 0
+    && ATTUNE_MEMORY_TRIGGERS.length > 0
+    && ATTUNE_MEMORY_COLUMNS.every((column) => columns.has(column))
     && objects.has('memories_fts')
     && ATTUNE_MEMORY_TRIGGERS.every((trigger) => objects.has(trigger));
   if (!complete) {

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -68,11 +68,14 @@ function openAttuneDb(): NodeSqliteDb {
   // executeAttune (ADR 0006 uses the same 250 ms for index-writer/CLI
   // connections), so each BEGIN fails fast and retries within that budget.
   db.exec('PRAGMA busy_timeout=250');
-  const columns = new Set(
-    db.prepare('PRAGMA table_info(memories)').all().map((row) => String(row.name)),
-  );
+  const info = db.prepare('PRAGMA table_info(memories)').all();
+  const columns = new Set(info.map((row) => String(row.name)));
+  // Column names alone are not enough: without `id` as PRIMARY KEY, remember
+  // ids lose uniqueness and forget() can update multiple rows at once.
+  const idRow = info.find((row) => row.name === 'id');
   const columnsOk = ATTUNE_MEMORY_COLUMNS.length > 0
-    && ATTUNE_MEMORY_COLUMNS.every((column) => columns.has(column));
+    && ATTUNE_MEMORY_COLUMNS.every((column) => columns.has(column))
+    && Number(idRow?.pk ?? 0) > 0;
   if (!columnsOk) {
     db.close();
     throw new Error('Obelisk index predates the memory layer; run an index build (obelisk --build) before writing memories');
@@ -85,10 +88,11 @@ function openAttuneDb(): NodeSqliteDb {
 // Names and SQL text prove nothing — a trigger's own name contains
 // 'memories_fts', and a lookalike table can borrow the right DDL — so
 // validate to executability instead. Must run inside a write transaction
-// (executeAttune's retryable mutation wrapper): the probe writes, updates,
-// and deletes one row, so a committed probe is net-zero and a failed probe
-// rolls back. Id and tokens are random per probe: fixed values could match a
-// legitimate memory and produce a false "incomplete layer" verdict.
+// (executeAttune's retryable mutation wrapper). The probe body is wrapped in
+// a SAVEPOINT that is always rolled back, so even a successful probe leaves
+// no persistent trace — not just no logical row, but no FTS5 shadow-table
+// churn either. Id and tokens are random per probe: fixed values could match
+// a legitimate memory and produce a false "incomplete layer" verdict.
 function probeAttuneMemoryLayer(db: SqliteDb): void {
   const layerError = new Error('Obelisk index predates the memory layer; run an index build (obelisk --build) before writing memories');
   const probeId = `__attune_probe_${randomUUID()}`;
@@ -97,6 +101,7 @@ function probeAttuneMemoryLayer(db: SqliteDb): void {
   // FTS MATCH on the random token, filtered by the probe id: pre-existing
   // memories can never interfere either way.
   const matches = (token: string) => db.prepare('SELECT id FROM memories_fts WHERE memories_fts MATCH ? AND id = ?').all(token, probeId).length;
+  db.exec('SAVEPOINT attune_probe');
   try {
     db.prepare('INSERT INTO memories (id, path, summary, created_at) VALUES (?, ?, ?, ?)').run(probeId, '/probe', `${insertToken} marker`, '1970-01-01T00:00:00Z');
     if (matches(insertToken) !== 1) throw layerError;
@@ -105,14 +110,18 @@ function probeAttuneMemoryLayer(db: SqliteDb): void {
     db.prepare('DELETE FROM memories WHERE id=?').run(probeId);
     if (matches(updateToken) !== 0) throw layerError;
   } catch (error) {
-    if (error === layerError) throw error;
     // Translate only the expected schema defects into the honest layer
     // error; real I/O failures (disk full, SQLITE_IOERR, corruption) must
     // surface as themselves.
-    if (error instanceof Error && /no such table|no such column|unable to use function MATCH/i.test(error.message)) {
-      throw layerError;
+    if (error !== layerError
+      && !(error instanceof Error && /no such table|no such column|unable to use function MATCH/i.test(error.message))) {
+      throw error;
     }
-    throw error;
+    throw layerError;
+  } finally {
+    // The probe never persists: roll its writes back whether it passed or
+    // failed. The surrounding transaction stays usable either way.
+    try { db.exec('ROLLBACK TO attune_probe'); db.exec('RELEASE attune_probe'); } catch { /* the outer transaction's rollback cleans up */ }
   }
 }
 

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -67,27 +67,35 @@ function openAttuneDb(): NodeSqliteDb {
   const columns = new Set(
     db.prepare('PRAGMA table_info(memories)').all().map((row) => String(row.name)),
   );
-  // The FTS table and its maintenance triggers are part of the memory layer:
-  // without them a write "succeeds" but the memory can never be recalled.
-  // Names alone are not enough — a plain table or a hollow trigger with the
-  // right name would fool a name check, so verify the definitions too.
-  const definitions = new Map(
-    db.prepare("SELECT name, sql FROM sqlite_master WHERE type IN ('table', 'trigger')")
-      .all().map((row) => [String(row.name), String(row.sql ?? '')]),
-  );
-  const ftsSql = definitions.get('memories_fts') ?? '';
-  const ftsOk = /create\s+virtual\s+table/i.test(ftsSql) && /fts5/i.test(ftsSql);
-  const triggersOk = ATTUNE_MEMORY_TRIGGERS.length > 0
-    && ATTUNE_MEMORY_TRIGGERS.every((trigger) => (definitions.get(trigger) ?? '').includes('memories_fts'));
-  const complete = ATTUNE_MEMORY_COLUMNS.length > 0
-    && ATTUNE_MEMORY_COLUMNS.every((column) => columns.has(column))
-    && ftsOk
-    && triggersOk;
-  if (!complete) {
+  const columnsOk = ATTUNE_MEMORY_COLUMNS.length > 0
+    && ATTUNE_MEMORY_COLUMNS.every((column) => columns.has(column));
+  if (!columnsOk) {
     db.close();
     throw new Error('Obelisk index predates the memory layer; run an index build (obelisk --build) before writing memories');
   }
   return db;
+}
+
+// The FTS table and its maintenance triggers are the recall half of the
+// memory layer: without them a write "succeeds" but can never be found.
+// Names and SQL text prove nothing — a trigger's own name contains
+// 'memories_fts', and a lookalike table can borrow the right DDL — so
+// validate to executability instead. Must run inside a write transaction
+// (executeAttune's retryable mutation wrapper): the probe writes and deletes
+// one row, so a committed probe is net-zero and a failed probe rolls back.
+function probeAttuneMemoryLayer(db: SqliteDb): void {
+  try {
+    db.prepare("INSERT INTO memories (id, path, summary, created_at) VALUES ('__attune_probe__', '/probe', 'attuneprobetoken marker', '1970-01-01T00:00:00Z')").run();
+    const visible = db.prepare("SELECT id FROM memories_fts WHERE memories_fts MATCH 'attuneprobetoken'").get();
+    db.prepare("DELETE FROM memories WHERE id='__attune_probe__'").run();
+    const gone = db.prepare("SELECT id FROM memories_fts WHERE memories_fts MATCH 'attuneprobetoken'").get();
+    if (!visible || gone) throw new Error('probe mismatch');
+  } catch {
+    // Lock errors cannot occur here: BEGIN IMMEDIATE already holds the write
+    // lock before this probe runs, so any failure is a broken layer, not
+    // contention. Report honestly and let the transaction roll back.
+    throw new Error('Obelisk index predates the memory layer; run an index build (obelisk --build) before writing memories');
+  }
 }
 
 function openWriterLeaseDb(lockPath: string): NodeSqliteDb {
@@ -99,4 +107,4 @@ function rebuildMemoryFts(db: SqliteDb): void {
 }
 
 
-export { CLAUDE_DIR, CODEX_DIR, OBELISK_DIR, DB_PATH, TEXT_LIMIT, ATTUNE_MEMORY_COLUMNS, ATTUNE_MEMORY_TRIGGERS, openDb, openReadDb, openAttuneDb, openWriterLeaseDb, rebuildMemoryFts, trunc, truncJson, extractText, extractContentType, extractMessageIsMeta, filePath, isDir, readLines };
+export { CLAUDE_DIR, CODEX_DIR, OBELISK_DIR, DB_PATH, TEXT_LIMIT, ATTUNE_MEMORY_COLUMNS, ATTUNE_MEMORY_TRIGGERS, openDb, openReadDb, openAttuneDb, probeAttuneMemoryLayer, openWriterLeaseDb, rebuildMemoryFts, trunc, truncJson, extractText, extractContentType, extractMessageIsMeta, filePath, isDir, readLines };

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -70,12 +70,14 @@ function openAttuneDb(): NodeSqliteDb {
   db.exec('PRAGMA busy_timeout=250');
   const info = db.prepare('PRAGMA table_info(memories)').all();
   const columns = new Set(info.map((row) => String(row.name)));
-  // Column names alone are not enough: without `id` as PRIMARY KEY, remember
-  // ids lose uniqueness and forget() can update multiple rows at once.
-  const idRow = info.find((row) => row.name === 'id');
+  // Column names alone are not enough: id must be the ONLY primary-key
+  // column. A composite PRIMARY KEY (id, project) still lets duplicate ids
+  // in, so remember ids lose uniqueness and forget() can update several
+  // rows at once.
+  const pkColumns = info.filter((row) => Number(row.pk ?? 0) > 0).map((row) => String(row.name));
   const columnsOk = ATTUNE_MEMORY_COLUMNS.length > 0
     && ATTUNE_MEMORY_COLUMNS.every((column) => columns.has(column))
-    && Number(idRow?.pk ?? 0) > 0;
+    && pkColumns.length === 1 && pkColumns[0] === 'id';
   if (!columnsOk) {
     db.close();
     throw new Error('Obelisk index predates the memory layer; run an index build (obelisk --build) before writing memories');
@@ -110,6 +112,10 @@ function probeAttuneMemoryLayer(db: SqliteDb): void {
     db.prepare('DELETE FROM memories WHERE id=?').run(probeId);
     if (matches(updateToken) !== 0) throw layerError;
   } catch (error) {
+    // Failure path: the probe throws, so the outer transaction rolls back
+    // regardless — a cleanup error here may be swallowed to keep the primary
+    // error (ADR 0006: cleanup never masks the primary exception).
+    try { db.exec('ROLLBACK TO attune_probe'); db.exec('RELEASE attune_probe'); } catch { /* the outer transaction's rollback cleans up */ }
     // Translate only the expected schema defects into the honest layer
     // error; real I/O failures (disk full, SQLITE_IOERR, corruption) must
     // surface as themselves.
@@ -118,11 +124,11 @@ function probeAttuneMemoryLayer(db: SqliteDb): void {
       throw error;
     }
     throw layerError;
-  } finally {
-    // The probe never persists: roll its writes back whether it passed or
-    // failed. The surrounding transaction stays usable either way.
-    try { db.exec('ROLLBACK TO attune_probe'); db.exec('RELEASE attune_probe'); } catch { /* the outer transaction's rollback cleans up */ }
   }
+  // Success path: a cleanup failure MUST propagate — otherwise the outer
+  // transaction would commit the probe writes it was meant to discard.
+  db.exec('ROLLBACK TO attune_probe');
+  db.exec('RELEASE attune_probe');
 }
 
 function openWriterLeaseDb(lockPath: string): NodeSqliteDb {

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -87,4 +87,4 @@ function rebuildMemoryFts(db: SqliteDb): void {
 }
 
 
-export { CLAUDE_DIR, CODEX_DIR, OBELISK_DIR, DB_PATH, TEXT_LIMIT, openDb, openReadDb, openAttuneDb, openWriterLeaseDb, rebuildMemoryFts, trunc, truncJson, extractText, extractContentType, extractMessageIsMeta, filePath, isDir, readLines };
+export { CLAUDE_DIR, CODEX_DIR, OBELISK_DIR, DB_PATH, TEXT_LIMIT, ATTUNE_MEMORY_COLUMNS, ATTUNE_MEMORY_TRIGGERS, openDb, openReadDb, openAttuneDb, openWriterLeaseDb, rebuildMemoryFts, trunc, truncJson, extractText, extractContentType, extractMessageIsMeta, filePath, isDir, readLines };

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -678,7 +678,7 @@ function createQueryApi(
   return { sql: q, search, context, trace, thread, subagents, workflows, workflowTree, fileHistory, failures, sessions, recent, summaries, raw, memories, overview };
 }
 
-function createAttuneApi(db: SqliteDb) {
+function createAttuneApi(db: SqliteDb, runMutation: <T>(work: () => T) => T = (work) => work()) {
   const resolveMemoryPath = (memoryPath: string, sessionId?: string): string => {
     let base = null;
     if (sessionId) {
@@ -726,8 +726,8 @@ function createAttuneApi(db: SqliteDb) {
     const id = `mem-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const proj = project || db.prepare('SELECT project FROM sessions WHERE id=?').get(session_id)?.project || null;
     const created_at = new Date().toISOString();
-    db.prepare('INSERT OR REPLACE INTO memories (id, session_id, project, message_start, message_end, path, anchors, summary, created_at) VALUES (?,?,?,?,?,?,?,?,?)').run(
-      id, session_id || null, proj, message_start || null, message_end || null, normalizedPath, normalizedAnchors, summary, created_at);
+    runMutation(() => db.prepare('INSERT OR REPLACE INTO memories (id, session_id, project, message_start, message_end, path, anchors, summary, created_at) VALUES (?,?,?,?,?,?,?,?,?)').run(
+      id, session_id || null, proj, message_start || null, message_end || null, normalizedPath, normalizedAnchors, summary, created_at));
     return { id, path: normalizedPath, project: proj, anchors: normalizedAnchors, created_at };
   };
 
@@ -740,7 +740,7 @@ function createAttuneApi(db: SqliteDb) {
       return { id, deleted_at: row.deleted_at, deleted_reason: row.deleted_reason, already_deleted: true };
     }
     const deleted_at = new Date().toISOString();
-    db.prepare('UPDATE memories SET deleted_at=?, deleted_reason=? WHERE id=?').run(deleted_at, deletionReason, id);
+    runMutation(() => db.prepare('UPDATE memories SET deleted_at=?, deleted_reason=? WHERE id=?').run(deleted_at, deletionReason, id));
     return { id, deleted_at, deleted_reason: deletionReason };
   };
 

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -736,7 +736,10 @@ function createAttuneApi(db: SqliteDb, runMutation: <T>(work: () => T) => T = (w
             id, session_id || null, proj, message_start || null, message_end || null, normalizedPath, normalizedAnchors, summary, created_at);
           return;
         } catch (error) {
-          if (attempt < 2 && error instanceof Error && /UNIQUE constraint/i.test(error.message)) {
+          // SQLITE_CONSTRAINT_PRIMARYKEY (1555): id collision, regenerate.
+          // Any other constraint or error propagates unchanged.
+          const errcode = (error as { errcode?: unknown })?.errcode;
+          if (attempt < 2 && errcode === 1555) {
             id = `mem-${randomUUID()}`;
             continue;
           }

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -12,6 +12,9 @@ import type { SqliteDb, SqliteRow } from './sqlite-types.ts';
 
 type DbRow = SqliteRow;
 
+// SQLite extended result code for a primary-key uniqueness violation.
+const SQLITE_CONSTRAINT_PRIMARYKEY = 1555;
+
 interface QueryOptions extends Record<string, any> {
   limit?: number;
   sessionId?: string;
@@ -739,10 +742,10 @@ function createAttuneApi(db: SqliteDb, runMutation: <T>(work: () => T) => T = (w
             id, session_id || null, proj, message_start || null, message_end || null, normalizedPath, normalizedAnchors, summary, created_at);
           return;
         } catch (error) {
-          // SQLITE_CONSTRAINT_PRIMARYKEY (1555): id collision, regenerate.
-          // Any other constraint or error propagates unchanged.
+          // Primary-key collision: regenerate the id and retry. Any other
+          // constraint or error propagates unchanged.
           const errcode = (error as { errcode?: unknown })?.errcode;
-          if (attempt < 2 && errcode === 1555) {
+          if (attempt < 2 && errcode === SQLITE_CONSTRAINT_PRIMARYKEY) {
             id = `mem-${randomUUID()}`;
             continue;
           }

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -734,14 +734,18 @@ function createAttuneApi(db: SqliteDb, runMutation: <T>(work: () => T) => T = (w
   const forget = ({ id, reason }: ForgetInput) => {
     const deletionReason = String(reason || '').trim();
     if (!id || !deletionReason) throw new Error('forget() requires id and reason');
-    const row = db.prepare('SELECT id, deleted_at, deleted_reason FROM memories WHERE id=?').get(id);
-    if (!row) throw new Error(`forget() memory not found: ${id}`);
-    if (row.deleted_at) {
-      return { id, deleted_at: row.deleted_at, deleted_reason: row.deleted_reason, already_deleted: true };
-    }
-    const deleted_at = new Date().toISOString();
-    runMutation(() => db.prepare('UPDATE memories SET deleted_at=?, deleted_reason=? WHERE id=?').run(deleted_at, deletionReason, id));
-    return { id, deleted_at, deleted_reason: deletionReason };
+    // Read, decide, and update in one write transaction: a concurrent forget
+    // must observe the deleted state, not overwrite another forget's reason.
+    return runMutation(() => {
+      const row = db.prepare('SELECT id, deleted_at, deleted_reason FROM memories WHERE id=?').get(id);
+      if (!row) throw new Error(`forget() memory not found: ${id}`);
+      if (row.deleted_at) {
+        return { id, deleted_at: row.deleted_at, deleted_reason: row.deleted_reason, already_deleted: true };
+      }
+      const deleted_at = new Date().toISOString();
+      db.prepare('UPDATE memories SET deleted_at=?, deleted_reason=? WHERE id=?').run(deleted_at, deletionReason, id);
+      return { id, deleted_at, deleted_reason: deletionReason };
+    });
   };
 
   return { remember, forget };

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -1,5 +1,6 @@
 // Query and attune sandbox helpers for the Core package.
 import { statSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { isAbsolute, normalize, resolve, sep } from 'node:path';
 import { storedSessionCursor } from './provider-indexing.ts';
 import { createBuiltinProviderRegistry } from './providers/builtins.ts';
@@ -723,11 +724,26 @@ function createAttuneApi(db: SqliteDb, runMutation: <T>(work: () => T) => T = (w
     assertEnglishMemoryText(summary, 'remember() summary');
     const normalizedPath = resolveMemoryPath(memoryPath, session_id);
     const normalizedAnchors = normalizeAnchors(anchors);
-    const id = `mem-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const proj = project || db.prepare('SELECT project FROM sessions WHERE id=?').get(session_id)?.project || null;
     const created_at = new Date().toISOString();
-    runMutation(() => db.prepare('INSERT OR REPLACE INTO memories (id, session_id, project, message_start, message_end, path, anchors, summary, created_at) VALUES (?,?,?,?,?,?,?,?,?)').run(
-      id, session_id || null, proj, message_start || null, message_end || null, normalizedPath, normalizedAnchors, summary, created_at));
+    // Plain INSERT, never OR REPLACE: a memory id must not silently overwrite
+    // an existing memory. Collisions regenerate instead of losing data.
+    let id = `mem-${randomUUID()}`;
+    runMutation(() => {
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        try {
+          db.prepare('INSERT INTO memories (id, session_id, project, message_start, message_end, path, anchors, summary, created_at) VALUES (?,?,?,?,?,?,?,?,?)').run(
+            id, session_id || null, proj, message_start || null, message_end || null, normalizedPath, normalizedAnchors, summary, created_at);
+          return;
+        } catch (error) {
+          if (attempt < 2 && error instanceof Error && /UNIQUE constraint/i.test(error.message)) {
+            id = `mem-${randomUUID()}`;
+            continue;
+          }
+          throw error;
+        }
+      }
+    });
     return { id, path: normalizedPath, project: proj, anchors: normalizedAnchors, created_at };
   };
 

--- a/packages/core/src/write-coordinator.ts
+++ b/packages/core/src/write-coordinator.ts
@@ -15,6 +15,10 @@ export interface WriteRetryOptions {
   maxAttempts?: number;
   budgetMs?: number;
   retryDelayMs?: number;
+  // BEGIN-busy means the work never ran, so retrying it is safe for idempotent
+  // work. It stays opt-in: index builds defer BEGIN contention to their
+  // scheduler instead of retrying here (ADR 0006).
+  retryOnBeginBusy?: boolean;
   now?: () => number;
   sleep?: (ms: number) => void;
 }
@@ -64,6 +68,7 @@ export function runWithWriteRetry<T>(operation: () => T, {
   maxAttempts = 3,
   budgetMs = 1000,
   retryDelayMs = 25,
+  retryOnBeginBusy = false,
   now = Date.now,
   sleep = syncSleep,
 }: WriteRetryOptions = {}): T {
@@ -74,7 +79,9 @@ export function runWithWriteRetry<T>(operation: () => T, {
     } catch (error) {
       const info = diagnostics(error);
       if (info) info.attempts = attempt;
-      if (!isRetryableWriteFailure(error) || attempt >= maxAttempts) throw error;
+      const retryable = isRetryableWriteFailure(error)
+        || (retryOnBeginBusy && isBeginBusyFailure(error));
+      if (!retryable || attempt >= maxAttempts) throw error;
       const remaining = budgetMs - (now() - startedAt);
       if (remaining <= 0) throw error;
       sleep(Math.min(retryDelayMs * attempt, remaining));

--- a/packages/core/src/write-coordinator.ts
+++ b/packages/core/src/write-coordinator.ts
@@ -1,6 +1,7 @@
 // Core's bounded retry policy above the transaction primitive. Callers opt in only for
-// idempotent work; BEGIN contention and an uncertain/live transaction are never
-// retried here.
+// idempotent work; an uncertain/live transaction is never retried. BEGIN contention is
+// not retried by default — builds defer it to their scheduler — but idempotent callers
+// without a scheduler (e.g. attune) may opt in via retryOnBeginBusy.
 
 import { runWriteTransaction, type WriteTxDb, type WriteTxOptions } from './tx.ts';
 

--- a/skill-doc/references/api-reference.md
+++ b/skill-doc/references/api-reference.md
@@ -79,6 +79,11 @@ remember, forget
 `--attune` does not expose `search()`, `sql()`, `memories()`, or other read
 helpers. If you need IDs, discover them first with a normal `--query` script.
 
+Memory writes are independent of index writes: `--attune` does not refresh the
+index, does not read provider settings, and works while the app daemon owns
+index writes. It requires an already-initialized index (run any query or
+`obelisk --build` once first) and fails honestly otherwise.
+
 ---
 
 ## Core Helpers

--- a/tests/attune-contention.test.mjs
+++ b/tests/attune-contention.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Lock-contention test for the attune memory carve-out, exercising the real
 // openAttuneDb + executeAttune combination: the connection busy_timeout is
 // deliberately short (250 ms), so a contended BEGIN IMMEDIATE fails fast and

--- a/tests/attune-contention.test.mjs
+++ b/tests/attune-contention.test.mjs
@@ -1,0 +1,74 @@
+// Lock-contention test for the attune memory carve-out, exercising the real
+// openAttuneDb + executeAttune combination: the connection busy_timeout is
+// deliberately short (250 ms), so a contended BEGIN IMMEDIATE fails fast and
+// the retry layer (budgetMs: 5000, retryOnBeginBusy) owns the waiting. Without
+// that layering the first BEGIN would fail at ~250 ms and the mutation would
+// error out while the lock is still held.
+//
+// HOME must point at the fixture root BEFORE any core module is imported: the
+// core db path is derived from homedir() at module load time.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { spawn } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { makeTempDir } from './temp-dirs.mjs';
+
+const home = makeTempDir('obelisk-attune-contention-');
+process.env.HOME = home;
+process.env.USERPROFILE = home;
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require('node:sqlite');
+
+const { executeAttune } = await import('../packages/core/src/core.ts');
+
+test('attune mutation succeeds through real lock contention via the retry budget', async () => {
+  const obeliskDir = join(home, '.obelisk');
+  mkdirSync(obeliskDir, { recursive: true });
+  const dbPath = join(obeliskDir, 'obelisk.sqlite');
+  const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+
+  const setup = new DatabaseSync(dbPath);
+  setup.exec(schema);
+  setup.close();
+
+  const memoryPath = join(home, 'memory.md');
+  writeFileSync(memoryPath, '# Contended memory\n');
+
+  // A child process holds the write lock well past the 250 ms connection
+  // busy_timeout. It must be a separate process: the retry layer's backoff
+  // sleep blocks this thread's event loop, so an in-process timer could not
+  // fire between attempts.
+  const holder = spawn(process.execPath, ['-e', `
+    const { DatabaseSync } = require('node:sqlite');
+    const db = new DatabaseSync(process.argv[1]);
+    db.exec('PRAGMA busy_timeout=0; BEGIN IMMEDIATE');
+    setTimeout(() => { db.exec('ROLLBACK'); db.close(); }, 800);
+  `, dbPath]);
+  const holderExit = new Promise(resolve => holder.on('exit', resolve));
+  // Give the child a moment to acquire the lock before contending.
+  await new Promise(resolve => setTimeout(resolve, 150));
+
+  try {
+    const result = await executeAttune(`
+      return remember({
+        path: ${JSON.stringify(memoryPath)},
+        project: 'contention-test',
+        summary: 'Decision: attune waits out a bounded lock hold and still writes.'
+      });
+    `);
+    assert.ok(result.id);
+    assert.equal(result.project, 'contention-test');
+  } finally {
+    holder.kill();
+    await holderExit;
+  }
+
+  const check = new DatabaseSync(dbPath, { readOnly: true });
+  const row = check.prepare("SELECT summary FROM memories WHERE project='contention-test'").get();
+  assert.match(row.summary, /waits out a bounded lock hold/);
+  check.close();
+});

--- a/tests/attune-contention.test.mjs
+++ b/tests/attune-contention.test.mjs
@@ -39,18 +39,28 @@ test('attune mutation succeeds through real lock contention via the retry budget
   writeFileSync(memoryPath, '# Contended memory\n');
 
   // A child process holds the write lock well past the 250 ms connection
-  // busy_timeout. It must be a separate process: the retry layer's backoff
-  // sleep blocks this thread's event loop, so an in-process timer could not
-  // fire between attempts.
+  // busy_timeout and across several retry attempts. It must be a separate
+  // process: the retry layer's backoff sleep blocks this thread's event loop,
+  // so an in-process timer could not fire between attempts. The child prints
+  // 'ready' only after BEGIN IMMEDIATE succeeds — without this handshake the
+  // test could pass with no contention at all (e.g. on a slow CI where the
+  // child has not acquired the lock yet).
   const holder = spawn(process.execPath, ['-e', `
     const { DatabaseSync } = require('node:sqlite');
     const db = new DatabaseSync(process.argv[1]);
     db.exec('PRAGMA busy_timeout=0; BEGIN IMMEDIATE');
-    setTimeout(() => { db.exec('ROLLBACK'); db.close(); }, 800);
+    process.stdout.write('ready');
+    setTimeout(() => { db.exec('ROLLBACK'); db.close(); }, 1500);
   `, dbPath]);
   const holderExit = new Promise(resolve => holder.on('exit', resolve));
-  // Give the child a moment to acquire the lock before contending.
-  await new Promise(resolve => setTimeout(resolve, 150));
+  // Wait for the child to actually hold the lock before contending, and fail
+  // fast if it died before signalling (e.g. it never acquired the lock).
+  await new Promise((resolve, reject) => {
+    holder.stdout.once('data', chunk => {
+      if (chunk.toString().includes('ready')) resolve();
+    });
+    holder.once('exit', code => reject(new Error(`lock holder exited before ready (code ${code})`)));
+  });
 
   try {
     const result = await executeAttune(`

--- a/tests/daemon-arbitration.test.mjs
+++ b/tests/daemon-arbitration.test.mjs
@@ -171,6 +171,49 @@ test('attune reports honestly when the memory layer is incomplete', () => {
   check.close();
 });
 
+test('attune rejects a forged memory layer with hollow lookalikes', () => {
+  const home = makeTempDir('obelisk-daemon-attune-forged-');
+  const obeliskDir = join(home, '.obelisk');
+  mkdirSync(obeliskDir, { recursive: true });
+  // A plain table named memories_fts and hollow triggers with the right
+  // names: passes a name-only check, but recall would break. Attune must
+  // refuse, not accept writes that can never be recalled.
+  const dbPath = join(obeliskDir, 'obelisk.sqlite');
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE memories (
+      id TEXT PRIMARY KEY, session_id TEXT, project TEXT,
+      message_start TEXT, message_end TEXT,
+      path TEXT, anchors TEXT, summary TEXT, created_at TEXT,
+      deleted_at TEXT, deleted_reason TEXT
+    );
+    CREATE TABLE memories_fts (id TEXT, path TEXT, summary TEXT);
+    CREATE TRIGGER memories_fts_ai AFTER INSERT ON memories BEGIN SELECT 1; END;
+    CREATE TRIGGER memories_fts_ad AFTER DELETE ON memories BEGIN SELECT 1; END;
+    CREATE TRIGGER memories_fts_au AFTER UPDATE ON memories BEGIN SELECT 1; END;
+  `);
+  db.close();
+
+  const memoryPath = join(home, 'memory.md');
+  const attunePath = join(home, 'attune.mjs');
+  writeFileSync(memoryPath, '# Forged layer\n');
+  writeFileSync(attunePath, `
+    return remember({
+      path: ${JSON.stringify(memoryPath)},
+      project: 'forged-test',
+      summary: 'Decision: this write must be refused, not silently unrecallable.'
+    });
+  `);
+
+  const result = runCli(['--attune', attunePath], { home });
+  assert.equal(result.status, 1);
+  assert.match(JSON.parse(result.stdout).error, /predates the memory layer/i);
+
+  const check = new DatabaseSync(dbPath, { readOnly: true });
+  assert.equal(check.prepare('SELECT COUNT(*) AS c FROM memories').get().c, 0);
+  check.close();
+});
+
 test('a passive query stays read-only when another process holds the writer lease', () => {
   const home = makeTempDir('obelisk-writer-owned-');
   const obeliskDir = join(home, '.obelisk');

--- a/tests/daemon-arbitration.test.mjs
+++ b/tests/daemon-arbitration.test.mjs
@@ -134,6 +134,43 @@ test('attune reports honestly when the index is not initialized', () => {
   assert.match(JSON.parse(result.stdout).error, /index is not initialized/i);
 });
 
+test('attune reports honestly when the memory layer is incomplete', () => {
+  const home = makeTempDir('obelisk-daemon-attune-partial-');
+  const obeliskDir = join(home, '.obelisk');
+  mkdirSync(obeliskDir, { recursive: true });
+  // A database with a full-column memories table but no memories_fts or
+  // maintenance triggers: writes would "succeed" yet never be recallable.
+  const db = new DatabaseSync(join(obeliskDir, 'obelisk.sqlite'));
+  db.exec(`
+    CREATE TABLE memories (
+      id TEXT PRIMARY KEY, session_id TEXT, project TEXT,
+      message_start TEXT, message_end TEXT,
+      path TEXT, anchors TEXT, summary TEXT, created_at TEXT,
+      deleted_at TEXT, deleted_reason TEXT
+    );
+  `);
+  db.close();
+
+  const memoryPath = join(home, 'memory.md');
+  const attunePath = join(home, 'attune.mjs');
+  writeFileSync(memoryPath, '# Unreachable memory\n');
+  writeFileSync(attunePath, `
+    return remember({
+      path: ${JSON.stringify(memoryPath)},
+      project: 'partial-test',
+      summary: 'Decision: this write must be refused, not silently unrecallable.'
+    });
+  `);
+
+  const result = runCli(['--attune', attunePath], { home });
+  assert.equal(result.status, 1);
+  assert.match(JSON.parse(result.stdout).error, /predates the memory layer/i);
+
+  const check = new DatabaseSync(join(obeliskDir, 'obelisk.sqlite'), { readOnly: true });
+  assert.equal(check.prepare('SELECT COUNT(*) AS c FROM memories').get().c, 0);
+  check.close();
+});
+
 test('a passive query stays read-only when another process holds the writer lease', () => {
   const home = makeTempDir('obelisk-writer-owned-');
   const obeliskDir = join(home, '.obelisk');

--- a/tests/daemon-arbitration.test.mjs
+++ b/tests/daemon-arbitration.test.mjs
@@ -267,38 +267,50 @@ test('attune rejects a layer whose UPDATE trigger does not maintain the FTS', ()
   check.close();
 });
 
-test('attune rejects a memories table whose id is not a primary key', () => {
-  const home = makeTempDir('obelisk-daemon-attune-no-pk-');
-  const obeliskDir = join(home, '.obelisk');
-  mkdirSync(obeliskDir, { recursive: true });
-  // Full columns, real FTS, real triggers — but id is plain TEXT. Without
-  // the primary key, remember ids lose uniqueness and forget() can update
-  // several rows at once.
-  const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
-  const dbPath = join(obeliskDir, 'obelisk.sqlite');
-  const db = new DatabaseSync(dbPath);
-  db.exec(schema.replace('CREATE TABLE IF NOT EXISTS memories (\n  id TEXT PRIMARY KEY,', 'CREATE TABLE IF NOT EXISTS memories (\n  id TEXT,'));
-  assert.equal(db.prepare('PRAGMA table_info(memories)').all().find(row => row.name === 'id').pk, 0);
-  db.close();
+test('attune rejects a memories table whose id is not the sole primary key', () => {
+  const variants = {
+    // id is plain TEXT: no uniqueness at all.
+    'no-pk': 'CREATE TABLE IF NOT EXISTS memories (\n  id TEXT,',
+    // PRIMARY KEY (id, project): id.pk > 0 yet duplicate ids still allowed.
+    'composite-pk': 'CREATE TABLE IF NOT EXISTS memories (\n  id TEXT, session_id TEXT, project TEXT,\n  message_start TEXT, message_end TEXT,\n  path TEXT, anchors TEXT, summary TEXT, created_at TEXT,\n  deleted_at TEXT, deleted_reason TEXT,\n  PRIMARY KEY (id, project));',
+  };
+  for (const [name, memoriesDdl] of Object.entries(variants)) {
+    const home = makeTempDir(`obelisk-daemon-attune-${name}-`);
+    const obeliskDir = join(home, '.obelisk');
+    mkdirSync(obeliskDir, { recursive: true });
+    // Full columns, real FTS, real triggers — only the memories table's
+    // primary key deviates. Without id as the sole key, remember ids lose
+    // uniqueness and forget() can update several rows at once.
+    const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+    const dbPath = join(obeliskDir, 'obelisk.sqlite');
+    const db = new DatabaseSync(dbPath);
+    if (name === 'no-pk') {
+      db.exec(schema.replace('CREATE TABLE IF NOT EXISTS memories (\n  id TEXT PRIMARY KEY,', memoriesDdl));
+    } else {
+      const memoriesBlock = schema.match(/CREATE TABLE IF NOT EXISTS memories \([\s\S]+?\);/)[0];
+      db.exec(schema.replace(memoriesBlock, memoriesDdl));
+    }
+    db.close();
 
-  const memoryPath = join(home, 'memory.md');
-  const attunePath = join(home, 'attune.mjs');
-  writeFileSync(memoryPath, '# No primary key\n');
-  writeFileSync(attunePath, `
-    return remember({
-      path: ${JSON.stringify(memoryPath)},
-      project: 'no-pk-test',
-      summary: 'Decision: this write must be refused without a primary key.'
-    });
-  `);
+    const memoryPath = join(home, 'memory.md');
+    const attunePath = join(home, 'attune.mjs');
+    writeFileSync(memoryPath, '# Bad primary key\n');
+    writeFileSync(attunePath, `
+      return remember({
+        path: ${JSON.stringify(memoryPath)},
+        project: '${name}-test',
+        summary: 'Decision: this write must be refused without a sole primary key.'
+      });
+    `);
 
-  const result = runCli(['--attune', attunePath], { home });
-  assert.equal(result.status, 1);
-  assert.match(JSON.parse(result.stdout).error, /predates the memory layer/i);
+    const result = runCli(['--attune', attunePath], { home });
+    assert.equal(result.status, 1, `${name}: ${result.stderr || result.stdout}`);
+    assert.match(JSON.parse(result.stdout).error, /predates the memory layer/i);
 
-  const check = new DatabaseSync(dbPath, { readOnly: true });
-  assert.equal(check.prepare('SELECT COUNT(*) AS c FROM memories').get().c, 0);
-  check.close();
+    const check = new DatabaseSync(dbPath, { readOnly: true });
+    assert.equal(check.prepare('SELECT COUNT(*) AS c FROM memories').get().c, 0, name);
+    check.close();
+  }
 });
 
 test('an attune probe leaves no persistent state behind', () => {

--- a/tests/daemon-arbitration.test.mjs
+++ b/tests/daemon-arbitration.test.mjs
@@ -175,9 +175,9 @@ test('attune rejects a forged memory layer with hollow lookalikes', () => {
   const home = makeTempDir('obelisk-daemon-attune-forged-');
   const obeliskDir = join(home, '.obelisk');
   mkdirSync(obeliskDir, { recursive: true });
-  // A plain table named memories_fts and hollow triggers with the right
-  // names: passes a name-only check, but recall would break. Attune must
-  // refuse, not accept writes that can never be recalled.
+  // A REAL FTS5 table plus triggers whose bodies only *mention* memories_fts
+  // without maintaining it: passes name- and DDL-level checks, but a probe
+  // write can never be recalled. Attune must refuse.
   const dbPath = join(obeliskDir, 'obelisk.sqlite');
   const db = new DatabaseSync(dbPath);
   db.exec(`
@@ -187,10 +187,13 @@ test('attune rejects a forged memory layer with hollow lookalikes', () => {
       path TEXT, anchors TEXT, summary TEXT, created_at TEXT,
       deleted_at TEXT, deleted_reason TEXT
     );
-    CREATE TABLE memories_fts (id TEXT, path TEXT, summary TEXT);
-    CREATE TRIGGER memories_fts_ai AFTER INSERT ON memories BEGIN SELECT 1; END;
-    CREATE TRIGGER memories_fts_ad AFTER DELETE ON memories BEGIN SELECT 1; END;
-    CREATE TRIGGER memories_fts_au AFTER UPDATE ON memories BEGIN SELECT 1; END;
+    CREATE VIRTUAL TABLE memories_fts USING fts5(
+      id UNINDEXED, path, summary,
+      content=memories, content_rowid=rowid,
+      tokenize='unicode61 remove_diacritics 1');
+    CREATE TRIGGER memories_fts_ai AFTER INSERT ON memories BEGIN SELECT 'memories_fts'; END;
+    CREATE TRIGGER memories_fts_ad AFTER DELETE ON memories BEGIN SELECT 'memories_fts'; END;
+    CREATE TRIGGER memories_fts_au AFTER UPDATE ON memories BEGIN SELECT 'memories_fts'; END;
   `);
   db.close();
 

--- a/tests/daemon-arbitration.test.mjs
+++ b/tests/daemon-arbitration.test.mjs
@@ -267,6 +267,70 @@ test('attune rejects a layer whose UPDATE trigger does not maintain the FTS', ()
   check.close();
 });
 
+test('attune rejects a memories table whose id is not a primary key', () => {
+  const home = makeTempDir('obelisk-daemon-attune-no-pk-');
+  const obeliskDir = join(home, '.obelisk');
+  mkdirSync(obeliskDir, { recursive: true });
+  // Full columns, real FTS, real triggers — but id is plain TEXT. Without
+  // the primary key, remember ids lose uniqueness and forget() can update
+  // several rows at once.
+  const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+  const dbPath = join(obeliskDir, 'obelisk.sqlite');
+  const db = new DatabaseSync(dbPath);
+  db.exec(schema.replace('CREATE TABLE IF NOT EXISTS memories (\n  id TEXT PRIMARY KEY,', 'CREATE TABLE IF NOT EXISTS memories (\n  id TEXT,'));
+  assert.equal(db.prepare('PRAGMA table_info(memories)').all().find(row => row.name === 'id').pk, 0);
+  db.close();
+
+  const memoryPath = join(home, 'memory.md');
+  const attunePath = join(home, 'attune.mjs');
+  writeFileSync(memoryPath, '# No primary key\n');
+  writeFileSync(attunePath, `
+    return remember({
+      path: ${JSON.stringify(memoryPath)},
+      project: 'no-pk-test',
+      summary: 'Decision: this write must be refused without a primary key.'
+    });
+  `);
+
+  const result = runCli(['--attune', attunePath], { home });
+  assert.equal(result.status, 1);
+  assert.match(JSON.parse(result.stdout).error, /predates the memory layer/i);
+
+  const check = new DatabaseSync(dbPath, { readOnly: true });
+  assert.equal(check.prepare('SELECT COUNT(*) AS c FROM memories').get().c, 0);
+  check.close();
+});
+
+test('an attune probe leaves no persistent state behind', () => {
+  const home = makeTempDir('obelisk-daemon-attune-clean-');
+  const obeliskDir = join(home, '.obelisk');
+  mkdirSync(obeliskDir, { recursive: true });
+  const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+  const dbPath = join(obeliskDir, 'obelisk.sqlite');
+  const db = new DatabaseSync(dbPath);
+  db.exec(schema);
+  db.prepare("INSERT INTO memories (id, path, summary, created_at) VALUES ('mem-1', '/m.md', 'existing memory', '2026-01-01T00:00:00Z')").run();
+  db.close();
+
+  const dumpMemoryTables = () => {
+    const reader = new DatabaseSync(dbPath, { readOnly: true });
+    const tables = reader.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'memories%' ORDER BY name").all().map(row => row.name);
+    const dump = Object.fromEntries(tables.map(table => [table, reader.prepare(`SELECT * FROM ${table} ORDER BY 1`).all()]));
+    reader.close();
+    return dump;
+  };
+  const before = dumpMemoryTables();
+
+  const attunePath = join(home, 'attune.mjs');
+  writeFileSync(attunePath, 'return true;');
+  const result = runCli(['--attune', attunePath], { home });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  // Not just the logical rows: the FTS5 shadow tables must be untouched too
+  // (the probe rolls its writes back via SAVEPOINT, never committing churn).
+  assert.deepEqual(dumpMemoryTables(), before);
+});
+
 test('a passive query stays read-only when another process holds the writer lease', () => {
   const home = makeTempDir('obelisk-writer-owned-');
   const obeliskDir = join(home, '.obelisk');

--- a/tests/daemon-arbitration.test.mjs
+++ b/tests/daemon-arbitration.test.mjs
@@ -76,28 +76,62 @@ test('a passive query reports when a daemon blocks its schema upgrade', () => {
   check.close();
 });
 
-test('attune refuses to mutate the index while a fresh daemon owns writes', () => {
+test('attune writes memories while a fresh daemon owns index writes', () => {
   const home = makeTempDir('obelisk-daemon-attune-');
   const obeliskDir = join(home, '.obelisk');
   const dbPath = join(obeliskDir, 'obelisk.sqlite');
   mkdirSync(obeliskDir, { recursive: true });
+  const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
   const db = new DatabaseSync(dbPath);
-  db.exec('CREATE TABLE index_state (jsonl_path TEXT PRIMARY KEY, mtime REAL, lines_processed INTEGER)');
-  const marker = db.prepare('INSERT INTO index_state (jsonl_path, mtime, lines_processed) VALUES (?, ?, 0)');
-  const now = Date.now();
-  marker.run('__app_heartbeat__', now);
+  db.exec(schema);
+  db.prepare('INSERT INTO index_state (jsonl_path, mtime, lines_processed) VALUES (?, ?, 0)')
+    .run('__app_heartbeat__', Date.now());
   db.close();
 
+  // A live transcript that an index build would pick up: attune must not
+  // trigger any indexing while the daemon owns writes.
+  const projectDir = join(home, '.claude', 'projects', '-proj');
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(join(projectDir, 'sid-live.jsonl'), `${JSON.stringify({
+    uuid: 'msg-live', type: 'user', timestamp: '2026-06-10T10:00:00Z',
+    message: { role: 'user', content: 'must stay unindexed' },
+  })}\n`);
+
+  const memoryPath = join(home, 'memory.md');
   const attunePath = join(home, 'attune.mjs');
-  writeFileSync(attunePath, 'return true;');
+  writeFileSync(memoryPath, '# Daemon-time memory\n');
+  writeFileSync(attunePath, `
+    return remember({
+      path: ${JSON.stringify(memoryPath)},
+      project: 'daemon-test',
+      summary: 'Decision: memory writes stay available while the daemon owns index writes.'
+    });
+  `);
   const result = runCli(['--attune', attunePath], { home });
-  assert.equal(result.status, 1);
-  assert.match(JSON.parse(result.stdout).error, /daemon owns index writes/i);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.project, 'daemon-test');
+  assert.ok(payload.id);
 
   const check = new DatabaseSync(dbPath, { readOnly: true });
-  const tables = check.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all().map(row => row.name);
+  const memory = check.prepare('SELECT summary, deleted_at FROM memories WHERE id=?').get(payload.id);
+  assert.match(memory.summary, /memory writes stay available/);
+  assert.equal(memory.deleted_at, null);
+  // The FTS trigger fired, so recall sees the memory immediately.
+  assert.ok(check.prepare("SELECT id FROM memories_fts WHERE memories_fts MATCH 'daemon'").all().some(row => row.id === payload.id));
+  // No index build ran as a side effect of attune.
+  assert.equal(check.prepare('SELECT COUNT(*) AS c FROM messages').get().c, 0);
   check.close();
-  assert.deepEqual(tables, ['index_state']);
+});
+
+test('attune reports honestly when the index is not initialized', () => {
+  const home = makeTempDir('obelisk-daemon-attune-empty-');
+  const attunePath = join(home, 'attune.mjs');
+  writeFileSync(attunePath, 'return true;');
+
+  const result = runCli(['--attune', attunePath], { home });
+  assert.equal(result.status, 1);
+  assert.match(JSON.parse(result.stdout).error, /index is not initialized/i);
 });
 
 test('a passive query stays read-only when another process holds the writer lease', () => {

--- a/tests/daemon-arbitration.test.mjs
+++ b/tests/daemon-arbitration.test.mjs
@@ -220,6 +220,53 @@ test('attune rejects a forged memory layer with hollow lookalikes', () => {
   check.close();
 });
 
+test('attune rejects a layer whose UPDATE trigger does not maintain the FTS', () => {
+  const home = makeTempDir('obelisk-daemon-attune-hollow-au-');
+  const obeliskDir = join(home, '.obelisk');
+  mkdirSync(obeliskDir, { recursive: true });
+  // Real INSERT/DELETE triggers from the schema, but a hollow UPDATE trigger:
+  // only a probe with an UPDATE leg can catch this.
+  const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+  const realTrigger = (name) => schema.match(new RegExp(`CREATE TRIGGER IF NOT EXISTS ${name}[\\s\\S]+?END;`))?.[0];
+  const dbPath = join(obeliskDir, 'obelisk.sqlite');
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE memories (
+      id TEXT PRIMARY KEY, session_id TEXT, project TEXT,
+      message_start TEXT, message_end TEXT,
+      path TEXT, anchors TEXT, summary TEXT, created_at TEXT,
+      deleted_at TEXT, deleted_reason TEXT
+    );
+    CREATE VIRTUAL TABLE memories_fts USING fts5(
+      id UNINDEXED, path, summary,
+      content=memories, content_rowid=rowid,
+      tokenize='unicode61 remove_diacritics 1');
+    ${realTrigger('memories_fts_ai')}
+    ${realTrigger('memories_fts_ad')}
+    CREATE TRIGGER memories_fts_au AFTER UPDATE ON memories BEGIN SELECT 'memories_fts'; END;
+  `);
+  db.close();
+
+  const memoryPath = join(home, 'memory.md');
+  const attunePath = join(home, 'attune.mjs');
+  writeFileSync(memoryPath, '# Hollow update trigger\n');
+  writeFileSync(attunePath, `
+    return remember({
+      path: ${JSON.stringify(memoryPath)},
+      project: 'hollow-au-test',
+      summary: 'Decision: this write must be refused while the update trigger is hollow.'
+    });
+  `);
+
+  const result = runCli(['--attune', attunePath], { home });
+  assert.equal(result.status, 1);
+  assert.match(JSON.parse(result.stdout).error, /predates the memory layer/i);
+
+  const check = new DatabaseSync(dbPath, { readOnly: true });
+  assert.equal(check.prepare('SELECT COUNT(*) AS c FROM memories').get().c, 0);
+  check.close();
+});
+
 test('a passive query stays read-only when another process holds the writer lease', () => {
   const home = makeTempDir('obelisk-writer-owned-');
   const obeliskDir = join(home, '.obelisk');

--- a/tests/pi-runtime.test.mjs
+++ b/tests/pi-runtime.test.mjs
@@ -94,18 +94,15 @@ test('passive-pull runtime honors the same persisted Pi root as the app', () => 
 });
 
 test('passive CLI operations report an incomplete Pi inventory without hiding partial results', () => {
-  for (const command of ['search', 'query', 'attune']) {
+  // --attune is deliberately absent: memory writes no longer run an index
+  // build, so there is no inventory to report on that path.
+  for (const command of ['search', 'query']) {
     const home = makeTempDir(`obelisk-pi-partial-${command}-`);
     const piRoot = join(home, '.pi', 'agent', 'sessions');
     mkdirSync(dirname(piRoot), { recursive: true });
     writeFileSync(piRoot, 'not a directory');
     const queryPath = join(home, 'query.mjs');
-    writeFileSync(
-      queryPath,
-      command === 'attune'
-        ? 'return null;'
-        : "return sessions({ source: 'pi', limit: 5 });",
-    );
+    writeFileSync(queryPath, "return sessions({ source: 'pi', limit: 5 });");
     const args = command === 'search'
       ? ['--search', 'partial-probe']
       : [`--${command}`, queryPath];
@@ -116,7 +113,7 @@ test('passive CLI operations report an incomplete Pi inventory without hiding pa
     });
 
     assert.equal(result.status, 0, result.stderr || result.stdout);
-    assert.deepEqual(JSON.parse(result.stdout), command === 'attune' ? null : []);
+    assert.deepEqual(JSON.parse(result.stdout), []);
     assert.match(result.stderr, /Warning: incomplete pi source inventory/);
     assert.match(
       result.stderr,

--- a/tests/provider-schema-stability.test.mjs
+++ b/tests/provider-schema-stability.test.mjs
@@ -15,13 +15,16 @@ test('canonical transcript persistence schema changes only by explicit decision'
   );
 });
 
-test('attune memory-layer expectations stay in sync with schema.sql', () => {
-  const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
-  const memoriesBlock = schema.match(/CREATE TABLE IF NOT EXISTS memories \(([^;]+)\);/s)?.[1];
-  assert.ok(memoriesBlock);
-  const columns = memoriesBlock.split(',').map(part => part.trim().split(/\s+/)[0]);
-  assert.deepEqual([...ATTUNE_MEMORY_COLUMNS], columns);
-
-  const triggers = [...schema.matchAll(/CREATE TRIGGER IF NOT EXISTS (memories_fts_\w+)/g)].map(match => match[1]);
-  assert.deepEqual([...ATTUNE_MEMORY_TRIGGERS], triggers);
+test('attune memory-layer expectations derive from schema.sql', () => {
+  // The attune compatibility check derives its expected memory-layer shape
+  // from schema.sql at module load. Pin the derivation result so a schema
+  // evolution (or a format change that breaks the derivation) surfaces here
+  // as an explicit decision, never as a silent behavior change.
+  assert.deepEqual([...ATTUNE_MEMORY_COLUMNS], [
+    'id', 'session_id', 'project', 'message_start', 'message_end',
+    'path', 'anchors', 'summary', 'created_at', 'deleted_at', 'deleted_reason',
+  ]);
+  assert.deepEqual([...ATTUNE_MEMORY_TRIGGERS], [
+    'memories_fts_ai', 'memories_fts_ad', 'memories_fts_au',
+  ]);
 });

--- a/tests/provider-schema-stability.test.mjs
+++ b/tests/provider-schema-stability.test.mjs
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 
+import { ATTUNE_MEMORY_COLUMNS, ATTUNE_MEMORY_TRIGGERS } from '../packages/core/src/db.ts';
+
 test('canonical transcript persistence schema changes only by explicit decision', () => {
   const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url));
   assert.equal(
@@ -11,4 +13,15 @@ test('canonical transcript persistence schema changes only by explicit decision'
     // invocation-nonce resolver can bound its tool_calls scan to recent rows.
     '712df79e346a09f753deeb951f975c36f0148bfe047df68830fbc7e172aec09a',
   );
+});
+
+test('attune memory-layer expectations stay in sync with schema.sql', () => {
+  const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+  const memoriesBlock = schema.match(/CREATE TABLE IF NOT EXISTS memories \(([^;]+)\);/s)?.[1];
+  assert.ok(memoriesBlock);
+  const columns = memoriesBlock.split(',').map(part => part.trim().split(/\s+/)[0]);
+  assert.deepEqual([...ATTUNE_MEMORY_COLUMNS], columns);
+
+  const triggers = [...schema.matchAll(/CREATE TRIGGER IF NOT EXISTS (memories_fts_\w+)/g)].map(match => match[1]);
+  assert.deepEqual([...ATTUNE_MEMORY_TRIGGERS], triggers);
 });

--- a/tests/query.test.mjs
+++ b/tests/query.test.mjs
@@ -541,6 +541,45 @@ test('attune api exposes only memory mutation helpers', () => {
   db.close();
 });
 
+test('remember regenerates the id on a primary-key collision instead of overwriting', () => {
+  const memoryDir = makeTempDir('obelisk-remember-collision-');
+  const memoryPath = join(memoryDir, 'memory.md');
+  writeFileSync(memoryPath, '# Memory\n');
+
+  const inserted = [];
+  let failFirstInsert = true;
+  const fakeDb = {
+    prepare(sql) {
+      if (sql.startsWith('INSERT INTO memories')) {
+        return {
+          run: (...args) => {
+            if (failFirstInsert) {
+              failFirstInsert = false;
+              throw new Error('UNIQUE constraint failed: memories.id');
+            }
+            inserted.push(args);
+          },
+        };
+      }
+      throw new Error(`unexpected SQL: ${sql}`);
+    },
+    exec() {},
+    close() {},
+  };
+
+  const result = createAttuneApi(fakeDb).remember({
+    path: memoryPath,
+    project: 'collision-test',
+    summary: 'Decision: memory ids regenerate on collision instead of overwriting.',
+  });
+
+  // The first id collided; the persisted row must carry a regenerated id,
+  // and the existing row was never replaced (plain INSERT, not OR REPLACE).
+  assert.equal(inserted.length, 1);
+  assert.equal(inserted[0][0], result.id);
+  assert.match(result.id, /^mem-[0-9a-f-]{36}$/);
+});
+
 test('remember stores absolute project-relative memory path', () => {
   const projectDir = makeTempDir('obelisk-memory-project-');
   const memoryDir = join(projectDir, '.obelisk', 'memories');

--- a/tests/query.test.mjs
+++ b/tests/query.test.mjs
@@ -547,15 +547,19 @@ test('remember regenerates the id on a primary-key collision instead of overwrit
   writeFileSync(memoryPath, '# Memory\n');
 
   const inserted = [];
+  const attempted = [];
   let failFirstInsert = true;
   const fakeDb = {
     prepare(sql) {
       if (sql.startsWith('INSERT INTO memories')) {
         return {
           run: (...args) => {
+            attempted.push(args[0]);
             if (failFirstInsert) {
               failFirstInsert = false;
-              throw new Error('UNIQUE constraint failed: memories.id');
+              const error = new Error('UNIQUE constraint failed: memories.id');
+              error.errcode = 1555; // SQLITE_CONSTRAINT_PRIMARYKEY
+              throw error;
             }
             inserted.push(args);
           },
@@ -573,10 +577,14 @@ test('remember regenerates the id on a primary-key collision instead of overwrit
     summary: 'Decision: memory ids regenerate on collision instead of overwriting.',
   });
 
-  // The first id collided; the persisted row must carry a regenerated id,
+  // The first attempt collided; the persisted row must carry a REGENERATED
+  // id (a retry of the same id would satisfy inserted[0][0] === result.id),
   // and the existing row was never replaced (plain INSERT, not OR REPLACE).
+  assert.equal(attempted.length, 2);
+  assert.notEqual(attempted[0], attempted[1]);
   assert.equal(inserted.length, 1);
   assert.equal(inserted[0][0], result.id);
+  assert.equal(attempted[1], result.id);
   assert.match(result.id, /^mem-[0-9a-f-]{36}$/);
 });
 

--- a/tests/runtime-cli-envelope.test.mjs
+++ b/tests/runtime-cli-envelope.test.mjs
@@ -77,6 +77,12 @@ test('--query surfaces a throw as { error, stack } and exits 1', () => {
 
 test('--attune surfaces a throw as { error, stack } and exits 1', () => {
   const home = tempHome();
+  // Attune requires an initialized index; bring one up so the script's own
+  // throw is what surfaces.
+  const initPath = join(home, 'init.mjs');
+  writeFileSync(initPath, "return 'init';");
+  const init = runRuntime(['--query', initPath], { home });
+  assert.equal(init.status, 0, init.stderr || init.stdout);
   const scriptPath = join(home, 'attune-boom.mjs');
   writeFileSync(scriptPath, "throw new Error('attune-envelope');");
 

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -68,19 +68,21 @@ test('malformed Obelisk settings skip refresh without disabling provider-backed 
   assert.match(JSON.parse(rebuild.stdout).error, /settings_unavailable/);
   assert.match(JSON.parse(rebuild.stdout).error, /Unable to read Obelisk settings/);
 
-  const memoryPath = join(home, 'blocked-memory.md');
+  const memoryPath = join(home, 'settings-free-memory.md');
   const attunePath = join(home, 'attune.mjs');
-  writeFileSync(memoryPath, '# Blocked memory\n');
+  writeFileSync(memoryPath, '# Settings-free memory\n');
   writeFileSync(attunePath, `
     return remember({
       path: ${JSON.stringify(memoryPath)},
       project: 'runtime-test',
-      summary: 'Decision: this mutation must not use an index with unavailable settings.'
+      summary: 'Decision: memory writes do not depend on provider settings.'
     });
   `);
+  // Memory writes touch only the memories table, so they stay available even
+  // while provider settings are unreadable.
   const attune = runRuntime(['--attune', attunePath], { home });
-  assert.equal(attune.status, 1);
-  assert.match(JSON.parse(attune.stdout).error, /settings.*attune was not applied/i);
+  assert.equal(attune.status, 0, attune.stderr || attune.stdout);
+  assert.equal(JSON.parse(attune.stdout).project, 'runtime-test');
 });
 
 test('runtime attune scripts expose only memory mutation helpers', () => {
@@ -88,6 +90,11 @@ test('runtime attune scripts expose only memory mutation helpers', () => {
   const memoryPath = join(home, 'memory.md');
   const scriptPath = join(home, 'attune.mjs');
   writeFileSync(memoryPath, '# Memory\n');
+  // Attune no longer builds the index itself; initialize it with a query first.
+  const initPath = join(home, 'init.mjs');
+  writeFileSync(initPath, "return 'init';");
+  const init = runRuntime(['--query', initPath], { home });
+  assert.equal(init.status, 0, init.stderr || init.stdout);
   writeFileSync(scriptPath, `
     return {
       rememberType: typeof remember,

--- a/tests/write-transaction.test.mjs
+++ b/tests/write-transaction.test.mjs
@@ -4,7 +4,7 @@ import { createRequire } from 'node:module';
 import { join } from 'node:path';
 
 import { nodeSqliteTransactionAdapter, runWriteTransaction } from '../packages/core/src/tx.ts';
-import { hasUnusableTransaction, isBeginBusyFailure, isRetryableWriteFailure } from '../packages/core/src/write-coordinator.ts';
+import { hasUnusableTransaction, isBeginBusyFailure, isRetryableWriteFailure, runRetryableWriteTransaction } from '../packages/core/src/write-coordinator.ts';
 import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
@@ -162,4 +162,38 @@ test('a BEGIN failure with an active transaction is not deferrable', () => {
   assert.equal(primary.obelisk.transactionActive, true);
   assert.equal(hasUnusableTransaction(primary), true);
   assert.equal(isBeginBusyFailure(primary), false);
+});
+
+test('BEGIN-busy is retried only when explicitly opted in', () => {
+  const dbPath = join(makeTempDir('obelisk-begin-retry-'), 'index.sqlite');
+  const holder = new DatabaseSync(dbPath);
+  holder.exec('PRAGMA busy_timeout=0; CREATE TABLE t (value TEXT); BEGIN IMMEDIATE');
+  const contender = new DatabaseSync(dbPath);
+  contender.exec('PRAGMA busy_timeout=0');
+  const txDb = nodeSqliteTransactionAdapter(contender);
+
+  try {
+    // Default policy: BEGIN contention is deferred to the caller, not retried.
+    let workCalls = 0;
+    assert.throws(
+      () => runRetryableWriteTransaction(txDb, () => { workCalls += 1; }),
+      error => isBeginBusyFailure(error) && error.obelisk.attempts === 1,
+    );
+    assert.equal(workCalls, 0);
+
+    // Opted in: the retry runs the work once the holder releases (the injected
+    // sleep releases the lock between attempts).
+    const result = runRetryableWriteTransaction(
+      txDb,
+      () => { contender.exec("INSERT INTO t VALUES ('x')"); return 'done'; },
+      {},
+      { retryOnBeginBusy: true, sleep: () => holder.exec('ROLLBACK') },
+    );
+    assert.equal(result, 'done');
+    assert.equal(contender.prepare('SELECT COUNT(*) AS c FROM t').get().c, 1);
+  } finally {
+    try { holder.exec('ROLLBACK'); } catch { /* already released by the retry sleep */ }
+    holder.close();
+    contender.close();
+  }
 });


### PR DESCRIPTION
## What and why

Resolves #55.

While the app daemon holds a fresh heartbeat, `obelisk --attune` previously refused to run: the pre-write `buildIndex` skipped with `daemon_active`, and the writer lease / heartbeat TOCTOU check blocked the rest. That made the CLI memory flow unusable whenever the app was open — without buying safety, because memory mutations are disjoint from index writes:

- `remember()`/`forget()` touch only the `memories` table and its FTS triggers; index builds — force rebuilds included — never delete from `memories`.
- `remember()` generates unique ids and `forget()` is idempotent, so concurrent attunes have no logical conflict for a mutex to prevent; WAL serializes writers, and contention is just a bounded busy retry.

## What changed

- `executeAttune` no longer reads provider settings, builds the index, checks daemon ownership, or acquires the writer lease.
- `openAttuneDb()` opens the existing database only — never creates, migrates, or configures the index — and checks the static shape (memory columns present, `id` the sole primary key). The behavioral check lives in `executeAttune`: a SAVEPOINT-wrapped probe (insert/FTS-recall/update/delete, random tokens, id-filtered) runs inside the retryable mutation wrapper and fails honestly ("run an index build first") when the memory layer cannot actually recall, leaving zero persistent state behind.
- Each mutation runs as one short `runRetryableWriteTransaction`, with `retryOnBeginBusy` opted in; `forget()` reads, decides, and updates in a single transaction.
- ADR 0006 gains a second amendment superseding the "attune stays read-only under a fresh heartbeat" rule; CONTRIBUTING.md's daemon-ownership bullet now names both carve-outs; `skill-doc/references/api-reference.md` documents the new contract.

## Non-breaking note

Behavior change is intentional: attune no longer refreshes the index (its only index dependency was a soft read of `sessions` for project inference, which degrades honestly to null/cwd fallback) and no longer requires readable provider settings. Memory recall (`memories()` in `--query`) is unchanged.

## Verification

- npm test — 462 passed, 0 failed (re-verified on a merge of latest main, incl. the #57 license headers); typecheck 0 errors; lint 0 errors, 4 pre-existing warnings.
- daemon-arbitration: the old "attune refuses while daemon owns writes" test is inverted — attune now writes the memory under a fresh heartbeat, the FTS trigger fires, and `messages` stays empty (proving no index build ran). New tests: uninitialized index and incomplete memory layer (no FTS/triggers) both fail honestly with zero writes.
- write-transaction: BEGIN-busy is not retried by default (build policy) and is retried when opted in — both directions pinned with a real lock holder.
- provider-schema-stability: a drift guard parses `schema.sql` and pins the attune memory-layer column/trigger expectations against it.
- runtime: malformed settings no longer block attune; the sandbox-envelope test initializes the index first so the script's own throw is what surfaces.
- pi-runtime: attune removed from the incomplete-inventory loop — with no index build on that path there is no inventory to report.
- The attune path is visibly cheaper now: the daemon-mode attune test runs in ~90ms vs ~4.3s for query tests that pay for an index build.

## Why the old daemon-attune assertion was wrong

The pre-change test asserted that attune **fails** while a fresh daemon owns writes, with zero writes observed. That assertion pinned a policy bug as expected behavior: it treated memory mutations as index writes. `remember()`/`forget()` touch only the memory layer (`memories` + `memories_fts` via triggers), which no index build — force rebuilds included — ever deletes from, and there is no multi-transaction state for the writer lease to protect. The inverted test now proves attune writes the memory under a fresh heartbeat, fires the FTS trigger, and runs no index build (`messages` stays empty).