### PR TITLE
feat(deepseek): add DeepSeek Harness transcript provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![version](https://img.shields.io/github/v/tag/tommy0103/obelisk?label=version&style=flat-square)](https://github.com/tommy0103/obelisk/releases)
 [![license](https://img.shields.io/badge/license-AGPL--3.0-blue.svg?style=flat-square)](LICENSE)
 
-Past Claude Code, Codex, Kimi Code, and Pi sessions -- queryable by your agent, browsable by you.
+Past Claude Code, Codex, Kimi Code, Pi, and DeepSeek Harness sessions -- queryable by your agent, browsable by you.
 
 </div>
 
@@ -25,7 +25,7 @@ The agent writes JS queries, runs them locally, and answers in plain language.
 
 **App side** — an Electron desktop app for humans to browse sessions, manage memories, view usage stats, and see weekly recap cards.
 
-Both read from the same `~/.obelisk/obelisk.sqlite` database. The indexer reads Claude Code transcripts from `~/.claude/projects`, Codex transcripts from `~/.codex/sessions` and `~/.codex/archived_sessions`, Kimi Code sessions from `~/.kimi-code/sessions` (or `$KIMI_CODE_HOME/sessions`), and Pi sessions from `~/.pi/agent/sessions`.
+Both read from the same `~/.obelisk/obelisk.sqlite` database. The indexer reads Claude Code transcripts from `~/.claude/projects`, Codex transcripts from `~/.codex/sessions` and `~/.codex/archived_sessions`, Kimi Code sessions from `~/.kimi-code/sessions` (or `$KIMI_CODE_HOME/sessions`), Pi sessions from `~/.pi/agent/sessions`, and DeepSeek Harness sessions from `~/.dsh/sessions` (or `$DSH_HOME/sessions`).
 
 ## Multi-provider support
 
@@ -49,7 +49,7 @@ Pi JSONL v1-v3 sessions are projected through the same provider contract. Pi's t
 
 Because Pi's explicit `--session-id` is project-local, Obelisk combines the header ID with a deterministic hash of the normalized header `cwd`; this keeps the identity stable across file moves and v1-v3 migration while allowing two projects to use the same custom ID. Replacement and deletion replay is provenance-aware, so stale session snapshots are retracted atomically; compaction and branch-summary model usage is included in usage totals.
 
-For live app refresh, Obelisk watches the roots declared by every registered provider, including `~/.claude/projects`, `~/.codex/sessions`, `~/.codex/archived_sessions`, `~/.kimi-code/sessions`, and `~/.pi/agent/sessions`. Codex's `session_index.jsonl` is used as lightweight title/update metadata during indexing, not as the message transcript source.
+For live app refresh, Obelisk watches the roots declared by every registered provider, including `~/.claude/projects`, `~/.codex/sessions`, `~/.codex/archived_sessions`, `~/.kimi-code/sessions`, `~/.pi/agent/sessions`, and `~/.dsh/sessions`. Codex's `session_index.jsonl` is used as lightweight title/update metadata during indexing, not as the message transcript source.
 
 Pi chooses its session directory in this order: `--session-dir`, `PI_CODING_AGENT_SESSION_DIR`, `sessionDir` in settings, then the default under `~/.pi/agent/sessions`. Obelisk automatically follows absolute or `~`-prefixed environment/global settings and the project setting for Obelisk's launch cwd; a relative project setting is resolved against that cwd. CLI-only roots, relative environment/global settings, and project settings from another launch cwd cannot be inferred safely, so select the resolved directory in Obelisk **Settings** instead of letting Obelisk guess.
 
@@ -168,7 +168,7 @@ npm ci
 npm run dev
 ```
 
-`electron-vite` starts the renderer dev server and launches Electron. On first run, Obelisk creates `~/.obelisk/obelisk.sqlite`, indexes the available registered-provider transcripts, and then watches them for changes. The default sources include `~/.claude/projects`, `~/.codex/sessions`, `~/.codex/archived_sessions`, `~/.kimi-code/sessions`, and `~/.pi/agent/sessions`; use **Settings** to point the app at different directories. On Windows, Obelisk also checks common WSL distributions for the Claude Code directory.
+`electron-vite` starts the renderer dev server and launches Electron. On first run, Obelisk creates `~/.obelisk/obelisk.sqlite`, indexes the available registered-provider transcripts, and then watches them for changes. The default sources include `~/.claude/projects`, `~/.codex/sessions`, `~/.codex/archived_sessions`, `~/.kimi-code/sessions`, `~/.pi/agent/sessions`, and `~/.dsh/sessions`; use **Settings** to point the app at different directories. On Windows, Obelisk also checks common WSL distributions for the Claude Code directory.
 
 ### Debug the app
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@obelisk-apps/cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Local Obelisk runtime for coding agents.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,7 @@
     "./session-detail": "./dist/session-detail.js",
     "./providers/claude": "./dist/providers/claude.js",
     "./providers/codex": "./dist/providers/codex.js",
+    "./providers/deepseek": "./dist/providers/deepseek.js",
     "./providers/kimi": "./dist/providers/kimi.js",
     "./providers/pi": "./dist/providers/pi.js",
     "./providers/registry": "./dist/providers/registry.js",

--- a/packages/core/src/providers/builtins.ts
+++ b/packages/core/src/providers/builtins.ts
@@ -3,6 +3,7 @@
 
 import { createClaudeProvider } from './claude.ts';
 import { createCodexProvider } from './codex.ts';
+import { createDeepseekProvider } from './deepseek.ts';
 import { createKimiProvider } from './kimi.ts';
 import { createPiProvider } from './pi.ts';
 import { createProviderRegistry, type ProviderRegistry } from './registry.ts';
@@ -16,6 +17,7 @@ export function createBuiltinProviderRegistry(
   return createProviderRegistry([
     createClaudeProvider({ rootDir: roots['claude'] }),
     createCodexProvider({ rootDir: roots['codex'] }),
+    createDeepseekProvider({ rootDir: roots['deepseek'] }),
     createKimiProvider({ rootDir: roots['kimi'] }),
     createPiProvider({ rootDir: roots['pi'], cwd }),
   ]);

--- a/packages/core/src/providers/deepseek.ts
+++ b/packages/core/src/providers/deepseek.ts
@@ -1,0 +1,512 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+// DeepSeek Harness provider adapter in Core (see docs/adr/0001).
+//
+// Pure: discovers DeepSeek Harness session artifacts and parses one into a
+// canonical record stream. It never touches the Obelisk database.
+//
+// DeepSeek Harness persists one append-only JSONL per session under
+// `$DSH_HOME/sessions` (default `~/.dsh/sessions`), grouped by a human-
+// readable project directory:
+//
+//   <root>/--<project-slug>--/<encoded-session-id>/session.jsonl.zstd
+//                                                 (or session.jsonl)
+//
+// The first JSONL line is a `session` header; subsequent lines are events
+// `{type, seq, time, data}` with contiguous seq, or packed chunk rows
+// (`text-chunks`/`reasoning-chunks`/`tool-call-chunks`) that expand to
+// `assistant/chunk` events. Unlike Codex, the log is single-carrier and
+// append-only, so the adapter is line-incremental like claude: it skips
+// already-indexed lines and yields only new records (countMode 'delta'),
+// falling back to a full reparse ('total') on the first index or when a
+// crash repair truncated the artifact below the indexed line count.
+// Subagent child sessions are their own artifacts whose header carries
+// `origin: 'subagent'` and `parentSession`; they project into the parent
+// session as sidechain messages plus a subagent row.
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { isAbsolute, join, normalize, relative } from 'node:path';
+import { zstdDecompressSync } from 'node:zlib';
+
+import {
+  isDir, normalizeObservedCwd, projectSlugFromPath, sourceInventoryIssue, trunc, truncJson,
+} from '../parsing.ts';
+import { decodeZstdArtifact, scanZstdFrames } from '../zstd.ts';
+import type {
+  Cursor, DiscoverContext, IndexUnit, ProviderAdapter, RawLookup, RawRecord,
+  TranscriptRecord,
+} from './types.ts';
+
+export const name = 'deepseek';
+
+const DEEPSEEK_CANONICAL_TRANSCRIPT_MARKER = '__deepseek_canonical_transcript_v1__';
+const SESSION_FILE_SUFFIXES = ['.jsonl.zstd', '.jsonl'] as const;
+/** DeepSeek Harness tool names whose arguments name a local file. */
+const FILE_TOOLS = new Set(['read', 'edit', 'write']);
+
+/** Header line of a DeepSeek Harness session artifact. */
+interface DeepseekHeaderLine {
+  type: 'session'
+  version: number
+  id: string
+  createdAt: number
+  cwd?: string
+  parentSession?: string
+  origin?: 'subagent'
+  delegationDepth: number
+  agentPreset?: string
+}
+
+/** Resolve the DeepSeek Harness sessions root: `$DSH_HOME/sessions` or `~/.dsh/sessions`. */
+function deepseekSessionsRoot(): string {
+  const env = process.env.DSH_HOME;
+  const home = env !== undefined && env.trim().length > 0 ? env : join(homedir(), '.dsh');
+  return join(home, 'sessions');
+}
+
+/** Parse the artifact's header line; `undefined` when it is not a well-formed session header. */
+function parseHeaderLine(line: string): DeepseekHeaderLine | undefined {
+  let parsed: unknown;
+  try { parsed = JSON.parse(line); } catch { return undefined; }
+  if (typeof parsed !== 'object' || parsed === null) return undefined;
+  const h = parsed as Record<string, unknown>;
+  if (h.type !== 'session' || typeof h.id !== 'string' || typeof h.version !== 'number'
+    || typeof h.createdAt !== 'number' || typeof h.delegationDepth !== 'number') return undefined;
+  return {
+    type: 'session',
+    version: h.version,
+    id: h.id,
+    createdAt: h.createdAt,
+    ...typeof h.cwd === 'string' ? { cwd: h.cwd } : {},
+    ...typeof h.parentSession === 'string' ? { parentSession: h.parentSession } : {},
+    ...(h.origin === 'subagent' ? { origin: 'subagent' as const } : {}),
+    delegationDepth: h.delegationDepth,
+    ...typeof h.agentPreset === 'string' ? { agentPreset: h.agentPreset } : {},
+  };
+}
+
+/** Read just the first JSONL line (the header) without decoding the whole artifact. */
+function readFirstLine(path: string): string | undefined {
+  const buffer = readFileSync(path);
+  if (path.endsWith('.zstd')) {
+    const { frames } = scanZstdFrames(buffer, 1);
+    if (frames.length === 0) return undefined;
+    const frame = frames[0]!;
+    let plaintext: Buffer;
+    try { plaintext = zstdDecompressSync(buffer.subarray(frame.start, frame.end)); } catch { return undefined; }
+    const nl = plaintext.indexOf(0x0a);
+    if (nl === -1) return undefined;
+    return plaintext.subarray(0, nl).toString('utf8');
+  }
+  const nl = buffer.indexOf(0x0a);
+  return nl === -1 ? undefined : buffer.subarray(0, nl).toString('utf8');
+}
+
+/** Decode one artifact to its JSONL text (zstd frames or plaintext). */
+function artifactText(path: string, buffer: Buffer): string {
+  return path.endsWith('.zstd') ? decodeZstdArtifact(buffer).text : buffer.toString('utf8');
+}
+
+/** Concatenate every `text`-typed block's payload. */
+function textFromBlocks(blocks: unknown, type: 'text' | 'reasoning'): string {
+  if (!Array.isArray(blocks)) return '';
+  const parts: string[] = [];
+  for (const block of blocks) {
+    if (block && typeof block === 'object'
+      && (block as { type?: unknown }).type === type
+      && typeof (block as { text?: unknown }).text === 'string') {
+      parts.push((block as { text: string }).text);
+    }
+  }
+  return parts.join('\n');
+}
+
+/** Recursively concatenate `text` blocks inside a (possibly nested) content array. */
+function resultText(blocks: unknown): string {
+  if (!Array.isArray(blocks)) return '';
+  const parts: string[] = [];
+  const walk = (list: unknown[]): void => {
+    for (const block of list) {
+      if (!block || typeof block !== 'object') continue;
+      const b = block as { type?: unknown; text?: unknown; content?: unknown };
+      if (b.type === 'text' && typeof b.text === 'string') parts.push(b.text);
+      else if (Array.isArray(b.content)) walk(b.content as unknown[]);
+    }
+  };
+  walk(blocks);
+  return parts.join('\n');
+}
+
+/** Parse a tool-call `arguments` JSON string, preserving invalid JSON as text. */
+function parseArguments(raw: unknown): unknown {
+  if (typeof raw !== 'string') return {};
+  try { return raw.length > 0 ? JSON.parse(raw) : {}; } catch { return raw; }
+}
+
+/** Whether a user-role message is injected (plugin/model context) rather than a direct human prompt. */
+function userMessageIsMeta(data: unknown): 0 | 1 {
+  if (typeof data !== 'object' || data === null) return 0;
+  const kind = (data as { source?: { kind?: unknown } }).source?.kind;
+  return kind === 'user' ? 0 : 1;
+}
+
+/** The tool-result call id, which lives on the single `tool-result` block of the result message. */
+function resultCallId(data: unknown): string | null {
+  if (typeof data !== 'object' || data === null) return null;
+  const message = (data as { message?: { content?: unknown } }).message;
+  if (typeof message !== 'object' || message === null) return null;
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content) || content.length === 0) return null;
+  const block = content[0] as { type?: unknown; toolCallId?: unknown } | undefined;
+  if (block === null || typeof block !== 'object') return null;
+  return block?.type === 'tool-result' && typeof block?.toolCallId === 'string' ? block.toolCallId : null;
+}
+
+/** The file a tool call operated on, when the tool arguments name one. */
+function toolFilePath(name: string, input: unknown): string | null {
+  if (!FILE_TOOLS.has(name) || typeof input !== 'object' || input === null) return null;
+  const path = (input as { file_path?: unknown }).file_path;
+  return typeof path === 'string' ? path : null;
+}
+
+function cursorToSkip(cursor: Cursor): number {
+  if (!cursor) return 0;
+  const n = Number(cursor.split(':')[1]);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/** Discover every session artifact needing (re)indexing under the sessions root. */
+function discoverAt(rootDir: string, ctx: DiscoverContext): IndexUnit[] {
+  if (!existsSync(rootDir)) {
+    if ((ctx.indexedSessions?.().length ?? 0) > 0) {
+      ctx.reportIncompleteInventory?.({ path: rootDir, error: 'Source folder is unavailable' });
+    }
+    return [];
+  }
+  const changedFiles = new Set<string>();
+  for (const changedPath of ctx.changedPaths ?? []) {
+    const absolute = isAbsolute(changedPath) ? normalize(changedPath) : normalize(join(rootDir, changedPath));
+    const inside = relative(rootDir, absolute);
+    if (!inside || inside.startsWith('..') || isAbsolute(inside)) continue;
+    if (absolute.endsWith('.jsonl') || absolute.endsWith('.jsonl.zstd')) changedFiles.add(absolute);
+  }
+
+  const units: IndexUnit[] = [];
+  let projects: string[];
+  try { projects = readdirSync(rootDir); } catch (error) {
+    ctx.reportIncompleteInventory?.(sourceInventoryIssue(rootDir, error));
+    return units;
+  }
+  for (const project of projects) {
+    const projectPath = join(rootDir, project);
+    if (!isDir(projectPath)) continue;
+    let sessions: string[];
+    try { sessions = readdirSync(projectPath); } catch (error) {
+      ctx.reportIncompleteInventory?.(sourceInventoryIssue(projectPath, error));
+      continue;
+    }
+    for (const session of sessions) {
+      const sessionPath = join(projectPath, session);
+      if (!isDir(sessionPath)) continue;
+      for (const suffix of SESSION_FILE_SUFFIXES) {
+        const file = join(sessionPath, `session${suffix}`);
+        if (!existsSync(file)) continue;
+        const normalizedFile = normalize(file);
+        if (ctx.changedPaths !== undefined && !changedFiles.has(normalizedFile)) continue;
+        const cursor = ctx.lastCursor(file);
+        if (ctx.changedPaths === undefined && cursor !== null
+          && Number(cursor.split(':')[0]) >= statSync(file).mtimeMs) continue;
+        const headerLine = readFirstLine(file);
+        const header = headerLine === undefined ? undefined : parseHeaderLine(headerLine);
+        if (header === undefined) continue; // malformed or half-written artifact
+        const isSubagent = header.origin === 'subagent';
+        const parent = header.parentSession;
+        units.push({
+          key: file,
+          sessionId: parent ?? header.id, // sidechain: child messages join the parent session
+          project: header.cwd !== undefined ? (projectSlugFromPath(header.cwd) ?? undefined) : undefined,
+          isSubagent: isSubagent ? true : undefined,
+          agentId: isSubagent ? header.id : undefined,
+          meta: { header },
+        });
+        break; // one artifact per session directory
+      }
+    }
+  }
+  return units;
+}
+
+/**
+ * Parse one session artifact into canonical records, resuming from `cursor`
+ * (`mtime:lines`, same encoding as claude). Lines up to the cursor are
+ * skipped; a truncation below the indexed line count forces a full reparse.
+ * @param unit - the discovered artifact unit.
+ * @param cursor - opaque resume token from a previous run.
+ * @returns the record stream, then the new cursor.
+ */
+export function* parse(unit: IndexUnit, cursor: Cursor): Generator<TranscriptRecord, Cursor> {
+  const path = unit.key;
+  const mtime = statSync(path).mtimeMs;
+  const skip = cursorToSkip(cursor);
+  const lines = artifactText(path, readFileSync(path)).split('\n');
+  // Only non-empty lines are JSONL records (split() leaves a trailing empty
+  // fragment after the final newline); line numbers must match that view so a
+  // resume cursor stays aligned with a re-parse.
+  const recordCount = lines.reduce((n, line) => n + (line === '' ? 0 : 1), 0);
+  const effectiveSkip = recordCount < skip ? 0 : skip;
+
+  const header = parseHeaderLine(lines[0] ?? '');
+  if (header === undefined) return cursor; // malformed; keep the old cursor
+  const isSubagent = header.origin === 'subagent';
+  const sessionId = unit.sessionId;
+  const agentId = isSubagent ? header.id : null;
+  const cwd = normalizeObservedCwd(header.cwd);
+  const parentSession = header.parentSession ?? null;
+
+  const records: TranscriptRecord[] = [];
+  const sm = {
+    title: null as string | null,
+    ended_at: null as string | null,
+    model: null as string | null,
+    n: 0,
+  };
+  const callMessageUuids = new Map<string, string>();
+  let descriptor: { provider?: unknown; label?: unknown } | null = null;
+
+  const insertMessage = (
+    uuid: string,
+    type: string,
+    role: string | null,
+    text: string | null,
+    contentType: string,
+    timestamp: string | null,
+    isMeta: 0 | 1,
+    inputTokens: number | null,
+    outputTokens: number | null,
+  ): string => {
+    records.push({
+      kind: 'message', uuid, session_id: sessionId, type, parent_uuid: null,
+      timestamp, role, text: trunc(text), content_type: contentType, is_meta: isMeta,
+      visibility: 'visible', model: sm.model, is_sidechain: isSubagent ? 1 : 0, agent_id: agentId,
+      input_tokens: inputTokens, output_tokens: outputTokens, cwd, skill: null, source: 'deepseek',
+    });
+    return uuid;
+  };
+
+  let lineNum = 0;
+  for (const line of lines) {
+    if (line === '') continue; // split() trailing fragment after the final newline
+    lineNum++;
+    if (lineNum === 1) continue; // header line
+    if (lineNum <= effectiveSkip) continue;
+    let obj: unknown;
+    try { obj = JSON.parse(line); } catch { continue; }
+    if (typeof obj !== 'object' || obj === null) continue;
+    const event = obj as { type?: unknown; time?: unknown; data?: unknown };
+    if (typeof event.type !== 'string') continue;
+    const timestamp = typeof event.time === 'number'
+      ? new Date(event.time).toISOString()
+      : null;
+    if (timestamp !== null && (sm.ended_at === null || timestamp > sm.ended_at)) sm.ended_at = timestamp;
+    const data = event.data;
+
+    switch (event.type) {
+      case 'user/message': {
+        const message = (data as { message?: unknown }).message ?? data;
+        const content = (message as { content?: unknown }).content;
+        const text = Array.isArray(content) ? textFromBlocks(content, 'text') : '';
+        sm.n++;
+        insertMessage(
+          `deepseek:${header.id}:${lineNum}`, 'user', 'user',
+          text || null, 'text', timestamp, userMessageIsMeta(data), null, null,
+        );
+        continue;
+      }
+      case 'assistant/message': {
+        const message = (data as { message?: unknown }).message;
+        const content = typeof message === 'object' && message !== null
+          ? (message as { content?: unknown }).content
+          : undefined;
+        const usage = typeof data === 'object' && data !== null
+          ? (data as { usage?: unknown }).usage
+          : undefined;
+        const inputTokens = usage !== null && typeof usage === 'object'
+          ? (usage as { inputTokens?: unknown }).inputTokens ?? null
+          : null;
+        const outputTokens = usage !== null && typeof usage === 'object'
+          ? (usage as { outputTokens?: unknown }).outputTokens ?? null
+          : null;
+        sm.n++;
+        if (Array.isArray(content)) {
+          const reasoning = textFromBlocks(content, 'reasoning');
+          if (reasoning.length > 0) {
+            // `:0` sorts before the text message's `:1` at the same timestamp,
+            // which is the order assembleSessionDetail expects (thinking folds
+            // into the assistant message that follows it).
+            insertMessage(
+              `deepseek:${header.id}:${lineNum}:0`, 'assistant', 'assistant',
+              reasoning, 'thinking', timestamp, 0,
+              typeof inputTokens === 'number' ? inputTokens : null,
+              typeof outputTokens === 'number' ? outputTokens : null,
+            );
+          }
+          const text = textFromBlocks(content, 'text');
+          insertMessage(
+            `deepseek:${header.id}:${lineNum}:1`, 'assistant', 'assistant',
+            text || null, 'text', timestamp, 0,
+            typeof inputTokens === 'number' ? inputTokens : null,
+            typeof outputTokens === 'number' ? outputTokens : null,
+          );
+        }
+        continue;
+      }
+      case 'tool/call': {
+        const call = data as { callId?: unknown; name?: unknown; arguments?: unknown };
+        if (typeof call.callId !== 'string') continue;
+        const name = typeof call.name === 'string' ? call.name : 'unknown';
+        const uuid = insertMessage(
+          `deepseek:${header.id}:${lineNum}`, 'assistant', 'assistant',
+          null, 'tool_use', timestamp, 0, null, null,
+        );
+        const input = parseArguments(call.arguments);
+        records.push({
+          kind: 'tool_call', id: call.callId, message_uuid: uuid, session_id: sessionId,
+          name, presentation: name === 'skill' ? 'skill' : 'default',
+          input_json: truncJson(input) as string, file_path: toolFilePath(name, input),
+        });
+        callMessageUuids.set(call.callId, uuid);
+        continue;
+      }
+      case 'tool/result': {
+        const callId = resultCallId(data);
+        if (callId === null) continue;
+        const message = (data as { message?: { content?: unknown } }).message;
+        const content = typeof message === 'object' && message !== null
+          ? (message as { content?: unknown }).content
+          : undefined;
+        const error = typeof data === 'object' && data !== null
+          ? (data as { error?: unknown }).error
+          : undefined;
+        records.push({
+          kind: 'tool_result', tool_use_id: callId,
+          message_uuid: callMessageUuids.get(callId) ?? '',
+          session_id: sessionId, content: trunc(resultText(content) || ''),
+          file_path: null, is_error: error !== undefined ? 1 : 0,
+        });
+        continue;
+      }
+      case 'session/title': {
+        const title = (data as { title?: unknown }).title;
+        if (typeof title === 'string') sm.title = title;
+        continue;
+      }
+      case 'request/header': {
+        const headerData = (data as { header?: unknown }).header;
+        if (typeof headerData === 'object' && headerData !== null) {
+          const config = (headerData as { config?: unknown }).config;
+          if (typeof config === 'object' && config !== null) {
+            const model = (config as { model?: unknown }).model;
+            if (typeof model === 'string') sm.model = model;
+          }
+        }
+        continue;
+      }
+      case 'subagent/descriptor': {
+        if (typeof data === 'object' && data !== null) {
+          descriptor = data as { provider?: unknown; label?: unknown };
+        }
+        continue;
+      }
+      default:
+        // Everything else — turn/step markers, assistant/chunk + packed chunk
+        // rows, approval/permission/sandbox state, todo/write, agent/inbox
+        // control plane — is log-only or duplicated by an indexed event.
+        continue;
+    }
+  }
+
+  if (isSubagent && parentSession !== null) {
+    records.push({
+      kind: 'subagent', agent_id: header.id, session_id: parentSession,
+      parent_tool_use_id: null,
+      agent_type: typeof descriptor?.provider === 'string' ? descriptor.provider : null,
+      description: typeof descriptor?.label === 'string' ? descriptor.label : null,
+      duration_ms: null, total_tokens: null,
+    });
+  } else if (!isSubagent) {
+    records.push({
+      kind: 'session', id: sessionId,
+      title: sm.title,
+      project: projectSlugFromPath(normalizeObservedCwd(header.cwd)) ?? unit.project ?? null,
+      started_at: new Date(header.createdAt).toISOString(), ended_at: sm.ended_at,
+      git_branch: null, version: String(header.version),
+      message_count: sm.n, countMode: effectiveSkip > 0 ? 'delta' : 'total',
+      jsonl_path: path, source: 'deepseek',
+    });
+  }
+
+  yield* records;
+  return `${mtime}:${lineNum}`;
+}
+
+/** Locate a session artifact by raw session id across the project directories. */
+function findDeepseekFile(rootDir: string, sessionId: string): string | null {
+  if (!existsSync(rootDir)) return null;
+  for (const project of readdirSync(rootDir)) {
+    const projectPath = join(rootDir, project);
+    if (!isDir(projectPath)) continue;
+    for (const suffix of SESSION_FILE_SUFFIXES) {
+      const candidate = join(projectPath, sessionId, `session${suffix}`);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+/** Return the raw artifact line for a message uuid (`deepseek:<sessionId>:<line>[:0|:1]`). */
+function rawDeepseek(rootDir: string, input: RawLookup): RawRecord | null {
+  const match = /^deepseek:([^:]+):(\d+)(?::[01])?$/.exec(input.messageUuid);
+  if (match === null) return null;
+  const sessionId = match[1]!;
+  const lineNumber = Number(match[2]);
+  const path = typeof input.session?.jsonl_path === 'string' && existsSync(input.session.jsonl_path)
+    ? input.session.jsonl_path
+    : findDeepseekFile(rootDir, sessionId);
+  if (path === null || !existsSync(path)) return null;
+  const lines = artifactText(path, readFileSync(path)).split('\n');
+  let raw: string | undefined;
+  let recordNum = 0;
+  for (const line of lines) {
+    if (line === '') continue;
+    recordNum++;
+    if (recordNum === lineNumber) { raw = line; break; }
+  }
+  if (raw === undefined || raw === '') return null;
+  let messageText: string | null = null;
+  try {
+    const obj = JSON.parse(raw) as { type?: unknown; data?: unknown };
+    if (obj?.type === 'user/message' || obj?.type === 'assistant/message') {
+      const message = (obj.data as { message?: { content?: unknown } } | undefined)?.message;
+      const content = typeof message === 'object' && message !== null
+        ? (message as { content?: unknown }).content
+        : undefined;
+      messageText = Array.isArray(content) ? textFromBlocks(content, 'text') : null;
+    }
+  } catch { /* malformed source line */ }
+  return { text: raw, totalLength: raw.length, offset: 0, limit: raw.length, hasMore: false, messageText };
+}
+
+export function createDeepseekProvider({ rootDir = deepseekSessionsRoot() } = {}): ProviderAdapter {
+  return {
+    name,
+    descriptor: { id: name, name: 'DeepSeek Harness', vendor: 'DeepSeek', defaultRoot: rootDir, color: '#4d6bfe' },
+    indexVersionMarker: DEEPSEEK_CANONICAL_TRANSCRIPT_MARKER,
+    watchRoots: (configuredRoot) => [configuredRoot],
+    discover: (ctx) => discoverAt(rootDir, ctx),
+    parse,
+    raw: (input) => rawDeepseek(rootDir, input),
+  };
+}
+
+export const deepseekProvider = createDeepseekProvider();

--- a/packages/core/src/zstd.ts
+++ b/packages/core/src/zstd.ts
@@ -1,0 +1,125 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Portions derived from `@deepseek-ai/dsh-session-persistence-jsonl`
+// (https://github.com/deepseek-ai/deepseek-harness), MIT License:
+//   Copyright (C) DeepSeek AI. Licensed under the MIT License.
+//
+// Zstandard frame primitives for DeepSeek Harness session artifacts. The
+// JSONL backend writes one independently decodable, checksummed zstd frame per
+// durable batch (the header line is its own first frame), so a reader can
+// locate complete frames structurally and decode only those, skipping a torn
+// final frame left by a crash. Obelisk only reads these artifacts, so this
+// module needs no compression path.
+
+import { zstdDecompressSync } from 'node:zlib'
+
+/** Byte range occupied by one structurally complete Zstandard frame. */
+export interface ZstdFrameRange {
+  /** Inclusive frame start. */
+  start: number
+  /** Exclusive frame end. */
+  end: number
+}
+
+/** Structural scan result for a concatenated Zstandard stream. */
+export interface ZstdFrameScan {
+  /** Complete frames in file order. */
+  frames: ZstdFrameRange[]
+  /** Start of an incomplete final frame, when EOF interrupts one. */
+  tornStart?: number
+}
+
+const ZSTD_MAGIC = 0xFD2FB528
+
+/**
+ * Locate complete frames without decompressing their blocks. Invalid complete
+ * structure rejects; EOF inside the final frame returns its start so callers
+ * can skip the torn tail.
+ * @param buffer - complete bytes currently present in the artifact.
+ * @param maxFrames - optional complete-frame limit for metadata-only readers.
+ * @returns complete frame ranges and an optional incomplete-final-frame start.
+ */
+export function scanZstdFrames(buffer: Buffer, maxFrames = Number.POSITIVE_INFINITY): ZstdFrameScan {
+  const frames: ZstdFrameRange[] = []
+  let offset = 0
+
+  while (offset < buffer.length) {
+    const start = offset
+    if (buffer.length - offset < 4) return { frames, tornStart: start }
+    if (buffer.readUInt32LE(offset) !== ZSTD_MAGIC) {
+      throw new Error(`corrupt Zstandard session log: invalid frame magic at byte ${offset}`)
+    }
+    offset += 4
+
+    if (offset === buffer.length) return { frames, tornStart: start }
+    const descriptor = buffer.readUInt8(offset)
+    offset += 1
+    if ((descriptor & 0x18) !== 0) {
+      throw new Error(`corrupt Zstandard session log: reserved frame-header bit at byte ${offset - 1}`)
+    }
+
+    const contentSizeFlag = descriptor >>> 6
+    const singleSegment = (descriptor & 0x20) !== 0
+    const checksum = (descriptor & 0x04) !== 0
+    const dictionaryFlag = descriptor & 0x03
+    const dictionaryBytes = dictionaryFlag === 3 ? 4 : dictionaryFlag
+    const contentSizeBytes = contentSizeFlag === 0
+      ? (singleSegment ? 1 : 0)
+      : 1 << contentSizeFlag
+    const remainingHeaderBytes = (singleSegment ? 0 : 1) + dictionaryBytes + contentSizeBytes
+    if (buffer.length - offset < remainingHeaderBytes) return { frames, tornStart: start }
+    offset += remainingHeaderBytes
+
+    for (;;) {
+      if (buffer.length - offset < 3) return { frames, tornStart: start }
+      const blockHeader = buffer.readUIntLE(offset, 3)
+      offset += 3
+      const lastBlock = (blockHeader & 1) !== 0
+      const blockType = (blockHeader >>> 1) & 0x03
+      const blockSize = blockHeader >>> 3
+      if (blockType === 0x03) {
+        throw new Error(`corrupt Zstandard session log: reserved block type at byte ${offset - 3}`)
+      }
+      const payloadBytes = blockType === 0x01 ? 1 : blockSize
+      if (buffer.length - offset < payloadBytes) return { frames, tornStart: start }
+      offset += payloadBytes
+      if (lastBlock) break
+    }
+
+    if (checksum) {
+      if (buffer.length - offset < 4) return { frames, tornStart: start }
+      offset += 4
+    }
+    frames.push({ start, end: offset })
+    if (frames.length === maxFrames) return { frames }
+  }
+
+  return { frames }
+}
+
+/**
+ * Decode a DeepSeek Harness session artifact (concatenated checksummed zstd
+ * frames) into its plaintext JSONL. Complete frames are decoded in order;
+ * a structurally incomplete final frame (crash tail) is skipped. The first
+ * frame must be present and hold the header line.
+ * @param buffer - complete artifact bytes.
+ * @returns the decoded JSONL text plus whether a torn tail was skipped.
+ */
+export function decodeZstdArtifact(buffer: Buffer): { text: string; torn: boolean } {
+  const { frames, tornStart } = scanZstdFrames(buffer)
+  if (frames.length === 0) throw new Error('empty or header-less Zstandard session log')
+  const plaintexts: Buffer[] = []
+  for (const { start, end } of frames) {
+    let decoded: Buffer
+    try {
+      decoded = zstdDecompressSync(buffer.subarray(start, end))
+    } catch (error) {
+      throw new Error(`corrupt Zstandard session log: frame at byte ${start} failed validation`, {
+        cause: error,
+      })
+    }
+    plaintexts.push(decoded)
+  }
+  return { text: Buffer.concat(plaintexts).toString('utf8'), torn: tornStart !== undefined }
+}

--- a/skill-doc/SKILL.md
+++ b/skill-doc/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: obelisk
 description: >
-  Search and query past Claude Code, Codex, Kimi Code, and Pi session history.
+  Search and query past Claude Code, Codex, Kimi Code, Pi, and DeepSeek Harness session history.
   Reactive: when the user asks "how did I fix X", "what did we do last time", "find the session where", "上次怎么修的", "之前的session", "历史记录".
   Proactive: when the user references past work you lack context for, when you're about to modify a file with complex edit history, when the user says "继续之前的" or "continue where we left off", or when understanding prior decisions would improve your current response.
   Memory: when the user says "记住这个", "remember this", "写入记忆", "save this conclusion", or when you determine a retrieval result contains a conclusion worth persisting.
@@ -13,14 +13,14 @@ allowed-tools:
 
 # obelisk
 
-Search and query local Claude Code, Codex, Kimi Code, and Pi session history.
+Search and query local Claude Code, Codex, Kimi Code, Pi, and DeepSeek Harness session history.
 Obelisk indexes sessions, messages, tool calls, tool results, summaries,
 subagents, workflows, workflow agents, parent chains, and raw JSONL lines into
 SQLite + FTS5.
 
 Obelisk has four transcript sources. Treat all of them as ordinary sessions by
 default: Claude rows use `source='claude'`, Codex rows use `source='codex'`,
-Kimi Code rows use `source='kimi'`, and Pi rows use `source='pi'`. Use `source`
+Kimi Code rows use `source='kimi'`, Pi rows use `source='pi'`, and DeepSeek Harness rows use `source='deepseek'`. Use `source`
 only when provenance matters or the user asks to scope to one provider.
 Provider-specific records are projected into the same canonical tables; some
 providers may not emit every kind of subagent or workflow metadata.
@@ -219,7 +219,7 @@ identity. Results are already ordered by FTS5 rank; lower rank sorts earlier.
 Prefer returned order over manually interpreting numeric rank unless you are
 deliberately using FTS5 semantics.
 
-`source` can be `'claude'`, `'codex'`, `'kimi'`, `'pi'`, or omitted. Omitted
+`source` can be `'claude'`, `'codex'`, `'kimi'`, `'pi'`, `'deepseek'`, or omitted. Omitted
 means search all indexed sources.
 
 ### `context(uuid, opts?)`

--- a/skill-doc/references/api-reference.md
+++ b/skill-doc/references/api-reference.md
@@ -230,7 +230,7 @@ Returns:
     projects,
     sessions,
     memories,
-    sources: [{ source: 'claude' | 'codex' | 'kimi' | 'pi', session_count, last_session_at }]
+    sources: [{ source: 'claude' | 'codex' | 'kimi' | 'pi' | 'deepseek', session_count, last_session_at }]
   }
 }
 ```

--- a/skill-doc/references/schema.md
+++ b/skill-doc/references/schema.md
@@ -14,7 +14,7 @@ exist.
 
 ## Source Model
 
-Obelisk stores Claude Code, Codex, Kimi Code, and Pi transcripts in the same
+Obelisk stores Claude Code, Codex, Kimi Code, Pi, and DeepSeek Harness transcripts in the same
 schema.
 
 - Claude rows use `source='claude'`.
@@ -64,7 +64,7 @@ One row per root session.
 | `version` | Provider CLI/app version |
 | `message_count` | Visible canonical messages; inactive and hidden records are excluded |
 | `jsonl_path` | Source JSONL path |
-| `source` | Provider ID: `claude`, `codex`, `kimi`, or `pi` |
+| `source` | Provider ID: `claude`, `codex`, `kimi`, `pi`, or `deepseek` |
 
 ### `messages`
 
@@ -88,7 +88,7 @@ Core evidence table.
 | `cwd` | Working directory at message time |
 | `skill` | Skill that generated the response, if known |
 | `turn_duration_ms` | Wall-clock duration for the turn |
-| `source` | Provider ID: `claude`, `codex`, `kimi`, or `pi` |
+| `source` | Provider ID: `claude`, `codex`, `kimi`, `pi`, or `deepseek` |
 
 `content_type='tool_use'` is only a marker. Tool-call details live in
 `tool_calls`. `content_type='tool_result'` marks provider-emitted tool-result

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -212,6 +212,7 @@ test('malformed settings keep the desktop recovery window available', async () =
 
 test('main process watches every root declared by the built-in provider registry', async () => {
   const originalHome = process.env.HOME;
+  const originalDshHome = process.env.DSH_HOME;
   const home = makeTempDir(`obelisk-main-watch-dirs-${Date.now()}`);
   const claudeDir = join(home, '.claude');
   const codexDir = join(home, '.codex');
@@ -221,6 +222,9 @@ test('main process watches every root declared by the built-in provider registry
   mkdirSync(join(home, '.obelisk'), { recursive: true });
   writeFileSync(join(home, '.obelisk', 'obelisk.sqlite'), '');
   process.env.HOME = home;
+  // The deepseek provider prefers $DSH_HOME over ~/.dsh; clear a harness-set
+  // DSH_HOME so the deepseek root follows the temp HOME like the others.
+  delete process.env.DSH_HOME;
 
   const serviceOptions = [];
   const workerCalls = [];
@@ -286,6 +290,7 @@ test('main process watches every root declared by the built-in provider registry
       join(codexDir, 'sessions'),
       join(codexDir, 'archived_sessions'),
       join(codexDir, 'session_index.jsonl'),
+      join(home, '.dsh', 'sessions'),
       join(home, '.kimi-code', 'sessions'),
       join(home, '.kimi-code', 'session_index.jsonl'),
       join(home, '.pi', 'agent', 'sessions'),
@@ -296,6 +301,8 @@ test('main process watches every root declared by the built-in provider registry
   } finally {
     restore();
     process.env.HOME = originalHome;
+    if (originalDshHome === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = originalDshHome;
     rmSync(home, { recursive: true, force: true });
   }
 });

--- a/tests/cli-test-helpers.mjs
+++ b/tests/cli-test-helpers.mjs
@@ -9,17 +9,20 @@ export const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 export const cliEntry = join(repoRoot, 'packages', 'cli', 'dist', 'cli', 'src', 'obelisk.js');
 
 export function runCli(args, { home, env = {}, cwd = repoRoot } = {}) {
+  // The deepseek provider resolves `$DSH_HOME/sessions` with higher precedence
+  // than `~/.dsh/sessions`; a harness shell exporting DSH_HOME would point CLI
+  // tests at the real session store instead of the temp HOME.
+  const childEnv = { ...process.env };
+  delete childEnv.DSH_HOME;
+  if (home) { childEnv.HOME = home; childEnv.USERPROFILE = home; }
+  Object.assign(childEnv, env);
   return spawnSync(process.execPath, [
     '--disable-warning=ExperimentalWarning',
     cliEntry,
     ...args,
   ], {
     cwd,
-    env: {
-      ...process.env,
-      ...(home ? { HOME: home, USERPROFILE: home } : {}),
-      ...env,
-    },
+    env: childEnv,
     encoding: 'utf8',
   });
 }

--- a/tests/db-schema.test.mjs
+++ b/tests/db-schema.test.mjs
@@ -165,9 +165,9 @@ test('schema reference stays focused on raw SQL structure', async () => {
 
   assert.ok(ref.split('\n').length < 420, 'schema.md should remain a quick SQL reference');
   assert.match(ref, /Raw SQL Quick Reference/i);
-  assert.match(ref, /Claude Code, Codex, Kimi Code, and Pi/);
+  assert.match(ref, /Claude Code, Codex, Kimi Code, Pi, and DeepSeek Harness/);
   assert.equal(
-    ref.match(/Provider ID: `claude`, `codex`, `kimi`, or `pi`/g)?.length,
+    ref.match(/Provider ID: `claude`, `codex`, `kimi`, `pi`, or `deepseek`/g)?.length,
     2,
     'session and message source fields should document every provider',
   );
@@ -185,7 +185,7 @@ test('api reference documents query helpers and current return fields', async ()
   const ref = await readApiReference();
 
   assert.match(ref, /## Query API Reference/);
-  assert.match(ref, /'claude' \| 'codex' \| 'kimi' \| 'pi'/);
+  assert.match(ref, /'claude' \| 'codex' \| 'kimi' \| 'pi' \| 'deepseek'/);
   assert.doesNotMatch(ref, /"claude", "codex", or omitted/);
   assert.match(ref, /#### `summaries\(opts\?\)`/);
   assert.match(ref, /summary rows/i);
@@ -205,8 +205,8 @@ test('api reference documents query helpers and current return fields', async ()
 test('skill routes agents to the right reference document', async () => {
   const skill = await readSkill();
 
-  assert.match(skill, /Claude Code, Codex, Kimi Code, and Pi/);
-  assert.match(skill, /'claude'.*'codex'.*'kimi'.*'pi'/s);
+  assert.match(skill, /Claude Code, Codex, Kimi Code, Pi, and DeepSeek Harness/);
+  assert.match(skill, /'claude'.*'codex'.*'kimi'.*'pi'.*'deepseek'/s);
   assert.match(skill, /Reference Map/);
   assert.match(skill, /references\/schema\.md.*raw SQL/i);
   assert.match(skill, /references\/api-reference\.md.*helper/i);

--- a/tests/deepseek-parse.test.mjs
+++ b/tests/deepseek-parse.test.mjs
@@ -1,0 +1,274 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Golden test: pins the deepseek adapter's parse() record stream against the
+// DeepSeek Harness JSONL format (header line + typed events + packed chunk
+// rows, plaintext or zstd-framed). Binding-independent (no database). Covers
+// the line-incremental delta resume, the truncation fallback to a full
+// reparse, tool call/result correlation, meta classification, thinking
+// messages, subagent projection, discover, and raw().
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { closeSync, mkdirSync, openSync, statSync, writeFileSync, writeSync } from 'node:fs';
+import { join } from 'node:path';
+import { zstdCompressSync } from 'node:zlib';
+
+import { createDeepseekProvider, parse } from '../packages/core/src/providers/deepseek.ts';
+import { makeTempDir } from './temp-dirs.mjs';
+
+const SID = 'session-019e8951-3e7d-7343-a3e3-05bff48a317d';
+const HEADER = {
+  type: 'session', version: 0, id: SID, createdAt: 1787054668467,
+  cwd: '/proj', delegationDepth: 0, agentPreset: 'standard',
+};
+
+function writeFixture(lines, { suffix = '.jsonl', framed = false } = {}) {
+  const dir = makeTempDir('obelisk-deepseek-parse-');
+  const path = join(dir, `session${suffix}`);
+  const text = lines.map(line => JSON.stringify(line)).join('\n') + '\n';
+  if (framed) {
+    // The header line is its own frame; the rest of the batch is a second frame.
+    const headerFrame = zstdCompressSync(Buffer.from(JSON.stringify(lines[0]) + '\n'));
+    const bodyFrame = zstdCompressSync(Buffer.from(lines.slice(1).map(l => JSON.stringify(l)).join('\n') + '\n'));
+    writeFileSync(path, Buffer.concat([headerFrame, bodyFrame]));
+  } else {
+    writeFileSync(path, text);
+  }
+  return path;
+}
+
+function drain(gen) {
+  const values = [];
+  let step = gen.next();
+  while (!step.done) { values.push(step.value); step = gen.next(); }
+  return { values, cursor: step.value };
+}
+
+const BASE_EVENTS = [
+  HEADER,
+  { type: 'user/message', seq: 0, time: 1787054669201, data: {
+    content: [{ type: 'text', text: 'hello deepseek' }],
+    source: { kind: 'user', rpcId: 'rpc-1' }, role: 'user', id: 'm-1' } },
+  { type: 'user/message', seq: 1, time: 1787054669300, data: {
+    content: [{ type: 'text', text: 'Current runtime context.' }],
+    source: { kind: 'plugin', plugin: '@deepseek-ai/dsh-system-prompt' }, role: 'user', id: 'm-2' } },
+  { type: 'assistant/message', seq: 2, time: 1787054669400, data: {
+    turn: 1, step: 1, message: { role: 'assistant', content: [
+      { type: 'reasoning', text: 'I should inspect.' },
+      { type: 'text', text: 'I will inspect.' },
+    ], id: 'a-1' }, usage: { inputTokens: 100, outputTokens: 50, reasoningTokens: 30 } } },
+  { type: 'tool/call', seq: 3, time: 1787054669500, data: {
+    turn: 1, step: 1, callId: 'call_1', name: 'bash', arguments: '{"command":"ls"}' } },
+  { type: 'tool/result', seq: 4, time: 1787054669600, data: {
+    turn: 1, step: 1, message: { role: 'user', content: [
+      { type: 'tool-result', toolCallId: 'call_1', content: [{ type: 'text', text: 'file listing' }], isError: false },
+    ], source: { kind: 'tool', tool: 'bash' }, id: 'tr-1' } } },
+  { type: 'session/title', seq: 5, time: 1787054669700, data: {
+    title: 'hello deepseek', messageSeqs: [0], source: { kind: 'fallback' } } },
+  { type: 'request/header', seq: 6, time: 1787054669800, data: {
+    header: { config: { provider: 'deepseek-official', model: 'deepseek-v4-flash' }, reason: 'initial' },
+    reason: 'initial' } },
+  // Log-only / control-plane events that must be skipped.
+  { type: 'turn/start', seq: 7, time: 1787054669900, data: { turn: 1 } },
+  { type: 'step/start', seq: 8, time: 1787054670000, data: { turn: 1, step: 1 } },
+  { type: 'assistant/chunk', seq: 9, time: 1787054670100, data: { turn: 1, step: 1, chunk: { type: 'text-delta', index: 0, text: 'he' } } },
+  { type: 'text-chunks', seq0: 10, time0: 1787054670200, data: { turn: 1, step: 1, index: 0, dt: [1], texts: ['l', 'lo'] } },
+  { type: 'approval/policy', seq: 11, time: 1787054670300, data: { policy: 'ask' } },
+  { type: 'agent/inbox/spliced', seq: 12, time: 1787054670400, data: { target: 'next-turn', start: 0, removedCount: 1, inserted: [] } },
+];
+
+test('deepseek parse() yields a delta-capable, tool-aware record stream', () => {
+  const path = writeFixture(BASE_EVENTS);
+  const { values, cursor } = drain(parse({ key: path, sessionId: SID }, null));
+  const byKind = k => values.filter(r => r.kind === k);
+
+  const [session] = byKind('session');
+  assert.equal(session.id, SID);
+  assert.equal(session.title, 'hello deepseek');
+  assert.equal(session.project, '-proj');
+  assert.equal(session.version, '0');
+  assert.equal(session.countMode, 'total');
+  assert.equal(session.source, 'deepseek');
+  assert.equal(session.started_at, '2026-08-18T12:04:28.467Z');
+  assert.equal(session.ended_at, '2026-08-18T12:04:30.400Z');
+  assert.match(session.jsonl_path, /session\.jsonl$/);
+
+  const msgs = byKind('message');
+  // user, injected user (meta), assistant thinking, assistant text, tool_use.
+  assert.equal(msgs.length, 5);
+  const user = msgs.find(m => m.type === 'user' && m.text === 'hello deepseek');
+  assert.equal(user.role, 'user');
+  assert.equal(user.content_type, 'text');
+  assert.equal(user.is_meta, 0);
+  assert.equal(user.source, 'deepseek');
+  assert.equal(user.model, null); // request/header comes after in the log
+  const injected = msgs.find(m => m.text === 'Current runtime context.');
+  assert.equal(injected.is_meta, 1);
+  const thinking = msgs.find(m => m.content_type === 'thinking');
+  assert.equal(thinking.text, 'I should inspect.');
+  assert.equal(thinking.input_tokens, 100);
+  assert.equal(thinking.output_tokens, 50);
+  const text = msgs.find(m => m.content_type === 'text' && m.type === 'assistant');
+  assert.equal(text.text, 'I will inspect.');
+  const toolUse = msgs.find(m => m.content_type === 'tool_use');
+  assert.equal(toolUse.text, null);
+  assert.equal(toolUse.model, null); // request/header appears later in the log
+
+  const calls = byKind('tool_call');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].id, 'call_1');
+  assert.equal(calls[0].message_uuid, toolUse.uuid);
+  assert.equal(calls[0].name, 'bash');
+  assert.equal(calls[0].presentation, 'default');
+  assert.deepEqual(JSON.parse(calls[0].input_json), { command: 'ls' });
+
+  const results = byKind('tool_result');
+  assert.equal(results.length, 1);
+  assert.equal(results[0].tool_use_id, 'call_1');
+  assert.equal(results[0].message_uuid, toolUse.uuid);
+  assert.equal(results[0].content, 'file listing');
+  assert.equal(results[0].is_error, 0);
+
+  assert.equal(byKind('summary').length, 0);
+  assert.equal(byKind('subagent').length, 0);
+  assert.ok(cursor.includes(`:${BASE_EVENTS.length}`), `cursor advances past all lines: ${cursor}`);
+});
+
+test('deepseek parse() resumes incrementally with a delta session record', () => {
+  const path = writeFixture(BASE_EVENTS);
+  const first = drain(parse({ key: path, sessionId: SID }, null));
+  assert.equal(first.values.filter(r => r.kind === 'session')[0].countMode, 'total');
+
+  // Append new events, then resume from the first cursor.
+  const appended = [
+    { type: 'user/message', seq: 13, time: 1787054670500, data: {
+      content: [{ type: 'text', text: 'continue please' }],
+      source: { kind: 'user' }, role: 'user', id: 'm-3' } },
+    { type: 'assistant/message', seq: 14, time: 1787054670600, data: {
+      turn: 2, step: 1, message: { role: 'assistant', content: [{ type: 'text', text: 'done' }], id: 'a-2' } } },
+  ];
+  const fd = openSync(path, 'a');
+  writeSync(fd, appended.map(l => JSON.stringify(l)).join('\n') + '\n');
+  closeSync(fd);
+
+  const second = drain(parse({ key: path, sessionId: SID }, first.cursor));
+  const byKind = k => second.values.filter(r => r.kind === k);
+  const [session] = byKind('session');
+  assert.equal(session.countMode, 'delta');
+  assert.equal(session.message_count, 2, 'delta message_count counts only new events');
+  const msgs = byKind('message');
+  assert.equal(msgs.length, 2, 'delta parse re-emits only the new messages');
+  assert.equal(msgs.find(m => m.text === 'continue please').role, 'user');
+  assert.equal(msgs.find(m => m.text === 'done').model, null);
+  assert.equal(byKind('tool_call').length, 0);
+});
+
+test('deepseek parse() falls back to a full reparse after a truncation', () => {
+  const path = writeFixture(BASE_EVENTS);
+  const first = drain(parse({ key: path, sessionId: SID }, null));
+  // Simulate a DSH crash repair: truncate below the indexed line count.
+  writeFileSync(path, JSON.stringify(HEADER) + '\n');
+  const second = drain(parse({ key: path, sessionId: SID }, first.cursor));
+  const [session] = second.values.filter(r => r.kind === 'session');
+  assert.equal(session.countMode, 'total', 'truncation below the cursor forces a total reparse');
+  assert.equal(second.values.filter(r => r.kind === 'message').length, 0, 'no messages left after truncation');
+});
+
+test('deepseek parse() reads zstd-framed artifacts and skips a torn tail', () => {
+  const dir = makeTempDir('obelisk-deepseek-zstd-');
+  const path = join(dir, 'session.jsonl.zstd');
+  const headerFrame = zstdCompressSync(Buffer.from(JSON.stringify(HEADER) + '\n'));
+  const bodyFrame = zstdCompressSync(Buffer.from(BASE_EVENTS.slice(1).map(l => JSON.stringify(l)).join('\n') + '\n'));
+  const torn = zstdCompressSync(Buffer.from(JSON.stringify({ type: 'assistant/message', seq: 99 }) + '\n')).subarray(0, 7);
+  writeFileSync(path, Buffer.concat([headerFrame, bodyFrame, torn]));
+
+  const { values, cursor } = drain(parse({ key: path, sessionId: SID }, null));
+  assert.equal(values.filter(r => r.kind === 'message').length, 5, 'torn frame lines are not indexed');
+  assert.ok(cursor.includes(`:${BASE_EVENTS.length}`), `cursor covers only complete frames: ${cursor}`);
+});
+
+test('deepseek parse() projects a subagent child into the parent session', () => {
+  const CHILD = 'session-child-0001-0000-4000-8000-000000000001';
+  const childHeader = {
+    type: 'session', version: 0, id: CHILD, createdAt: 1787054671000,
+    cwd: '/proj', parentSession: SID, origin: 'subagent', delegationDepth: 1,
+  };
+  const path = writeFixture([
+    childHeader,
+    { type: 'subagent/descriptor', seq: 0, time: 1787054671100, data: {
+      version: 2, mode: 'continuable', provider: 'dsh-subagent', label: 'inspect the repo' } },
+    { type: 'turn/start', seq: 1, time: 1787054671200, data: { turn: 1 } },
+    { type: 'user/message', seq: 2, time: 1787054671300, data: {
+      content: [{ type: 'text', text: 'child prompt' }], source: { kind: 'user' }, role: 'user', id: 'c-1' } },
+    { type: 'assistant/message', seq: 3, time: 1787054671400, data: {
+      turn: 1, step: 1, message: { role: 'assistant', content: [{ type: 'text', text: 'child work' }], id: 'c-2' } } },
+  ]);
+
+  const { values } = drain(parse({ key: path, sessionId: SID, isSubagent: true, agentId: CHILD }, null));
+  const msgs = values.filter(r => r.kind === 'message');
+  assert.equal(msgs.length, 2);
+  for (const m of msgs) {
+    assert.equal(m.session_id, SID, 'child messages join the parent session');
+    assert.equal(m.agent_id, CHILD);
+    assert.equal(m.is_sidechain, 1);
+  }
+  const subagents = values.filter(r => r.kind === 'subagent');
+  assert.equal(subagents.length, 1);
+  assert.equal(subagents[0].agent_id, CHILD);
+  assert.equal(subagents[0].session_id, SID);
+  assert.equal(subagents[0].agent_type, 'dsh-subagent');
+  assert.equal(subagents[0].description, 'inspect the repo');
+  assert.equal(values.some(r => r.kind === 'session'), false, 'subagent children own no session row');
+});
+
+test('deepseek discover() enumerates session artifacts and resolves sidechain identity', () => {
+  const root = makeTempDir('obelisk-deepseek-discover-');
+  const projectDir = join(root, '--proj--');
+  const sessionDir = join(projectDir, SID);
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(join(sessionDir, 'session.jsonl'), JSON.stringify(HEADER) + '\n');
+
+  const provider = createDeepseekProvider({ rootDir: root });
+  const units = provider.discover({ lastCursor: () => null });
+  assert.equal(units.length, 1);
+  assert.equal(units[0].key, join(sessionDir, 'session.jsonl'));
+  assert.equal(units[0].sessionId, SID);
+  assert.equal(units[0].isSubagent, undefined);
+  assert.equal(units[0].project, '-proj');
+  assert.equal(provider.descriptor.id, 'deepseek');
+  assert.deepEqual(provider.watchRoots(root), [root]);
+
+  // An unchanged file is not rediscovered; a changed one is. The cursor's mtime
+  // must be the artifact's own float mtime, matching the adapter comparison.
+  const mtime = statSync(join(sessionDir, 'session.jsonl')).mtimeMs;
+  assert.equal(provider.discover({ lastCursor: () => `${mtime}:2` }).length, 0);
+  assert.equal(provider.discover({ lastCursor: () => '1:2' }).length, 1);
+});
+
+test('deepseek raw() returns the original artifact line for a message uuid', () => {
+  const root = makeTempDir('obelisk-deepseek-raw-');
+  const projectDir = join(root, '--proj--');
+  const sessionDir = join(projectDir, SID);
+  mkdirSync(sessionDir, { recursive: true });
+  const path = join(sessionDir, 'session.jsonl');
+  writeFileSync(path, BASE_EVENTS.map(l => JSON.stringify(l)).join('\n') + '\n');
+  const provider = createDeepseekProvider({ rootDir: root });
+
+  const hit = provider.raw({ source: 'deepseek', messageUuid: `deepseek:${SID}:5`, session: null, agentId: null });
+  assert.ok(hit, 'raw resolves the tool/call line');
+  assert.ok(hit.text.includes('"type":"tool/call"'));
+  assert.equal(hit.messageText, null);
+
+  const thinking = provider.raw({ source: 'deepseek', messageUuid: `deepseek:${SID}:4:0`, session: null, agentId: null });
+  assert.ok(thinking && thinking.text.includes('"type":"assistant/message"'));
+
+  const miss = provider.raw({ source: 'deepseek', messageUuid: `deepseek:${SID}:999`, session: null, agentId: null });
+  assert.equal(miss, null);
+
+  // The persisted jsonl_path path is preferred when the caller supplies it.
+  const viaSession = provider.raw({
+    source: 'deepseek', messageUuid: `deepseek:${SID}:4`, session: { jsonl_path: path }, agentId: null,
+  });
+  assert.ok(viaSession && viaSession.text.includes('"type":"assistant/message"'));
+});

--- a/tests/deepseek-session-detail.test.mjs
+++ b/tests/deepseek-session-detail.test.mjs
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Provider conformance (ADR-0007): a deepseek parse() record stream must pass
+// directly through assembleSessionDetail, and the assembled result must
+// survive a persist round-trip unchanged.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { assembleSessionDetail } from '../packages/core/src/session-detail.ts';
+import { persist } from '../packages/core/src/persist.ts';
+import { parse as parseDeepseek } from '../packages/core/src/providers/deepseek.ts';
+import { makeTempDir } from './temp-dirs.mjs';
+
+const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+
+const SID = 'session-019e8951-3e7d-7343-a3e3-05bff48a317d';
+
+function writeDeepseekFixture(lines) {
+  const dir = makeTempDir('obelisk-deepseek-detail-');
+  const path = join(dir, 'session.jsonl');
+  writeFileSync(path, `${lines.map(line => JSON.stringify(line)).join('\n')}\n`);
+  return path;
+}
+
+const FIXTURE = [
+  {
+    type: 'session', version: 0, id: SID, createdAt: 1787054668467,
+    cwd: '/proj', delegationDepth: 0,
+  },
+  {
+    type: 'user/message', seq: 0, time: 1787054669201, data: {
+      content: [{ type: 'text', text: 'inspect the repository' }],
+      source: { kind: 'user' }, role: 'user', id: 'm-1' } },
+  {
+    type: 'assistant/message', seq: 1, time: 1787054669400, data: {
+      turn: 1, step: 1, message: { role: 'assistant', content: [
+        { type: 'reasoning', text: 'think first' },
+        { type: 'text', text: 'I will inspect it.' },
+      ], id: 'a-1' }, usage: { inputTokens: 100, outputTokens: 50 } } },
+  {
+    type: 'tool/call', seq: 2, time: 1787054669500, data: {
+      turn: 1, step: 1, callId: 'call_1', name: 'bash', arguments: '{"command":"ls"}' } },
+  {
+    type: 'tool/result', seq: 3, time: 1787054669600, data: {
+      turn: 1, step: 1, message: { role: 'user', content: [
+        { type: 'tool-result', toolCallId: 'call_1', content: [{ type: 'text', text: 'package.json' }] },
+      ], source: { kind: 'tool', tool: 'bash' }, id: 'tr-1' } } },
+  {
+    type: 'session/title', seq: 4, time: 1787054669700, data: {
+      title: 'inspect the repo', messageSeqs: [0], source: { kind: 'fallback' } } },
+];
+
+test('a deepseek record stream assembles directly into session detail', () => {
+  const path = writeDeepseekFixture(FIXTURE);
+  const records = [...parseDeepseek({ key: path, sessionId: SID }, null)];
+  const detail = assembleSessionDetail(records);
+
+  // The reasoning block folds into the assistant message's thinking; the text
+  // block is the visible message text.
+  assert.deepEqual(detail.messages.map(message => message.text), [
+    'inspect the repository',
+    'I will inspect it.',
+  ]);
+  const assistant = detail.messages[1];
+  assert.equal(assistant._thinking, 'think first');
+  assert.equal(assistant.tool_calls?.[0].name, 'bash');
+  assert.equal(assistant.tool_calls?.[0].result?.content, 'package.json');
+  assert.equal(detail.session.title, 'inspect the repo');
+
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  persist(db, { key: path, sessionId: SID }, parseDeepseek({ key: path, sessionId: SID }, null));
+  const persistedDetail = assembleSessionDetail({
+    session: db.prepare('SELECT * FROM sessions').get(),
+    messages: db.prepare('SELECT * FROM messages ORDER BY timestamp, uuid').all(),
+    toolCalls: db.prepare('SELECT * FROM tool_calls').all(),
+    toolResults: db.prepare('SELECT * FROM tool_results').all(),
+  });
+  assert.deepEqual(persistedDetail, detail);
+  db.close();
+});
+
+test('deepseek messages survive a persist round-trip with meta and source intact', () => {
+  const path = writeDeepseekFixture([
+    FIXTURE[0],
+    {
+      type: 'user/message', seq: 0, time: 1787054669201, data: {
+        content: [{ type: 'text', text: 'system context' }],
+        source: { kind: 'plugin', plugin: '@deepseek-ai/dsh-system-prompt' }, role: 'user', id: 'm-1' } },
+  ]);
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  persist(db, { key: path, sessionId: SID }, parseDeepseek({ key: path, sessionId: SID }, null));
+  const row = db.prepare('SELECT * FROM messages').get();
+  assert.equal(row.is_meta, 1);
+  assert.equal(row.source, 'deepseek');
+  assert.equal(row.visibility, 'visible');
+  const session = db.prepare('SELECT * FROM sessions').get();
+  assert.equal(session.source, 'deepseek');
+  assert.equal(session.version, '0');
+  db.close();
+});

--- a/tests/invoking-session.test.mjs
+++ b/tests/invoking-session.test.mjs
@@ -421,6 +421,10 @@ test('cli polls fresh snapshots until a concurrent writer indexes the nonce', as
 // the real ~/.obelisk. Same pattern as tests/pi-runtime.test.mjs.
 function runCoreScript(home, script, env = {}) {
   const coreUrl = pathToFileURL(join(repoRoot, 'packages/core/src/core.ts')).href;
+  // The deepseek provider prefers $DSH_HOME over ~/.dsh; a harness shell that
+  // exports DSH_HOME would point the build at the real session store.
+  const childEnv = { ...process.env, HOME: home, USERPROFILE: home, OBELISK_CORE_URL: coreUrl, ...env };
+  delete childEnv.DSH_HOME;
   const run = spawnSync(process.execPath, [
     '--experimental-strip-types',
     '--disable-warning=ExperimentalWarning',
@@ -429,7 +433,7 @@ function runCoreScript(home, script, env = {}) {
     script,
   ], {
     cwd: repoRoot,
-    env: { ...process.env, HOME: home, USERPROFILE: home, OBELISK_CORE_URL: coreUrl, ...env },
+    env: childEnv,
     encoding: 'utf8',
   });
   assert.equal(run.status, 0, run.stderr);

--- a/tests/provider-registry.test.mjs
+++ b/tests/provider-registry.test.mjs
@@ -63,6 +63,7 @@ test('built-in provider registry exposes every source without caller-side branch
   const registry = createBuiltinProviderRegistry({
     claude: '/sources/claude',
     codex: '/sources/codex',
+    deepseek: '/sources/deepseek',
     kimi: '/sources/kimi',
     pi: '/sources/pi',
   });
@@ -70,6 +71,7 @@ test('built-in provider registry exposes every source without caller-side branch
   assert.deepEqual(registry.catalog().map(({ id, name }) => ({ id, name })), [
     { id: 'claude', name: 'Claude Code' },
     { id: 'codex', name: 'Codex' },
+    { id: 'deepseek', name: 'DeepSeek Harness' },
     { id: 'kimi', name: 'Kimi Code' },
     { id: 'pi', name: 'Pi' },
   ]);
@@ -79,6 +81,7 @@ test('built-in provider registry exposes every source without caller-side branch
     '/sources/codex/sessions',
     '/sources/codex/archived_sessions',
     '/sources/codex/session_index.jsonl',
+    '/sources/deepseek',
     '/sources/kimi/sessions',
     '/sources/kimi/session_index.jsonl',
     '/sources/pi',


### PR DESCRIPTION
## Summary

Adds a `deepseek` provider adapter that indexes **DeepSeek Harness** session artifacts (`$DSH_HOME/sessions`, default `~/.dsh/sessions`) into the shared Obelisk schema, alongside `claude`, `codex`, `kimi`, and `pi`.

## What changed

- **`packages/core/src/providers/deepseek.ts`** — the provider adapter:
  - Line-incremental like claude: `mtime:lines` cursor skips already-indexed lines (`countMode: 'delta'`), with a full reparse (`'total'`) on first index or when a crash repair truncated the artifact below the indexed line count.
  - Subagent child sessions (header `origin: 'subagent'` + `parentSession`) project into their parent session as sidechain messages plus a `subagent` row.
  - `user/message` events with a non-`user` source kind map to `is_meta` (injected system prompts / skill reminders).
  - `tool/call` <-> `tool/result` correlation via `callId`; thinking (reasoning) blocks become `content_type: 'thinking'` messages ordered before the text message so `assembleSessionDetail` folds them correctly.
  - Stable message uuids `deepseek:<sessionId>:<line>` (plus `:0`/`:1` suffixes for thinking/text) so `raw()` returns the original artifact line.
  - Respects `$DSH_HOME`; falls back to `~/.dsh/sessions`.
- **`packages/core/src/zstd.ts`** — ports the frame scanner from `@deepseek-ai/dsh-session-persistence-jsonl` (MIT, attribution header kept) and decodes complete frames via built-in `node:zlib` (zstd), skipping a torn crash tail. **No new runtime dependencies.**
- **`builtins.ts` / `package.json`** — provider registration and exports.
- **Tests** — `tests/deepseek-parse.test.mjs` (golden: plaintext / zstd frames / torn tail / incremental delta resume / truncation fallback / subagent / discover / raw), `tests/deepseek-session-detail.test.mjs` (ADR-0007 conformance: parse -> `assembleSessionDetail` -> persist round-trip), plus updated registry and schema-doc assertions.
- **Docs** — README / SKILL / skill-doc source lists now include deepseek.
- **Test-harness fixes** — CLI test helpers clear a harness-exported `DSH_HOME` so CLI tests resolve the deepseek root against the temp HOME (the deepseek provider prefers `$DSH_HOME` over `~/.dsh`).

## Design notes

- DSH logs are single-carrier and append-only (unlike Codex), so the adapter does **not** need full-reparse; incremental resume is the norm.
- No `inactive` visibility handling: DSH compaction summarizes history but never supersedes branches (no tree semantics), so all messages stay `visible`, consistent with claude/codex.
- The ADR-0008 invocation-nonce self-identification works for DSH: DeepSeek Harness checkpoints the `tool/call` record to disk before the tool body runs (`session-checkpoint-policy`), so a CLI invocation's nonce record is indexed before the resolver runs. Verified end-to-end (`overview().current.session_id` resolves to the invoking DSH session in a live environment).

## Verification

- `npm run typecheck` — clean.
- `npm test` — 473/473 pass.
- End-to-end: built against a real `~/.dsh/sessions` artifact (zstd), searched, and confirmed the live DSH session is recognized as the invoking session via the nonce path.
