### PR TITLE
chore: add copyright and SPDX license headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,4 +335,6 @@ ownership. The PR template mirrors them as per-area checklists.
 
 ## License
 
-AGPL-3.0 @tommy0103
+Copyright (C) 2026 tommy0103 and contributors.
+
+Obelisk is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0-only); see [LICENSE](LICENSE). Derivative works are welcome: if you distribute a modified version, please keep the per-file copyright notices intact and mark your modifications prominently with a date, as AGPL-3.0 §5 requires.

--- a/app/electron.vite.config.ts
+++ b/app/electron.vite.config.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { resolve } from 'node:path';
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 import vue from '@vitejs/plugin-vue';

--- a/app/src/main/file-reference.ts
+++ b/app/src/main/file-reference.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import fs from 'node:fs';
 import path from 'node:path';
 

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { app, BrowserWindow, ipcMain, clipboard, dialog, shell, type IpcMainInvokeEvent } from 'electron';
 import path from 'node:path';
 import os from 'node:os';

--- a/app/src/main/indexer-service.ts
+++ b/app/src/main/indexer-service.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';

--- a/app/src/main/indexer-worker-client.ts
+++ b/app/src/main/indexer-worker-client.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Worker } from 'node:worker_threads';

--- a/app/src/main/indexer-worker.ts
+++ b/app/src/main/indexer-worker.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { parentPort } from 'node:worker_threads';
 import { buildIndex } from './indexer.ts';
 

--- a/app/src/main/indexer.ts
+++ b/app/src/main/indexer.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';

--- a/app/src/main/provider-settings.ts
+++ b/app/src/main/provider-settings.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { ProviderRegistry } from '../../../packages/core/src/providers/registry.ts';
 export { resolveProviderRoots } from '../../../packages/core/src/provider-settings.ts';
 

--- a/app/src/main/recap-capture-query.ts
+++ b/app/src/main/recap-capture-query.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import path from 'node:path';
 
 function cleanRecapFilename(filename?: string | null): string {

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
 import type {
   SessionPatch,

--- a/app/src/renderer/src/App.vue
+++ b/app/src/renderer/src/App.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { computed, watch, ref, provide, onMounted, onUnmounted } from 'vue';
 import { useRouter, useRoute } from 'vue-router';

--- a/app/src/renderer/src/activity-ledger.mjs
+++ b/app/src/renderer/src/activity-ledger.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { sourceLabel } from './source-catalog.mjs';
 
 export function activitySourceKey(session) {

--- a/app/src/renderer/src/components/ActivityLedger.vue
+++ b/app/src/renderer/src/components/ActivityLedger.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { computed, reactive } from 'vue';
 import {

--- a/app/src/renderer/src/components/ActivityLedgerRow.vue
+++ b/app/src/renderer/src/components/ActivityLedgerRow.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { computed } from 'vue';
 import { formatProjectLabel } from '../utils.js';

--- a/app/src/renderer/src/components/FlapNumber.vue
+++ b/app/src/renderer/src/components/FlapNumber.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { computed, onUnmounted, ref, watch } from 'vue';
 import {

--- a/app/src/renderer/src/components/SessionImage.ce.vue
+++ b/app/src/renderer/src/components/SessionImage.ce.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue';
 import {

--- a/app/src/renderer/src/components/SessionTimelineRow.vue
+++ b/app/src/renderer/src/components/SessionTimelineRow.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { computed } from 'vue';
 import { isTextTruncated } from '../data.js';

--- a/app/src/renderer/src/components/recap/ClosingCard.vue
+++ b/app/src/renderer/src/components/recap/ClosingCard.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 defineProps({
   headline: String,

--- a/app/src/renderer/src/components/recap/CoverCard.vue
+++ b/app/src/renderer/src/components/recap/CoverCard.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { computed } from 'vue';
 import { CORNER_SEALS } from './seals.js';

--- a/app/src/renderer/src/components/recap/PathCard.vue
+++ b/app/src/renderer/src/components/recap/PathCard.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 defineProps({
   title: String,

--- a/app/src/renderer/src/components/recap/VibeCard.vue
+++ b/app/src/renderer/src/components/recap/VibeCard.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 defineProps({
   title: String,

--- a/app/src/renderer/src/components/recap/WorkflowCard.vue
+++ b/app/src/renderer/src/components/recap/WorkflowCard.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 defineProps({
   title: String,

--- a/app/src/renderer/src/components/recap/archetypes.js
+++ b/app/src/renderer/src/components/recap/archetypes.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export const PALETTES = {
   architect:    { tc: '#a78bfa', tc2: '#c4b5fd', glow: 'rgba(167,139,250,0.40)', mid: 'rgba(167,139,250,0.22)', soft: 'rgba(167,139,250,0.10)' },
   debugger:     { tc: '#fbbf24', tc2: '#fde68a', glow: 'rgba(251,191,36,0.40)', mid: 'rgba(251,191,36,0.22)', soft: 'rgba(251,191,36,0.10)' },

--- a/app/src/renderer/src/components/recap/card-base.css
+++ b/app/src/renderer/src/components/recap/card-base.css
@@ -1,3 +1,6 @@
+/* Copyright (C) 2026 tommy0103 and contributors. */
+/* SPDX-License-Identifier: AGPL-3.0-only */
+
 .card {
   position: absolute; inset: 0;
   border-radius: 14px;

--- a/app/src/renderer/src/components/recap/seals.js
+++ b/app/src/renderer/src/components/recap/seals.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export const MINI_SEALS = {
   architect: `<svg viewBox="0 0 110 110" fill="none"><circle cx="55" cy="55" r="36" stroke="#a78bfa" stroke-width="4" stroke-opacity="0.7"/><polygon points="55,32 50,42 60,42" fill="#c4b5fd"/><polygon points="50,42 60,42 58,72 52,72" fill="#a78bfa"/></svg>`,
   debugger: `<svg viewBox="0 0 110 110" fill="none"><circle cx="55" cy="55" r="36" stroke="#fbbf24" stroke-width="4" stroke-opacity="0.7"/><path d="M 55 34 A 21 21 0 1 1 34 55 A 16 16 0 1 0 55 39 A 11 11 0 1 1 44 55" stroke="#fde68a" stroke-width="3.5" fill="none" stroke-linecap="round"/></svg>`,

--- a/app/src/renderer/src/data.js
+++ b/app/src/renderer/src/data.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Data loading layer -- bridges Electron IPC (window.obelisk.*) to reactive store.
 // All DB access goes through this module.
 

--- a/app/src/renderer/src/file-references.mjs
+++ b/app/src/renderer/src/file-references.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Two reference shapes appear in transcripts and need different handling:
 //   A. Markdown links with an absolute path — `[roadmap.md](/Users/me/proj/roadmap.md:162)`
 //   B. Inline code holding a project-relative path — `` `src/hooks/hook.ts:40` ``

--- a/app/src/renderer/src/flap-number.mjs
+++ b/app/src/renderer/src/flap-number.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 function normalizeFlapValue(value) {
   return String(value ?? '');
 }

--- a/app/src/renderer/src/keyboard-shortcuts.mjs
+++ b/app/src/renderer/src/keyboard-shortcuts.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export function normalizeShortcutKey(event) {
   return event.key.length === 1 ? event.key.toLowerCase() : event.key;
 }

--- a/app/src/renderer/src/main.js
+++ b/app/src/renderer/src/main.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Vue 3 application entry point for Obelisk.
 
 import { createApp } from 'vue';

--- a/app/src/renderer/src/markdown-image-renderer.js
+++ b/app/src/renderer/src/markdown-image-renderer.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { SESSION_IMAGE_TAG } from './session-image-contract.js';
 
 const SAFE_IMAGE_PROTOCOLS = new Set(['blob:', 'file:', 'http:', 'https:']);

--- a/app/src/renderer/src/router.js
+++ b/app/src/renderer/src/router.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Vue Router configuration for Obelisk.
 // Routes map to the main content views; sidebar navigation drives route changes.
 

--- a/app/src/renderer/src/session-disclosures.mjs
+++ b/app/src/renderer/src/session-disclosures.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { reactive } from 'vue';
 
 export function normalizeSessionDisclosureSnapshot(snapshot, messageUuids = null) {

--- a/app/src/renderer/src/session-global-refresh.mjs
+++ b/app/src/renderer/src/session-global-refresh.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 /**
  * Keeps global catalogue snapshots out of the active SessionDetail view.
  * SessionDetail receives its own incremental stream; the catalogue is an

--- a/app/src/renderer/src/session-image-contract.js
+++ b/app/src/renderer/src/session-image-contract.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Shared constants for the session image element. Kept free of the component
 // import so the Markdown renderer (and its tests) do not have to pull a .vue
 // module into scope just to know the tag name.

--- a/app/src/renderer/src/session-image-element.js
+++ b/app/src/renderer/src/session-image-element.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { defineCustomElement } from 'vue';
 import SessionImage from './components/SessionImage.ce.vue';
 import { SESSION_IMAGE_TAG } from './session-image-contract.js';

--- a/app/src/renderer/src/session-live-reload.mjs
+++ b/app/src/renderer/src/session-live-reload.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export function createSessionLiveReloadCoordinator({ isScrolling, load, commit }) {
   let pending = false;
   let loadedSnapshot = null;

--- a/app/src/renderer/src/session-live.mjs
+++ b/app/src/renderer/src/session-live.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export function createSessionLiveState() {
   return {
     dirtySessions: new Set(),

--- a/app/src/renderer/src/session-reader-state.mjs
+++ b/app/src/renderer/src/session-reader-state.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { normalizeSessionDisclosureSnapshot } from './session-disclosures.mjs';
 
 function normalizeAnchor(anchor) {

--- a/app/src/renderer/src/session-timeline-items.mjs
+++ b/app/src/renderer/src/session-timeline-items.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 function timelineItem(kind, message, messageUuid, extras = {}) {
   return {
     key: `${kind}:${messageUuid}`,

--- a/app/src/renderer/src/session-timeline-presentation.mjs
+++ b/app/src/renderer/src/session-timeline-presentation.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { getArgPreview, getToolIcon, renderTerminalTool } from './tool-renderer.js';
 import { renderMarkdown } from './utils.js';
 

--- a/app/src/renderer/src/session-timeline-scroll-policy.mjs
+++ b/app/src/renderer/src/session-timeline-scroll-policy.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export function createSessionTimelineScrollPolicy({
   isUserScrolling,
   writeScroll,

--- a/app/src/renderer/src/session-timeline-viewport.mjs
+++ b/app/src/renderer/src/session-timeline-viewport.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { computed, nextTick, onScopeDispose, ref } from 'vue';
 import {
   defaultRangeExtractor,

--- a/app/src/renderer/src/session-timeline.mjs
+++ b/app/src/renderer/src/session-timeline.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 function sameSnapshotValue(current, incoming) {
   if (Object.is(current, incoming)) return true;
   if (current === null || incoming === null) return false;

--- a/app/src/renderer/src/session-user-scroll.mjs
+++ b/app/src/renderer/src/session-user-scroll.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export function createSessionUserScroll({
   quietMs = 450,
   scrollEndGraceMs = 100,

--- a/app/src/renderer/src/sidebar-projects.mjs
+++ b/app/src/renderer/src/sidebar-projects.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 function countByProject(items) {
   const counts = {};
   for (const item of items) {

--- a/app/src/renderer/src/source-catalog.mjs
+++ b/app/src/renderer/src/source-catalog.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 const FALLBACK_COLOR = '#8b8b93';
 
 function sourceId(value) {

--- a/app/src/renderer/src/store.js
+++ b/app/src/renderer/src/store.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Shared renderer state. Navigation state belongs to Vue Router; this store
 // holds only data and cross-view UI preferences.
 

--- a/app/src/renderer/src/tool-renderer.js
+++ b/app/src/renderer/src/tool-renderer.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 function escapeHTML(value) {
   return String(value).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }

--- a/app/src/renderer/src/utils.js
+++ b/app/src/renderer/src/utils.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Utility functions ported from the vanilla JS utils.js.
 // Pure helpers with no side-effects on global state (except formatProjectLabel which reads store).
 

--- a/app/src/renderer/src/views/Activity.vue
+++ b/app/src/renderer/src/views/Activity.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { ref, reactive, computed, onMounted, onUnmounted } from 'vue';
 import { useRouter } from 'vue-router';

--- a/app/src/renderer/src/views/MemoryList.vue
+++ b/app/src/renderer/src/views/MemoryList.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { computed, ref, nextTick, onMounted, onUnmounted, watch } from 'vue';
 import { useRouter } from 'vue-router';

--- a/app/src/renderer/src/views/RecapDetail.vue
+++ b/app/src/renderer/src/views/RecapDetail.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { useRoute } from 'vue-router';

--- a/app/src/renderer/src/views/RecapExport.vue
+++ b/app/src/renderer/src/views/RecapExport.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';

--- a/app/src/renderer/src/views/RecapList.vue
+++ b/app/src/renderer/src/views/RecapList.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { ref, computed, onMounted, onUnmounted, inject } from 'vue';
 import { useRouter, useRoute } from 'vue-router';

--- a/app/src/renderer/src/views/SessionDetail.vue
+++ b/app/src/renderer/src/views/SessionDetail.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { ref, shallowRef, computed, reactive, onMounted, onBeforeUnmount, onUnmounted, nextTick, watch } from 'vue';
 import { useRouter, useRoute } from 'vue-router';

--- a/app/src/renderer/src/views/SessionList.vue
+++ b/app/src/renderer/src/views/SessionList.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { computed, ref, onMounted, onUnmounted } from 'vue';
 import { useRouter } from 'vue-router';

--- a/app/src/renderer/src/views/Settings.vue
+++ b/app/src/renderer/src/views/Settings.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { ref, onMounted, onBeforeUnmount, nextTick } from 'vue';
 

--- a/app/src/renderer/src/views/SubagentDetail.vue
+++ b/app/src/renderer/src/views/SubagentDetail.vue
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 tommy0103 and contributors. -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <script setup>
 import { ref, onMounted, watch, computed } from 'vue';
 import { useRouter } from 'vue-router';

--- a/app/src/renderer/styles/base.css
+++ b/app/src/renderer/styles/base.css
@@ -1,3 +1,6 @@
+/* Copyright (C) 2026 tommy0103 and contributors. */
+/* SPDX-License-Identifier: AGPL-3.0-only */
+
 :root {
   --bg: #0a0b14;
   --bg-2: #11131f;

--- a/app/src/renderer/styles/detail.css
+++ b/app/src/renderer/styles/detail.css
@@ -1,3 +1,6 @@
+/* Copyright (C) 2026 tommy0103 and contributors. */
+/* SPDX-License-Identifier: AGPL-3.0-only */
+
 .detail { max-width: 720px; margin: 0 auto; padding: 32px 32px 60px; }
 .detail-wide { max-width: 860px; margin: 0 auto; padding: 28px 32px 60px; }
 

--- a/app/src/renderer/styles/list.css
+++ b/app/src/renderer/styles/list.css
@@ -1,3 +1,6 @@
+/* Copyright (C) 2026 tommy0103 and contributors. */
+/* SPDX-License-Identifier: AGPL-3.0-only */
+
   .list-wrap, .detail-wrap, .session-list-wrap, .session-detail-wrap {
     flex: 1; overflow-y: auto; min-height: 0;
   }

--- a/app/src/renderer/styles/sidebar.css
+++ b/app/src/renderer/styles/sidebar.css
@@ -1,3 +1,6 @@
+/* Copyright (C) 2026 tommy0103 and contributors. */
+/* SPDX-License-Identifier: AGPL-3.0-only */
+
 .sidebar {
   border-right: 1px solid var(--hairline-strong);
   background: rgba(0,0,0,0.2);

--- a/app/src/renderer/styles/toolbar.css
+++ b/app/src/renderer/styles/toolbar.css
@@ -1,3 +1,6 @@
+/* Copyright (C) 2026 tommy0103 and contributors. */
+/* SPDX-License-Identifier: AGPL-3.0-only */
+
   .main { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
   .toolbar {
     height: 44px; flex-shrink: 0;

--- a/app/src/shared/ipc-types.ts
+++ b/app/src/shared/ipc-types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export interface SourceQueryOptions {
   source?: string;
 }

--- a/app/src/shared/session-detail-assembly.mjs
+++ b/app/src/shared/session-detail-assembly.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { assembleSessionDetail } from '../../../packages/core/src/session-detail.ts';
 
 export { assembleSessionDetail };

--- a/app/src/shared/session-detail-types.ts
+++ b/app/src/shared/session-detail-types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 export type {
   AssembledMessage,
   AssembledToolCall,

--- a/app/src/shared/session-patch.mjs
+++ b/app/src/shared/session-patch.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // @ts-check
 
 /** @typedef {import('./ipc-types.ts').AppliedSessionPatch} AppliedSessionPatch */

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Flat ESLint config for the Obelisk root (Core + CLI + packaging + tests).
 // Scope: the root ESM/TS sources, including packages/core/src/ and
 // packages/cli/src/. The Electron app has its own package and toolchain and is

--- a/packages/cli/src/obelisk.ts
+++ b/packages/cli/src/obelisk.ts
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Obelisk Core package (see docs/adr/0003-core-typescript-esm-precompiled.md).
 //
 // The single shared implementation behind every transport. The CLI and later

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // node:sqlite lifecycle and migrations for the Core package.
 import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';

--- a/packages/core/src/indexer.ts
+++ b/packages/core/src/indexer.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Passive-pull indexing orchestration for the Core package.
 import { existsSync } from 'node:fs';
 import { DB_PATH, openDb, openReadDb, openWriterLeaseDb, rebuildMemoryFts } from './db.ts';

--- a/packages/core/src/parsing.ts
+++ b/packages/core/src/parsing.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Core's pure parse/discover helpers — node:sqlite-free by construction, so the compiled
 // providers can be consumed by the app (better-sqlite3 / a Node without
 // node:sqlite). Originally extracted verbatim from db/indexer; it now exposes a

--- a/packages/core/src/persist.ts
+++ b/packages/core/src/persist.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Shared Core persist layer (see docs/adr/0001).
 //
 // Provider-agnostic and binding-agnostic: it consumes the TranscriptRecord stream

--- a/packages/core/src/provider-indexing.ts
+++ b/packages/core/src/provider-indexing.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { persist } from './persist.ts';
 import type { ProviderRegistry } from './providers/registry.ts';
 import type {

--- a/packages/core/src/provider-settings.ts
+++ b/packages/core/src/provider-settings.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { isAbsolute, join, normalize } from 'node:path';

--- a/packages/core/src/providers/builtins.ts
+++ b/packages/core/src/providers/builtins.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { createClaudeProvider } from './claude.ts';
 import { createCodexProvider } from './codex.ts';
 import { createKimiProvider } from './kimi.ts';

--- a/packages/core/src/providers/claude.ts
+++ b/packages/core/src/providers/claude.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Claude Code provider adapter in Core (see docs/adr/0001).
 //
 // Pure: discovers Claude transcript files and parses one into a record stream.

--- a/packages/core/src/providers/codex.ts
+++ b/packages/core/src/providers/codex.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Codex provider adapter in Core (see docs/adr/0001).
 //
 // Pure: discovers Codex rollout files and parses one into a record stream. It

--- a/packages/core/src/providers/kimi.ts
+++ b/packages/core/src/providers/kimi.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import {
   existsSync,
   readdirSync,

--- a/packages/core/src/providers/pi.ts
+++ b/packages/core/src/providers/pi.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { closeSync, existsSync, openSync, readFileSync, readSync, readdirSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';

--- a/packages/core/src/providers/registry.ts
+++ b/packages/core/src/providers/registry.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type {
   ProviderAdapter,
   ProviderDescriptor,

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Core provider contract (see docs/adr/0001).
 //
 // The indexing layer splits along two orthogonal axes:

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Query and attune sandbox helpers for the Core package.
 import { statSync } from 'node:fs';
 import { isAbsolute, normalize, resolve, sep } from 'node:path';

--- a/packages/core/src/schema-migrations.ts
+++ b/packages/core/src/schema-migrations.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type { SqliteDb } from './sqlite-types.ts';
 
 const COLUMN_MIGRATIONS = [

--- a/packages/core/src/schema.sql
+++ b/packages/core/src/schema.sql
@@ -1,3 +1,6 @@
+-- Copyright (C) 2026 tommy0103 and contributors.
+-- SPDX-License-Identifier: AGPL-3.0-only
+
 -- Shared Obelisk Core schema.
 CREATE TABLE IF NOT EXISTS sessions (
   id TEXT PRIMARY KEY, title TEXT, project TEXT, project_path TEXT,

--- a/packages/core/src/session-detail.ts
+++ b/packages/core/src/session-detail.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import type {
   TranscriptRecord,
   MessageVisibility,

--- a/packages/core/src/sqlite-types.ts
+++ b/packages/core/src/sqlite-types.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Minimal structural types shared by node:sqlite and better-sqlite3 consumers.
 // SQLite rows and bindings are dynamic at this boundary; domain records become
 // strongly typed after parsing, in providers/types.ts.

--- a/packages/core/src/tx.ts
+++ b/packages/core/src/tx.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Binding-agnostic SQLite write plumbing shared from the Core package
 // (docs/adr/0006). The injected db must expose `exec(sql)`; this works for both
 // node:sqlite (CLI) and better-sqlite3 (app), same injection model as

--- a/packages/core/src/write-coordinator.ts
+++ b/packages/core/src/write-coordinator.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Core's bounded retry policy above the transaction primitive. Callers opt in only for
 // idempotent work; BEGIN contention and an uncertain/live transaction are never
 // retried here.

--- a/packages/core/src/writer-lease.ts
+++ b/packages/core/src/writer-lease.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Cross-process single-writer lease shared by every Obelisk mutation. The
 // lock lives in a dedicated SQLite database so node:sqlite and better-sqlite3
 // share identical locking semantics on every supported platform.

--- a/packaging/build-skill.mjs
+++ b/packaging/build-skill.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { cpSync, mkdirSync, rmSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/tests/app-activity-ledger.test.mjs
+++ b/tests/app-activity-ledger.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/app-activity-usage.test.mjs
+++ b/tests/app-activity-usage.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';

--- a/tests/app-file-reference.test.mjs
+++ b/tests/app-file-reference.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';

--- a/tests/app-file-references.test.mjs
+++ b/tests/app-file-references.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {

--- a/tests/app-indexer-service.test.mjs
+++ b/tests/app-indexer-service.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/app-indexer-worker-client.test.mjs
+++ b/tests/app-indexer-worker-client.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/app-indexer.test.mjs
+++ b/tests/app-indexer.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/app-kimi-index.test.mjs
+++ b/tests/app-kimi-index.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/app-pi-index.test.mjs
+++ b/tests/app-pi-index.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/app-provider-indexer.test.mjs
+++ b/tests/app-provider-indexer.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/app-rollback-guard.test.mjs
+++ b/tests/app-rollback-guard.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Regression tests for the write-transaction runner (docs/adr/0006):
 //  - a transient BUSY (auto-rolled-back txn) is retried and recovers;
 //  - a persistent BUSY exhausts retries without publishing a partial force rebuild;

--- a/tests/app-tool-renderer.test.mjs
+++ b/tests/app-tool-renderer.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/app-writer-lease.test.mjs
+++ b/tests/app-writer-lease.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/claude-parse.test.mjs
+++ b/tests/claude-parse.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Phase 5b golden test: pins the claude adapter's parse() record stream.
 // This is the binding-independent contract — no database is involved. If the
 // per-line parse behavior drifts, this fails before persist ever runs.

--- a/tests/cli-bootstrap-install.test.mjs
+++ b/tests/cli-bootstrap-install.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';

--- a/tests/cli-package.test.mjs
+++ b/tests/cli-package.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';

--- a/tests/cli-test-helpers.mjs
+++ b/tests/cli-test-helpers.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { spawnSync } from 'node:child_process';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/tests/codex-index.test.mjs
+++ b/tests/codex-index.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Phase 5c: exercises the full codex buildIndex path (discover → codex.parse →
 // persist) for both a fresh full build and an incremental rebuild after append.
 // Codex is full-reparse with countMode 'total', so growth must REPLACE the count

--- a/tests/codex-parse.test.mjs
+++ b/tests/codex-parse.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Phase 5c-2 golden test: pins the codex adapter's parse() record stream.
 // Binding-independent (no database). Covers the event_msg↔response_item dedup,
 // tool call/result, token patching, turn-duration, the 'total' session count,

--- a/tests/codex-replay-tool-identity.test.mjs
+++ b/tests/codex-replay-tool-identity.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { DatabaseSync } from 'node:sqlite';

--- a/tests/contract-helper-shapes.test.mjs
+++ b/tests/contract-helper-shapes.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Tier 2 contract golden tests (see docs/adr/0002-two-tier-runtime-contract.md).
 //
 // These lock the *composite return shapes* that agents parse and that

--- a/tests/core-package-build.test.mjs
+++ b/tests/core-package-build.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';

--- a/tests/daemon-arbitration.test.mjs
+++ b/tests/daemon-arbitration.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/db-schema.test.mjs
+++ b/tests/db-schema.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/flap-number.test.mjs
+++ b/tests/flap-number.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';

--- a/tests/incremental-index.test.mjs
+++ b/tests/incremental-index.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Phase 5b-2b: verifies incremental (resume) indexing through the full rewired
 // buildIndex path (needsReindex → cursor → claude.parse → persist). A force
 // --build re-scans everything (skip=0) and never exercises resume, so this

--- a/tests/indexer-upsert-drift.test.mjs
+++ b/tests/indexer-upsert-drift.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Regression test for the message write semantics (formerly the indexJsonl
 // INSERT-OR-REPLACE vs ON-CONFLICT drift; now enforced through the shared
 // persist layer). Re-indexing a claude session must upsert messages (stable

--- a/tests/indexer.test.mjs
+++ b/tests/indexer.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/invoking-session.test.mjs
+++ b/tests/invoking-session.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Nonce self-search: the CLI embeds a unique invocation nonce in its argv
 // (--search --nonce <token>, or the as-typed --query file path). Providers
 // write the tool-call record before the tool finishes, so after the pre-query

--- a/tests/kimi-parse.test.mjs
+++ b/tests/kimi-parse.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';

--- a/tests/kimi-runtime.test.mjs
+++ b/tests/kimi-runtime.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdirSync, writeFileSync } from 'node:fs';

--- a/tests/markdown-image-renderer.test.mjs
+++ b/tests/markdown-image-renderer.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {

--- a/tests/persist.test.mjs
+++ b/tests/persist.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Phase 5b-2a: unit-tests the shared persist layer in isolation (no buildIndex).
 // Feeds claude.parse output into persist against an in-memory node:sqlite db and
 // asserts rows + the drift-fixed session merge semantics.

--- a/tests/pi-parse.test.mjs
+++ b/tests/pi-parse.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {

--- a/tests/pi-randomized-differential.test.mjs
+++ b/tests/pi-randomized-differential.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdirSync, writeFileSync } from 'node:fs';

--- a/tests/pi-runtime.test.mjs
+++ b/tests/pi-runtime.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';

--- a/tests/provider-inventory.test.mjs
+++ b/tests/provider-inventory.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { rmSync, writeFileSync } from 'node:fs';

--- a/tests/provider-registry.test.mjs
+++ b/tests/provider-registry.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/provider-schema-stability.test.mjs
+++ b/tests/provider-schema-stability.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
@@ -7,8 +10,7 @@ test('canonical transcript persistence schema changes only by explicit decision'
   const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url));
   assert.equal(
     createHash('sha256').update(schema).digest('hex'),
-    // 2026-08-11: added idx_messages_time on messages(timestamp) so the
-    // invocation-nonce resolver can bound its tool_calls scan to recent rows.
-    '712df79e346a09f753deeb951f975c36f0148bfe047df68830fbc7e172aec09a',
+    // 2026-08-12: added the copyright/SPDX header comment; no schema change.
+    '4c6867827ed8a373c6e4cbd63c58eaecf0a6375a2b746d595b7dfcff9f49f80d',
   );
 });

--- a/tests/provider-session-detail.test.mjs
+++ b/tests/provider-session-detail.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, writeFileSync } from 'node:fs';

--- a/tests/provider-settings.test.mjs
+++ b/tests/provider-settings.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { rmSync, writeFileSync } from 'node:fs';

--- a/tests/publish-skill-layout.test.mjs
+++ b/tests/publish-skill-layout.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';

--- a/tests/query-provider-raw.test.mjs
+++ b/tests/query-provider-raw.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/query.test.mjs
+++ b/tests/query.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/recap-capture-query.test.mjs
+++ b/tests/recap-capture-query.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/recap-patterns.test.mjs
+++ b/tests/recap-patterns.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';

--- a/tests/renderer-shortcuts.test.mjs
+++ b/tests/renderer-shortcuts.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/runtime-cli-envelope.test.mjs
+++ b/tests/runtime-cli-envelope.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Tier 1 contract golden tests (see docs/adr/0002-two-tier-runtime-contract.md).
 //
 // These lock the four-verb CLI I/O envelope at the process boundary so the

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/session-detail-assembly.test.mjs
+++ b/tests/session-detail-assembly.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { assembleSessionDetail } from '../app/src/shared/session-detail-assembly.mjs';

--- a/tests/session-disclosures.test.mjs
+++ b/tests/session-disclosures.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/session-global-refresh.test.mjs
+++ b/tests/session-global-refresh.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/session-live-patch.test.mjs
+++ b/tests/session-live-patch.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {

--- a/tests/session-live-reload.test.mjs
+++ b/tests/session-live-reload.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/session-live.test.mjs
+++ b/tests/session-live.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/session-reader-state.test.mjs
+++ b/tests/session-reader-state.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/session-timeline-items.test.mjs
+++ b/tests/session-timeline-items.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/session-timeline-scroll-policy.test.mjs
+++ b/tests/session-timeline-scroll-policy.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/session-timeline-virtualization.test.mjs
+++ b/tests/session-timeline-virtualization.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';

--- a/tests/session-timeline.test.mjs
+++ b/tests/session-timeline.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/session-user-scroll.test.mjs
+++ b/tests/session-user-scroll.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/settings-view.test.mjs
+++ b/tests/settings-view.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';

--- a/tests/sidebar-projects.test.mjs
+++ b/tests/sidebar-projects.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { buildSidebarProjects } from '../app/src/renderer/src/sidebar-projects.mjs';

--- a/tests/skill-doc-artifact.test.mjs
+++ b/tests/skill-doc-artifact.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';

--- a/tests/source-catalog.test.mjs
+++ b/tests/source-catalog.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/tests/temp-dirs.mjs
+++ b/tests/temp-dirs.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // Tests create throwaway directories with mkdtempSync but never deleted them,
 // leaking hundreds of MB into $TMPDIR over repeated runs (this caused ENOSPC).
 // makeTempDir records every directory it creates and removes them all when the

--- a/tests/workflow-parent-heal.test.mjs
+++ b/tests/workflow-parent-heal.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // End-to-end regression test for the workflow parent-link race: a workflow run
 // json can be indexed before its Workflow tool_result lands in the main
 // transcript. The workflow unit is then never re-parsed (its file no longer

--- a/tests/write-transaction.test.mjs
+++ b/tests/write-transaction.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';

--- a/tests/writer-lease.test.mjs
+++ b/tests/writer-lease.test.mjs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';


### PR DESCRIPTION
## What and why

Adds a per-file copyright and license notice to every first-party source file:

```
Copyright (C) 2026 tommy0103 and contributors.
SPDX-License-Identifier: AGPL-3.0-only
```

Until now the repo carried no copyright statement anywhere — the LICENSE file is the stock FSF text and source files had no headers. That weakens exactly the clauses (AGPL-3.0 §4 notice preservation, §5(a) prominent modification notices) that protect attribution when the code is copied or forked. With per-file notices, any downstream copy mechanically carries the attribution and the license grant with it.

Mechanical change only:

- Comment syntax follows each file type (`//`, `<!-- -->`, `/* */`, `--`); shebang lines stay first.
- `tests/fixtures/pi/pi-0.83.0-context-oracle.mjs` keeps its own MIT attribution (third-party transcription) and is deliberately unchanged.
- README License section expanded into a full copyright statement plus a short note for derivative works.
- `tests/provider-schema-stability.test.mjs` hash re-pinned: the schema.sql header comment changed the file hash; no schema change.

## Verification

- [x] `npm test` — 452 pass / 0 fail
- [x] `npm run typecheck` — 0 errors (root + app)
- [x] `npm run lint` — 0 errors in tracked files (only pre-existing warnings; local untracked scratch dir `resume_rebuild/` has its own errors and is not part of the repo)
- [ ] `npm run test:electron:all` — could not run locally: the Electron binary in this macOS environment rejects `--no-sandbox` before loading any project code (verified against the bare binary: `--no-sandbox --version` exits 9, `--version` works). Unrelated to this comment-only change; leaving this to CI.
- [x] New tests actually run in CI (`.github/workflows/`) — no new tests; existing suites only
- [x] No existing assertion was loosened — the schema hash pin was updated to the new file hash with a dated comment, per that test's explicit-decision convention
- [x] Every capability described above was exercised end to end from the outermost entry point — N/A, comment-only change
- [x] Re-ran the checks above on the current head, after the most recent merge

## Deliberately out of scope

- A DCO / `Signed-off-by` requirement in CONTRIBUTING.md was considered and left out — that is a process decision for maintainers, not something to smuggle into a mechanical header PR.
- Files under `app/scripts/` are gitignored local helpers; they got headers locally but are not part of the repo.
