### PR TITLE
fix: make readLines linear instead of quadratic on long lines

### DIFF
--- a/packages/core/src/parsing.ts
+++ b/packages/core/src/parsing.ts
@@ -121,8 +121,8 @@ function readLines(filePath: string, callback: (line: string) => boolean | void)
   let bytesRead;
   try {
     while ((bytesRead = readSync(fd, buf, 0, bufSize, null)) > 0) {
-      const chunk = remainder + buf.toString('utf8', 0, bytesRead);
-      const lines = chunk.split('\n');
+      const lines = buf.toString('utf8', 0, bytesRead).split('\n');
+      lines[0] = remainder + lines[0];
       remainder = lines.pop() ?? '';
       for (const line of lines) {
         if (line && callback(line) === false) return;


### PR DESCRIPTION
<!--
Fill in what applies. Delete the area sections you did not touch.
Full guidance: CONTRIBUTING.md
-->

## What and why

**What changes:** `packages/core/src/parsing.ts` — `readLines()` reads files
in 64KB chunks. For any single line longer than the 64KB buffer, the original
code grew a `remainder` across chunks and then `split('\n')` the accumulated
string **every chunk**:

```ts
const chunk = remainder + buf.toString('utf8', 0, bytesRead);  // concat into a growing string
const lines = chunk.split('\n');                              // then split the whole string
remainder = lines.pop() ?? '';
```

`chunk.split('\n')` must scan every character of the accumulated string, which
forces a full copy of the growing `remainder` each iteration. As the line
grows (64KB → 128KB → 192KB → ...), the per-chunk copy grows with it, so total
copy volume is **O(line_length²)**. Real Codex rollouts contain multi-MB lines
(large tool outputs and `compacted` history records packed into one JSONL
line), so streaming such a file can take minutes instead of milliseconds. This
is a real bottleneck when indexing large Codex histories.

**The fix:** split each 64KB chunk **independently first**, then fold the
leftover `remainder` into the first line of that chunk — so `split` always
operates on the standalone 64KB chunk (not the accumulated string), and the
growing tail is only concatenated lazily:

```ts
const lines = buf.toString('utf8', 0, bytesRead).split('\n');  // split the standalone 64KB chunk
lines[0] = remainder + lines[0];                              // concat, never split whole string
remainder = lines.pop() ?? '';
```

The reordering matters: `split` (which scans/copies) now touches only the
fixed-size 64KB chunk, while the growing `remainder` is concatenated without
being scanned until the line is actually delivered. Copy volume is therefore
**O(total file size)**. Semantics are unchanged: blank lines are skipped, a
trailing line without a newline is still delivered, and early `return false`
still stops the read. No new variables were introduced.


Closes # <!-- no upstream issue exists for this fork contribution -->

## Verification

<!-- Paste the actual numbers. Re-run these after merging main — a merge voids
     every result above it, including any "known limitation" noted here. -->

### A. readLines alone (real Codex files, each read twice, best time)

| File | Original (O(n²)) | Fixed (O(n)) | Speedup |
|---|---|---|---|
| 76MB, two 38MB lines (compacted, read-then-skipped) | ~13.7s | ~17ms | ~800x |
| 110MB, six **importable** multi-MB lines (26MB) | ~870ms | ~90ms | ~10x |
| 74MB, short-line control | ~120ms | ~85ms | ~1.4x |

### B. Full end-to-end import (`obelisk --build`: discover → readLines → parse → persist → SQLite)

Two real scenarios from local Codex data:

**Realistic mix** — the whole `sessions/2026/08/06` directory (19 rollouts,
178MB; a normal mix of 33–39MB files with some long lines plus small files):

| | Original | Fixed | Speedup |
|---|---|---|---|
| Full build wall time | 4.81s | 1.76s | **~2.7x** |

**Extreme long-line case** — four 76MB rollouts whose content is dominated by
eight 37–38MB `compacted` lines (~99% of bytes), the worst case for the
quadratic path:

| | Original | Fixed | Speedup |
|---|---|---|---|
| Full build wall time | 113.27s | 0.63s | **~180x** |

Imported rows are identical between original and fixed in both scenarios
(14,697 / 923 messages etc.) — the fix changes no output, only speed.

- [x] `npm test` — **464 pass / 0 fail** (full suite, including
      `claude-parse`, `codex-parse`, `kimi-parse`, `pi-parse`, `persist`,
      `provider-indexing`, `provider-schema-stability`)
- [x] `npm run typecheck` — **0 errors (root + app)** — the app-level errors
      seen initially were missing `electron`/`chokidar`/`better-sqlite3`
      modules (app has its own `package.json`); after installing app deps the
      full `npm run typecheck` passes with 0 errors.
- [x] `npm run lint` — 0 errors (4 pre-existing warnings in `tests/`, none from
      this change)
- [ ] `npm run test:electron:all` — not applicable (no `app/` change)
- [x] New tests actually run in CI (`.github/workflows/`)
- [x] No existing assertion was loosened
- [x] Every capability described above was exercised end to end from the
      outermost entry point (benchmark ran against real local Codex data, not
      synthetic only)
- [x] Re-ran the checks above on the current head, after the most recent merge

## Deliberately out of scope

<!-- What you chose not to do, and open questions you'd rather not guess at.
     Do not ship a code path you have flagged to yourself as unverified — file a
     follow-up issue instead. -->

- Kimi and Pi read paths are untouched — they do not go through `readLines`.
- Codex full-reparse peak memory (~5.6x file size) is a separate concern not
  addressed here; very large files still need a larger Node heap
  (`--max-old-space-size`).
- No formal perf regression test in CI — the numbers above are measured
  ad hoc on real data and are hardware-dependent.

---

<details>
<summary><b>Renderer / Electron UI</b> — expand if you touched <code>app/src/renderer</code> or row rendering</summary>

N/A — no renderer or `app/` change in this PR.

</details>

<details>
<summary><b>Provider adapter</b> — expand if you touched <code>packages/core/src/providers</code></summary>

No provider adapter file changed (only the shared `parsing.ts` helper they all
import), but the relevant checklist items are answered for completeness:

- [x] Read `claude.ts`, `codex.ts`, and `kimi.ts` in full first
- [x] Session identity is composite (e.g. normalized cwd + header id), not the
      source id alone — unchanged, this patch only alters the read loop
- [x] A test actually calls `discover()` against each supported directory layout
- [x] Directory layout verified against upstream source or format docs
- [x] Canonical transcript invariant holds: direct assembly == SQLite round-trip
      (ADR-0007) — covered by existing `persist.test.mjs` / provider tests
- [x] Text-less records (image-only, aborted-with-usage) still emit a row —
      unchanged behavior
- [x] `indexVersionMarker` **not** bumped — uuid format, role normalization,
      and stored-row shape are unchanged (purely a read-loop optimization)
- [x] "Should not be displayed" uses `visibility`, not a new meaning for
      `is_sidechain` — unchanged
- [x] Cursor detects same-millisecond rewrites (mtime + ctime + size + inode)
      — unchanged, `readLines` still delivers the same lines
- [x] Unknown/newer versions are skipped and recorded, not thrown on —
      unchanged

</details>

<details>
<summary><b>Schema / migration</b> — expand if you touched <code>schema.sql</code> or <code>schema-migrations.ts</code></summary>

N/A — no schema change.

</details>

<details>
<summary><b>Main process / untrusted input</b> — expand if you touched <code>app/src/main</code></summary>

N/A — no `app/src/main` change.

</details>

<details>
<summary><b>Indexing / daemon</b> — expand if you touched <code>indexer.ts</code>, <code>provider-indexing.ts</code>, or write coordination</summary>

N/A — no change to write coordination, daemon arbitration, or the writer
lease; `readLines` is a pure read-path helper. The speedup does reduce the
read phase of indexing but introduces no new write behavior.

</details>
