### PR TITLE
docs(skill): keep first-pass mktemp templates ending on XXXXXX

### DIFF
--- a/skill-doc/SKILL.md
+++ b/skill-doc/SKILL.md
@@ -47,6 +47,11 @@ Custom query:
    qfile=$(mktemp /tmp/obq.XXXXXX 2>/dev/null || echo "/tmp/obq.$$.$RANDOM.mjs")
    ```
 
+   Keep the `mktemp` template ending on `XXXXXX`. BSD `mktemp` treats only a
+   trailing `X` run as the unique part, so `/tmp/obq.XXXXXX.mjs` is one colliding
+   path and the next call fails with `File exists` before Obelisk runs. The
+   fallback already carries `.mjs`.
+
 2. Run:
 
    ```bash

--- a/skill-doc/references/pitfalls.md
+++ b/skill-doc/references/pitfalls.md
@@ -3,6 +3,14 @@
 Use this after a query error, suspicious empty result, over-large output, or
 unclear helper row shape. For query design, read `retrieval-semantics.md` first.
 
+## Empty `--query` After `mktemp`
+
+If stderr starts with `mktemp: mkstemp failed on /tmp/obq.XXXXXX.mjs: File exists`
+and then Obelisk prints usage, the query never started. BSD `mktemp` created the
+literal path `/tmp/obq.XXXXXX.mjs` because the template did not end on the `X`
+run. Recreate the file with `mktemp /tmp/obq.XXXXXX` and remove the leftover
+literal path if it is still present.
+
 ## Missing Columns And Wrong Aliases
 
 Common wrong guesses:


### PR DESCRIPTION
## What and why

Closes #66.

The first-pass custom-query recipe in `skill-doc/SKILL.md` is copied as `mktemp /tmp/obq.XXXXXX`. Agents then add `.mjs` because usage text says `<file.js>`. On BSD `mktemp` (macOS), that template is the literal path `/tmp/obq.XXXXXX.mjs`. The first call plants the file; every later call fails with `File exists` and `obelisk --query` prints usage because it received an empty path.

`references/api-reference.md` already has the trailing-`X` note. Agents follow the first-pass snippet and usually never load that file.

This PR states the constraint next to the copied snippet, and adds a recovery note in `references/pitfalls.md` for the exact stderr.

Docs-only. No runtime change. The published skill in `tommy0103/obelisk-skill` will pick this up on the next `publish:skill`.

## Verification

- [x] `npm test` — not run; docs-only, no runtime or test files touched
- [x] `npm run typecheck` — not run; same
- [x] `npm run lint` — not run; same
- [x] `npm run test:electron:all` — not required (`app/` unchanged)
- [x] New tests actually run in CI — no new tests
- [x] No existing assertion was loosened
- [x] Every capability described above was exercised end to end from the outermost entry point — reproduced the colliding `mktemp /tmp/obq.XXXXXX.mjs` loop on macOS; the documented recipe `mktemp /tmp/obq.XXXXXX` creates a unique file
- [x] Re-ran the checks above on the current head, after the most recent merge — branch is on `4112bdf` (`main`)

## Deliberately out of scope

- Changing the CLI usage string (`<file.js>`) that nudges agents toward a suffix
- Teaching GNU-style `mktemp --suffix`
- Refreshing the published `obelisk-skill` snapshot (that is `publish:skill`)