### PR TITLE
feat(codex): index archived sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The agent writes JS queries, runs them locally, and answers in plain language.
 
 **App side** — an Electron desktop app for humans to browse sessions, manage memories, view usage stats, and see weekly recap cards.
 
-Both read from the same `~/.obelisk/obelisk.sqlite` database. The indexer reads Claude Code transcripts from `~/.claude/projects`, Codex transcripts from `~/.codex/sessions`, Kimi Code sessions from `~/.kimi-code/sessions` (or `$KIMI_CODE_HOME/sessions`), and Pi sessions from `~/.pi/agent/sessions`.
+Both read from the same `~/.obelisk/obelisk.sqlite` database. The indexer reads Claude Code transcripts from `~/.claude/projects`, Codex transcripts from `~/.codex/sessions` and `~/.codex/archived_sessions`, Kimi Code sessions from `~/.kimi-code/sessions` (or `$KIMI_CODE_HOME/sessions`), and Pi sessions from `~/.pi/agent/sessions`.
 
 ## Multi-provider support
 
@@ -49,7 +49,7 @@ Pi JSONL v1-v3 sessions are projected through the same provider contract. Pi's t
 
 Because Pi's explicit `--session-id` is project-local, Obelisk combines the header ID with a deterministic hash of the normalized header `cwd`; this keeps the identity stable across file moves and v1-v3 migration while allowing two projects to use the same custom ID. Replacement and deletion replay is provenance-aware, so stale session snapshots are retracted atomically; compaction and branch-summary model usage is included in usage totals.
 
-For live app refresh, Obelisk watches the roots declared by every registered provider, including `~/.claude/projects`, `~/.codex/sessions`, `~/.kimi-code/sessions`, and `~/.pi/agent/sessions`. Codex's `session_index.jsonl` is used as lightweight title/update metadata during indexing, not as the message transcript source.
+For live app refresh, Obelisk watches the roots declared by every registered provider, including `~/.claude/projects`, `~/.codex/sessions`, `~/.codex/archived_sessions`, `~/.kimi-code/sessions`, and `~/.pi/agent/sessions`. Codex's `session_index.jsonl` is used as lightweight title/update metadata during indexing, not as the message transcript source.
 
 Pi chooses its session directory in this order: `--session-dir`, `PI_CODING_AGENT_SESSION_DIR`, `sessionDir` in settings, then the default under `~/.pi/agent/sessions`. Obelisk automatically follows absolute or `~`-prefixed environment/global settings and the project setting for Obelisk's launch cwd; a relative project setting is resolved against that cwd. CLI-only roots, relative environment/global settings, and project settings from another launch cwd cannot be inferred safely, so select the resolved directory in Obelisk **Settings** instead of letting Obelisk guess.
 
@@ -168,7 +168,7 @@ npm ci
 npm run dev
 ```
 
-`electron-vite` starts the renderer dev server and launches Electron. On first run, Obelisk creates `~/.obelisk/obelisk.sqlite`, indexes the available registered-provider transcripts, and then watches them for changes. The default sources include `~/.claude/projects`, `~/.codex/sessions`, `~/.kimi-code/sessions`, and `~/.pi/agent/sessions`; use **Settings** to point the app at different directories. On Windows, Obelisk also checks common WSL distributions for the Claude Code directory.
+`electron-vite` starts the renderer dev server and launches Electron. On first run, Obelisk creates `~/.obelisk/obelisk.sqlite`, indexes the available registered-provider transcripts, and then watches them for changes. The default sources include `~/.claude/projects`, `~/.codex/sessions`, `~/.codex/archived_sessions`, `~/.kimi-code/sessions`, and `~/.pi/agent/sessions`; use **Settings** to point the app at different directories. On Windows, Obelisk also checks common WSL distributions for the Claude Code directory.
 
 ### Debug the app
 
@@ -192,7 +192,7 @@ run `npm ci` again.
 
 | Layer | Source | What's captured |
 |-------|--------|----------------|
-| **Sessions** | Claude `<project>/<sessionId>.jsonl`; Codex `sessions/YYYY/MM/DD/*.jsonl`; Kimi session directories; Pi recursive `*.jsonl` | Title, project, timestamps, git branch, source |
+| **Sessions** | Claude `<project>/<sessionId>.jsonl`; Codex `sessions/YYYY/MM/DD/*.jsonl` and `archived_sessions/*.jsonl`; Kimi session directories; Pi recursive `*.jsonl` | Title, project, timestamps, git branch, source |
 | **Messages** | user + assistant turns | Full text, model, token usage, parent chain |
 | **Tool calls** | every tool invocation | Tool name, input, file paths |
 | **Subagents** | Claude `subagents/agent-<id>.jsonl`; Codex child threads | Agent type, description, full conversation |

--- a/packages/core/src/providers/codex.ts
+++ b/packages/core/src/providers/codex.ts
@@ -39,6 +39,8 @@ import type {
 
 export const name = 'codex';
 const CODEX_CANONICAL_TRANSCRIPT_MARKER = '__codex_canonical_transcript_v2__';
+const CODEX_SESSIONS_DIR = 'sessions';
+const CODEX_ARCHIVED_SESSIONS_DIR = 'archived_sessions';
 
 const HIDDEN_CONTEXT_ENVELOPE_RE = /^\s*<(environment_context|codex_internal_context)\b[^>]*>[\s\S]*<\/\1>\s*$/;
 
@@ -48,8 +50,15 @@ function messageVisibility(role: string, text: string | null): 'visible' | 'hidd
     : 'visible';
 }
 
+function codexTranscriptDirs(rootDir: string): string[] {
+  return [
+    join(rootDir, CODEX_SESSIONS_DIR),
+    join(rootDir, CODEX_ARCHIVED_SESSIONS_DIR),
+  ];
+}
+
 function discoverAt(rootDir: string, ctx: DiscoverContext): IndexUnit[] {
-  const sessionsDir = join(rootDir, 'sessions');
+  const [sessionsDir, archivedSessionsDir] = codexTranscriptDirs(rootDir);
   if (!existsSync(sessionsDir) && (ctx.indexedSessions?.().length ?? 0) > 0) {
     ctx.reportIncompleteInventory?.({ path: sessionsDir, error: 'Source folder is unavailable' });
   }
@@ -75,44 +84,49 @@ function discoverAt(rootDir: string, ctx: DiscoverContext): IndexUnit[] {
       ? normalize(changedPath)
       : normalize(join(rootDir, changedPath));
     if (rootRelative === sessionIndexPath) sessionIndexChanged = true;
-    const absolute = isAbsolute(changedPath)
-      ? normalize(changedPath)
-      : normalize(join(sessionsDir, changedPath));
-    const inside = relative(sessionsDir, absolute);
-    if (!inside || inside.startsWith('..') || isAbsolute(inside)) continue;
-    if (absolute.toLowerCase().endsWith('.jsonl')) changedFiles.add(absolute);
-  }
-  return discoverCodexJsonlFiles(sessionsDir, ctx.reportIncompleteInventory).flatMap((file) => {
-    if (ctx.changedPaths !== undefined && !sessionIndexChanged && !changedFiles.has(normalize(file.path))) return [];
-    const cursor = ctx.lastCursor(file.path);
-    const guardian = readCodexGuardianThreadInfo(file.path);
-    if (!sessionIndexChanged && cursor !== null && Number(cursor.split(':')[0]) >= statSync(file.path).mtimeMs && guardian === null) {
-      return [];
+    for (const transcriptDir of [sessionsDir, archivedSessionsDir]) {
+      const absolute = isAbsolute(changedPath)
+        ? normalize(changedPath)
+        : normalize(join(transcriptDir, changedPath));
+      const inside = relative(transcriptDir, absolute);
+      if (!inside || inside.startsWith('..') || isAbsolute(inside)) continue;
+      if (absolute.toLowerCase().endsWith('.jsonl')) changedFiles.add(absolute);
     }
-    let meta: any = null;
-    readLines(file.path, (line: string) => {
-      try {
-        const record = JSON.parse(line);
-        if (record?.type === 'session_meta' && record.payload?.id) {
-          meta = record.payload;
-          return false;
-        }
-      } catch { /* malformed source line */ }
-    });
-    const rawId = meta ? codexRawId(meta.id) : null;
-    const parentId = meta ? codexParentThreadId(meta) : null;
-    const indexed = rawId ? sessionIndex.get(rawId) : undefined;
-    return [{
-      key: file.path,
-      sessionId: guardian === null ? codexDbId(parentId || rawId) ?? '' : '',
-      meta: {
-        source: 'codex',
-        guardian: guardian !== null,
-        indexedTitle: indexed?.title,
-        indexedUpdatedAt: indexed?.updatedAt,
-      },
-    }];
-  });
+  }
+  return codexTranscriptDirs(rootDir).flatMap((transcriptDir) => (
+    discoverCodexJsonlFiles(transcriptDir, ctx.reportIncompleteInventory).flatMap((file) => {
+      const fileChanged = changedFiles.has(normalize(file.path));
+      if (ctx.changedPaths !== undefined && !sessionIndexChanged && !fileChanged) return [];
+      const cursor = ctx.lastCursor(file.path);
+      const guardian = readCodexGuardianThreadInfo(file.path);
+      if (!sessionIndexChanged && !fileChanged && cursor !== null && Number(cursor.split(':')[0]) >= statSync(file.path).mtimeMs && guardian === null) {
+        return [];
+      }
+      let meta: any = null;
+      readLines(file.path, (line: string) => {
+        try {
+          const record = JSON.parse(line);
+          if (record?.type === 'session_meta' && record.payload?.id) {
+            meta = record.payload;
+            return false;
+          }
+        } catch { /* malformed source line */ }
+      });
+      const rawId = meta ? codexRawId(meta.id) : null;
+      const parentId = meta ? codexParentThreadId(meta) : null;
+      const indexed = rawId ? sessionIndex.get(rawId) : undefined;
+      return [{
+        key: file.path,
+        sessionId: guardian === null ? codexDbId(parentId || rawId) ?? '' : '',
+        meta: {
+          source: 'codex',
+          guardian: guardian !== null,
+          indexedTitle: indexed?.title,
+          indexedUpdatedAt: indexed?.updatedAt,
+        },
+      }];
+    })
+  ));
 }
 
 export function discover(ctx: DiscoverContext): IndexUnit[] {
@@ -317,7 +331,7 @@ export function* parse(unit: IndexUnit, _cursor: Cursor): Generator<TranscriptRe
 }
 
 function findCodexFile(rootDir: string, rawThreadId: string): string | null {
-  const stack = [join(rootDir, 'sessions')];
+  const stack = codexTranscriptDirs(rootDir);
   while (stack.length > 0) {
     const current = stack.pop()!;
     if (!existsSync(current)) continue;
@@ -372,7 +386,10 @@ export function createCodexProvider({ rootDir = join(homedir(), '.codex') }: { r
     name,
     descriptor: { id: name, name: 'Codex', vendor: 'OpenAI', defaultRoot: rootDir, color: '#10a37f' },
     indexVersionMarker: CODEX_CANONICAL_TRANSCRIPT_MARKER,
-    watchRoots: (configuredRoot) => [join(configuredRoot, 'sessions'), join(configuredRoot, 'session_index.jsonl')],
+    watchRoots: (configuredRoot) => [
+      ...codexTranscriptDirs(configuredRoot),
+      join(configuredRoot, 'session_index.jsonl'),
+    ],
     discover: (ctx) => discoverAt(rootDir, ctx),
     parse,
     raw: (input) => rawCodex(rootDir, input),

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -284,6 +284,7 @@ test('main process watches every root declared by the built-in provider registry
       join(claudeDir, 'projects'),
       join(claudeDir, 'history.jsonl'),
       join(codexDir, 'sessions'),
+      join(codexDir, 'archived_sessions'),
       join(codexDir, 'session_index.jsonl'),
       join(home, '.kimi-code', 'sessions'),
       join(home, '.kimi-code', 'session_index.jsonl'),

--- a/tests/codex-parse.test.mjs
+++ b/tests/codex-parse.test.mjs
@@ -109,3 +109,33 @@ test('codex provider folds session_index metadata into its canonical session rec
   assert.equal(session.title, 'Indexed title');
   assert.equal(session.ended_at, '2026-06-10T11:00:00Z');
 });
+
+test('codex provider discovers, watches, and reads archived sessions', () => {
+  const root = makeTempDir('obelisk-codex-archive-');
+  const archiveDir = join(root, 'archived_sessions');
+  mkdirSync(archiveDir, { recursive: true });
+  const path = join(archiveDir, `rollout-${META.id}.jsonl`);
+  writeFileSync(path, [
+    JSON.stringify({ type: 'session_meta', timestamp: '2026-06-10T10:00:00Z', payload: META }),
+    JSON.stringify({ type: 'event_msg', timestamp: '2026-06-10T10:00:01Z', payload: { type: 'user_message', message: 'archived Codex sentinel' } }),
+    '',
+  ].join('\n'));
+
+  const provider = createCodexProvider({ rootDir: root });
+  const units = provider.discover({
+    lastCursor: () => '9999999999999:1',
+    changedPaths: [path],
+  });
+
+  assert.deepEqual(units.map(unit => unit.key), [path]);
+  assert.deepEqual(provider.watchRoots(root), [
+    join(root, 'sessions'),
+    archiveDir,
+    join(root, 'session_index.jsonl'),
+  ]);
+  const raw = provider.raw({
+    messageUuid: `codex:${META.id}:000002`,
+    agentId: 'codex:archive-agent',
+  });
+  assert.match(raw.text, /archived Codex sentinel/);
+});

--- a/tests/provider-registry.test.mjs
+++ b/tests/provider-registry.test.mjs
@@ -77,6 +77,7 @@ test('built-in provider registry exposes every source without caller-side branch
     '/sources/claude/projects',
     '/sources/claude/history.jsonl',
     '/sources/codex/sessions',
+    '/sources/codex/archived_sessions',
     '/sources/codex/session_index.jsonl',
     '/sources/kimi/sessions',
     '/sources/kimi/session_index.jsonl',

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -372,6 +372,59 @@ test('runtime indexes Codex root sessions into the shared query helpers', () => 
   assert.ok(payload.overviewSources.some(s => s.source === 'codex' && s.session_count === 1));
 });
 
+test('runtime indexes Codex archived sessions into the shared query helpers', () => {
+  const home = tempHome();
+  const archiveDir = join(home, '.codex', 'archived_sessions');
+  mkdirSync(archiveDir, { recursive: true });
+
+  const codexId = '019ec6ee-cebd-7431-9c93-ceec89a98a5e';
+  writeFileSync(join(archiveDir, `rollout-2026-06-15T00-19-59-${codexId}.jsonl`), [
+    JSON.stringify({
+      timestamp: '2026-06-14T16:19:59.842Z',
+      type: 'session_meta',
+      payload: {
+        id: codexId,
+        timestamp: '2026-06-14T16:19:59.842Z',
+        cwd: '/tmp/obelisk-archive-runtime',
+        source: 'cli',
+      },
+    }),
+    JSON.stringify({
+      timestamp: '2026-06-14T16:20:00.000Z',
+      type: 'event_msg',
+      payload: { type: 'user_message', message: 'archived runtime indexing sentinel' },
+    }),
+    '',
+  ].join('\n'));
+
+  const scriptPath = join(home, 'query.mjs');
+  writeFileSync(scriptPath, `
+    const sid = ${JSON.stringify(`codex:${codexId}`)};
+    return {
+      session: sessions({ source: 'codex', limit: 5 })
+        .filter(session => session.id === sid)
+        .map(({ id, project, project_path, message_count, source }) => ({ id, project, project_path, message_count, source }))[0],
+      message: thread(sid)[0]?.text,
+      rawHasMessage: raw(${JSON.stringify(`codex:${codexId}:000002`)}, { limit: 1000 })?.text.includes('archived runtime indexing sentinel') || false,
+    };
+  `);
+
+  const result = runRuntime(['--query', scriptPath], { home });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    session: {
+      id: `codex:${codexId}`,
+      project: '-tmp-obelisk-archive-runtime',
+      project_path: normalize('/tmp/obelisk-archive-runtime'),
+      message_count: 1,
+      source: 'codex',
+    },
+    message: 'archived runtime indexing sentinel',
+    rawHasMessage: true,
+  });
+});
+
 test('runtime raw lookup uses the configured Codex root for child sessions', () => {
   const home = tempHome();
   const codexDir = join(home, 'custom-codex');


### PR DESCRIPTION
## What and why

Adds `~/.codex/archived_sessions` as a Codex transcript root.

Codex archive JSONL files were previously unreachable because the provider only
discovered, watched, and searched `~/.codex/sessions`. This change includes the
archive directory in all three paths while preserving existing session IDs and
canonical record shapes.

- discovers archived JSONL files during full and changed-path indexing;
- watches archive changes in the desktop indexer; and
- resolves archived raw records, including child-thread lookups.

## Verification

- [x] `npm test` — 383 pass / 0 fail
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors; 4 pre-existing warnings
- [x] New provider and runtime tests run through the standard Node test suite
- [x] No existing assertion was loosened
- [x] Provider discovery, watch-root registration, raw lookup, and runtime
      indexing were exercised end to end

## Deliberately out of scope

No schema, session-identity, or canonical-transcript changes. This only makes
Codex's existing archived JSONL corpus available through the current provider.
