### PR TITLE
docs(skill): make the first-pass mktemp snippet suffix-safe

### DIFF
--- a/skill-doc/SKILL.md
+++ b/skill-doc/SKILL.md
@@ -44,13 +44,12 @@ Custom query:
    your invocation nonce:
 
    ```bash
-   qfile=$(mktemp /tmp/obq.XXXXXX 2>/dev/null || echo "/tmp/obq.$$.$RANDOM.mjs")
+   qdir=$(mktemp -d /tmp/obq.XXXXXX 2>/dev/null || { d="/tmp/obq.$$.$RANDOM"; mkdir "$d"; echo "$d"; })
+   qfile="$qdir/query.mjs"
    ```
 
-   Keep the `mktemp` template ending on `XXXXXX`. BSD `mktemp` treats only a
-   trailing `X` run as the unique part, so `/tmp/obq.XXXXXX.mjs` is one colliding
-   path and the next call fails with `File exists` before Obelisk runs. The
-   fallback already carries `.mjs`.
+   The `.mjs` name lives inside the unique directory, so the `mktemp`
+   template always ends on the `X` run (BSD `mktemp` requires that).
 
 2. Run:
 

--- a/skill-doc/references/api-reference.md
+++ b/skill-doc/references/api-reference.md
@@ -23,8 +23,8 @@ session appears in results. The CLI carries an invocation nonce to identify it:
   search text.
 - `obelisk --query <file>` — the nonce is the query file path as typed, so use
   unique temp names such as
-  `$(mktemp /tmp/obq.XXXXXX 2>/dev/null || echo "/tmp/obq.$$.$RANDOM.mjs")`
-  (note: `mktemp` templates must end in the `X` run, so no `.mjs` suffix).
+  `qdir=$(mktemp -d /tmp/obq.XXXXXX 2>/dev/null || { d="/tmp/obq.$$.$RANDOM"; mkdir "$d"; echo "$d"; }) && qfile="$qdir/query.mjs"`
+  (a unique directory per query; the `mktemp` template always ends in the `X` run).
 
 Resolution is newest-wins within a ~15-minute recency window (both the
 message-text and tool-call legs are bounded to it, which keeps weeks-old


### PR DESCRIPTION
## What and why

Follow-up to #67 / #66. That fix documented the BSD `mktemp` trailing-X trap next to the copied snippet, but it added a paragraph of defensive prose to the skill's first-pass flow. This change makes the snippet itself suffix-safe instead, so the trap cannot trigger regardless of how an agent rewrites the command:

```bash
qdir=$(mktemp -d /tmp/obq.XXXXXX 2>/dev/null || { d="/tmp/obq.$$.$RANDOM"; mkdir "$d"; echo "$d"; })
qfile="$qdir/query.mjs"
```

Each query gets a unique `mktemp -d` directory and the `.mjs` file lives inside it, so the template always ends on the `X` run — and there is no stray empty base file left in `/tmp`. The 5-line warning in SKILL.md shrinks to one sentence; the pitfalls.md recovery entry stays (hand-rolled `mktemp` variants can still hit the literal-path trap).

## Compatibility

- **No-mktemp machines**: the fallback creates the directory with `mkdir` + shell builtins — verified with `mktemp` removed from `PATH`.
- **BSD mktemp (macOS)**: verified; every call yields a fresh `/tmp/obq.XXXXXX/query.mjs`.
- The invocation nonce (the as-typed query file path) stays unique, as #50 requires.

## Verification

- npm test — 462 passed, 0 failed (docs-only; suite re-run anyway).
- Both snippet paths exercised as described above.