### PR TITLE
Keep Kimi undo replay in sync

### DIFF
--- a/packages/core/src/providers/kimi.ts
+++ b/packages/core/src/providers/kimi.ts
@@ -60,7 +60,7 @@ interface ProjectedSession {
 }
 
 const SOURCE = 'kimi';
-export const KIMI_CANONICAL_TRANSCRIPT_MARKER = '__kimi_canonical_transcript_v4__';
+export const KIMI_CANONICAL_TRANSCRIPT_MARKER = '__kimi_canonical_transcript_v5__';
 
 function defaultKimiRoot(): string {
   return process.env['KIMI_CODE_HOME'] ?? join(homedir(), '.kimi-code');
@@ -301,7 +301,6 @@ function projectSession(meta: KimiSessionUnitMeta, sessionId: string, state: Jso
       let removedUserCount = 0;
       for (let index = messages.length - 1; index >= undoFloor; index--) {
         const message = messages[index]!;
-        if (injectionMessageUuids.has(message.uuid)) continue;
         messages.splice(index, 1);
         removedMessageUuids.add(message.uuid);
         injectionMessageUuids.delete(message.uuid);

--- a/packages/core/src/providers/kimi.ts
+++ b/packages/core/src/providers/kimi.ts
@@ -60,7 +60,7 @@ interface ProjectedSession {
 }
 
 const SOURCE = 'kimi';
-export const KIMI_CANONICAL_TRANSCRIPT_MARKER = '__kimi_canonical_transcript_v5__';
+export const KIMI_CANONICAL_TRANSCRIPT_MARKER = '__kimi_canonical_transcript_v6__';
 
 function defaultKimiRoot(): string {
   return process.env['KIMI_CODE_HOME'] ?? join(homedir(), '.kimi-code');
@@ -285,8 +285,8 @@ function projectSession(meta: KimiSessionUnitMeta, sessionId: string, state: Jso
     const stepStarts = new Map<string, number>();
     const stepMessages = new Map<string, MessageRecord[]>();
     const callMessageUuids = new Map<string, string>();
-    const injectionMessageUuids = new Set<string>();
-    const realUserMessageUuids = new Set<string>();
+    const injectionOwnerPromptIds = new Map<string, unknown>();
+    const realUserPromptIds = new Map<string, unknown>();
     let undoFloor = wireMessageStart;
 
     const resetOpenState = (): void => {
@@ -299,15 +299,23 @@ function projectSession(meta: KimiSessionUnitMeta, sessionId: string, state: Jso
       if (count <= 0) return;
       const removedMessageUuids = new Set<string>();
       let removedUserCount = 0;
+      let anchorPromptId: unknown;
       for (let index = messages.length - 1; index >= undoFloor; index--) {
         const message = messages[index]!;
+        // Once the requested prompts are gone, keep walking back only through the
+        // injections that this last-removed prompt owns and that precede it.
+        if (removedUserCount >= count) {
+          if (typeof anchorPromptId !== 'string'
+            || injectionOwnerPromptIds.get(message.uuid) !== anchorPromptId) break;
+        }
         messages.splice(index, 1);
         removedMessageUuids.add(message.uuid);
-        injectionMessageUuids.delete(message.uuid);
+        injectionOwnerPromptIds.delete(message.uuid);
         if (wire.main) mainMessageCount--;
-        if (realUserMessageUuids.delete(message.uuid)) {
-          removedUserCount++;
-          if (removedUserCount >= count) break;
+        if (realUserPromptIds.has(message.uuid)) {
+          const promptId = realUserPromptIds.get(message.uuid);
+          realUserPromptIds.delete(message.uuid);
+          if (++removedUserCount >= count) anchorPromptId = promptId;
         }
       }
       const removedToolIds = new Set(
@@ -385,8 +393,8 @@ function projectSession(meta: KimiSessionUnitMeta, sessionId: string, state: Jso
           skill: null,
           source: SOURCE,
         });
-        if (origin?.kind === 'injection') injectionMessageUuids.add(messageUuid);
-        if (isRealUserMessage(source)) realUserMessageUuids.add(messageUuid);
+        if (origin?.kind === 'injection') injectionOwnerPromptIds.set(messageUuid, origin.ownerPromptId);
+        if (isRealUserMessage(source)) realUserPromptIds.set(messageUuid, source.id);
         if (Array.isArray(source.toolCalls)) {
           for (const call of source.toolCalls) {
             if (call === null || typeof call !== 'object' || typeof call.id !== 'string') continue;

--- a/tests/app-kimi-index.test.mjs
+++ b/tests/app-kimi-index.test.mjs
@@ -270,7 +270,7 @@ test('Kimi canonical transcript marker replays unchanged sessions once', () => {
   buildIndex(options);
   let db = new TestDatabase(dbPath);
   const marker = createKimiProvider({ rootDir: kimiDir }).indexVersionMarker;
-  assert.equal(marker, '__kimi_canonical_transcript_v4__');
+  assert.equal(marker, '__kimi_canonical_transcript_v5__');
   db.prepare("UPDATE messages SET text='stale expanded instructions', is_meta=1 WHERE source='kimi'").run();
   db.prepare('DELETE FROM index_state WHERE jsonl_path=?').run(marker);
   db.close();

--- a/tests/app-kimi-index.test.mjs
+++ b/tests/app-kimi-index.test.mjs
@@ -270,7 +270,7 @@ test('Kimi canonical transcript marker replays unchanged sessions once', () => {
   buildIndex(options);
   let db = new TestDatabase(dbPath);
   const marker = createKimiProvider({ rootDir: kimiDir }).indexVersionMarker;
-  assert.equal(marker, '__kimi_canonical_transcript_v5__');
+  assert.equal(marker, '__kimi_canonical_transcript_v6__');
   db.prepare("UPDATE messages SET text='stale expanded instructions', is_meta=1 WHERE source='kimi'").run();
   db.prepare('DELETE FROM index_state WHERE jsonl_path=?').run(marker);
   db.close();

--- a/tests/kimi-parse.test.mjs
+++ b/tests/kimi-parse.test.mjs
@@ -194,7 +194,7 @@ test('kimi provider normalizes think parts and drops empty thinking placeholders
   }).messageText, 'private reasoning');
 });
 
-test('kimi provider replays clear and undo markers with Kimi transcript semantics', () => {
+test('kimi provider removes injection messages inside an undone range', () => {
   const root = makeTempDir('obelisk-kimi-undo-');
   const sessionDir = join(root, 'sessions', 'workspace-1', 'session-undo-1');
   const mainDir = join(sessionDir, 'agents', 'main');
@@ -221,9 +221,9 @@ test('kimi provider replays clear and undo markers with Kimi transcript semantic
   const { values } = drain(provider.parse(unit, null));
   assert.deepEqual(
     values.filter(record => record.kind === 'message').map(record => record.text),
-    ['before clear', 'kept answer', 'persistent injection'],
+    ['before clear', 'kept answer'],
   );
-  assert.equal(values.find(record => record.kind === 'session').message_count, 3);
+  assert.equal(values.find(record => record.kind === 'session').message_count, 2);
 });
 
 test('kimi provider scopes changed-path discovery to one session and bypasses an unchanged cursor', () => {

--- a/tests/kimi-parse.test.mjs
+++ b/tests/kimi-parse.test.mjs
@@ -226,6 +226,35 @@ test('kimi provider removes injection messages inside an undone range', () => {
   assert.equal(values.find(record => record.kind === 'session').message_count, 2);
 });
 
+test('kimi provider removes a prompt-owned injection that precedes an undone prompt', () => {
+  const root = makeTempDir('obelisk-kimi-undo-injection-');
+  const sessionDir = join(root, 'sessions', 'workspace-1', 'session-undo-injection-1');
+  const mainDir = join(sessionDir, 'agents', 'main');
+  mkdirSync(mainDir, { recursive: true });
+  writeFileSync(join(sessionDir, 'state.json'), JSON.stringify({
+    workDir: '/tmp/kimi-undo-injection',
+    agents: { main: { type: 'main' } },
+  }));
+  const records = [
+    { type: 'metadata', protocol_version: '1.5', created_at: 1753005600000 },
+    { type: 'context.append_message', time: 1, message: { role: 'user', id: 'p1', content: 'kept prompt', toolCalls: [], origin: { kind: 'user' } } },
+    { type: 'context.append_loop_event', time: 2, event: { type: 'content.part', uuid: 'kept-answer', stepUuid: 's1', part: { type: 'text', text: 'kept answer' } } },
+    { type: 'context.append_message', time: 3, message: { role: 'user', id: 'inj-1', content: 'compressed image context', toolCalls: [], origin: { kind: 'injection', ownerPromptId: 'X', variant: 'image_compression' } } },
+    { type: 'context.append_message', time: 4, message: { role: 'user', id: 'X', content: 'undone prompt', toolCalls: [], origin: { kind: 'user' } } },
+    { type: 'context.undo', time: 5, count: 1 },
+  ];
+  writeFileSync(join(mainDir, 'wire.jsonl'), records.map(record => JSON.stringify(record)).join('\n') + '\n');
+  const provider = createKimiProvider({ rootDir: root });
+  const unit = provider.discover({ lastCursor: () => null })[0];
+
+  const { values } = drain(provider.parse(unit, null));
+  assert.deepEqual(
+    values.filter(record => record.kind === 'message').map(record => record.text),
+    ['kept prompt', 'kept answer'],
+  );
+  assert.equal(values.find(record => record.kind === 'session').message_count, 2);
+});
+
 test('kimi provider scopes changed-path discovery to one session and bypasses an unchanged cursor', () => {
   const root = makeTempDir('obelisk-kimi-changed-path-');
   const firstDir = join(root, 'sessions', 'workspace-1', 'session-1');


### PR DESCRIPTION
Fixes #26.

## Reproduction and root cause

A Kimi transcript with a real user message followed by `origin.kind = "injection"` and `context.undo(count: 1)` kept the injection in the canonical transcript. `applyUndo` skipped injection messages entirely while walking backward, although Kimi drops every message inside the undone range and only excludes injections from the user-message count.

## Changes

- remove every message encountered while replaying the undone range, while continuing to count only real user messages toward `count`
- correct the existing undo fixture so its assertion describes Kimi's surviving message set
- bump the Kimi canonical transcript marker so previously indexed sessions are replayed once

## Verification

- regression assertion against the original implementation: fails with the unexpected `persistent injection`
- `node --experimental-test-module-mocks --test tests/kimi-parse.test.mjs tests/app-kimi-index.test.mjs` — 14 passed
- `npm run typecheck` — passed
- `npm run lint` — passed (4 pre-existing warnings, 0 errors)