### PR TITLE
chore(release): prepare Obelisk v0.2.3

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obelisk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obelisk",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "better-sqlite3": "^13.0.2",
         "chokidar": "^4.0.3"

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obelisk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Memory management for Obelisk — let Claude Code search its own memory",
   "homepage": "https://github.com/tommy0103/obelisk",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1289,7 +1289,7 @@
     },
     "packages/cli": {
       "name": "@obelisk-apps/cli",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0",
       "bin": {
         "obelisk": "dist/cli/src/obelisk.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@obelisk-apps/cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Local Obelisk runtime for coding agents.",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Publishes @obelisk-apps/cli@0.2.3 and aligns the desktop app version metadata.

Validation:
- npm test (462 passed)
- npm run typecheck
- tracked-source ESLint (0 errors)
- npm pack --dry-run --workspace @obelisk-apps/cli

The npm package and v0.2.3 tag have already been published.