### PR TITLE
perf(core): stop rebuilding the whole messages_fts index in every incremental finalize

### DIFF
--- a/packages/core/src/indexer.ts
+++ b/packages/core/src/indexer.ts
@@ -108,6 +108,33 @@ function healWorkflowParentLinks(db: SqliteDb): void {
 const BUILD_DEBOUNCE_MS = 30000;
 const APP_HEARTBEAT_FRESH_MS = 60000;
 
+// messages_fts is maintained row-by-row by its schema triggers: persist writes
+// messages with INSERT ... ON CONFLICT DO UPDATE (fires messages_fts_au) and
+// deletes them with plain DELETE (fires messages_fts_ad), so an incremental
+// build never leaves the index stale. The wholesale rebuild that used to run in
+// every finalize predates that guarantee, and its cost is independent of how
+// much changed — on a 1.8 GB index it is ~30 s of a ~50 s incremental build
+// (3× that under a trigram tokenizer). It is still needed exactly once, to heal
+// an index whose rows were written before trigger-only maintenance could be
+// trusted (e.g. by a version that wrote messages with INSERT OR REPLACE, whose
+// implicit deletes fire no DELETE trigger). This marker records that the heal
+// has happened; it is written in the same transaction as the rebuild, so an
+// interrupted build simply redoes it — the marker never runs ahead of the work.
+const MESSAGES_FTS_SYNC_MARKER = '__messages_fts_synced__';
+
+function markMessagesFtsSynced(db: SqliteDb): void {
+  db.prepare(
+    "INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES (?, ?, 0)",
+  ).run(MESSAGES_FTS_SYNC_MARKER, Date.now());
+}
+
+function syncMessagesFtsOnce(db: SqliteDb): void {
+  const done = db.prepare('SELECT jsonl_path FROM index_state WHERE jsonl_path = ?').get(MESSAGES_FTS_SYNC_MARKER);
+  if (done) return;
+  db.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
+  markMessagesFtsSynced(db);
+}
+
 function shouldSkipBuild(db: NodeSqliteDb, { now = Date.now(), ignoreRecentBuild = false, ignoreDaemonOwnership = false }: BuildCheckOptions = {}) {
   if (!ignoreDaemonOwnership) {
     const appHeartbeat = db.prepare("SELECT mtime FROM index_state WHERE jsonl_path='__app_heartbeat__'").get();
@@ -240,7 +267,11 @@ function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwne
             });
             refreshSessionProjectPaths(db);
             healWorkflowParentLinks(db);
+            // A force snapshot keeps the wholesale rebuild as its last line of
+            // defence, and re-records the sync marker it just wiped with
+            // index_state so the next incremental build trusts the triggers.
             db.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
+            markMessagesFtsSynced(db);
             rebuildMemoryFts(db);
             db.prepare("INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES ('__last_build__', ?, 0)").run(Date.now());
             writeProviderIndexMarkers(db, providerPlan, providerResult);
@@ -326,7 +357,7 @@ function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwne
         runRetryableWriteTransaction(txDb, () => {
           refreshSessionProjectPaths(db);
           healWorkflowParentLinks(db);
-          db.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
+          syncMessagesFtsOnce(db);
           rebuildMemoryFts(db);
           db.prepare("INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES ('__last_build__', ?, 0)").run(Date.now());
           writeProviderIndexMarkers(db, providerPlan, providerResult);

--- a/tests/incremental-fts-sync-marker.test.mjs
+++ b/tests/incremental-fts-sync-marker.test.mjs
@@ -1,0 +1,167 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// The wholesale messages_fts rebuild no longer runs in every incremental
+// finalize: the schema triggers (ai/au/ad) plus persist's upsert keep the index
+// consistent row-by-row, and the one-time heal is recorded under the
+// __messages_fts_synced__ marker in index_state.
+//
+// The "did the rebuild run?" probe is a poison posting: a row inserted straight
+// into messages_fts with no counterpart in messages. A wholesale rebuild
+// regenerates the index from the content table and clears it; trigger-only
+// maintenance leaves it alone. So poison surviving an incremental build proves
+// the rebuild was skipped, and poison vanishing across a force build proves the
+// full path kept its last line of defence.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { mkdirSync, writeFileSync, appendFileSync, utimesSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+import { runCli } from './cli-test-helpers.mjs';
+import { makeTempDir } from './temp-dirs.mjs';
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require('node:sqlite');
+
+const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+const SYNC_MARKER = '__messages_fts_synced__';
+
+function line(uuid, type, ts, text = `${type} ${uuid}`) {
+  return JSON.stringify({ uuid, type, timestamp: ts, cwd: '/tmp/proj', message: { role: type, content: text } });
+}
+
+function withDb(home, fn) {
+  const db = new DatabaseSync(join(home, '.obelisk', 'obelisk.sqlite'));
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+function clearBuildDebounce(home) {
+  withDb(home, (db) => db.prepare("DELETE FROM index_state WHERE jsonl_path='__last_build__'").run());
+}
+
+function ftsHits(db, query) {
+  return db.prepare('SELECT COUNT(*) c FROM messages_fts WHERE messages_fts MATCH ?').get(query).c;
+}
+
+function markerPresent(db) {
+  return db.prepare('SELECT 1 ok FROM index_state WHERE jsonl_path=?').get(SYNC_MARKER) !== undefined;
+}
+
+function assertFtsMatchesContentTable(db) {
+  // rank=1 makes FTS5 verify the index against the external content table;
+  // a stale or orphaned posting raises SQLITE_CORRUPT_VTAB.
+  db.exec("INSERT INTO messages_fts(messages_fts, rank) VALUES('integrity-check', 1)");
+}
+
+test('incremental build keeps messages_fts consistent without the wholesale rebuild', () => {
+  const home = makeTempDir('obelisk-ftsmark-');
+  const projDir = join(home, '.claude', 'projects', '-tmp-proj');
+  mkdirSync(projDir, { recursive: true });
+  const jsonl = join(projDir, 'sess.jsonl');
+
+  writeFileSync(jsonl, [line('u1', 'user', '2026-06-10T10:00:00Z'), line('a1', 'assistant', '2026-06-10T10:00:05Z')].join('\n') + '\n');
+  assert.equal(runCli(['--build'], { home }).status, 0);
+
+  withDb(home, (db) => {
+    assert.equal(markerPresent(db), true, 'the force build records the one-time FTS sync marker');
+    // Poison: a posting with no messages row behind it.
+    db.prepare('INSERT INTO messages_fts(rowid, uuid, session_id, text) VALUES (?,?,?,?)')
+      .run(999999, 'poison', 'sess', 'poisonword');
+    assert.equal(ftsHits(db, 'poisonword'), 1, 'poison posting is searchable before the incremental build');
+  });
+
+  appendFileSync(jsonl, line('u2', 'user', '2026-06-10T10:01:00Z', 'freshneedle content') + '\n');
+  const t = statSync(jsonl).mtimeMs / 1000 + 10;
+  utimesSync(jsonl, t, t);
+  clearBuildDebounce(home);
+
+  // --query triggers the non-force incremental build before answering.
+  writeFileSync(join(home, 'q.mjs'), "return { hits: sql(\"SELECT COUNT(*) c FROM messages_fts WHERE messages_fts MATCH 'freshneedle'\")[0].c };");
+  const r = runCli(['--query', join(home, 'q.mjs')], { home });
+  assert.equal(r.status, 0, r.stderr || r.stdout);
+  assert.equal(JSON.parse(r.stdout).hits, 1, 'the appended message is searchable via the triggers alone');
+
+  withDb(home, (db) => {
+    assert.equal(ftsHits(db, 'poisonword'), 1, 'poison survived: the incremental build did not run the wholesale rebuild');
+  });
+});
+
+test('force build keeps the wholesale rebuild and re-records the marker it wiped', () => {
+  const home = makeTempDir('obelisk-ftsmark-force-');
+  const projDir = join(home, '.claude', 'projects', '-tmp-proj');
+  mkdirSync(projDir, { recursive: true });
+  writeFileSync(join(projDir, 'sess.jsonl'), line('u1', 'user', '2026-06-10T10:00:00Z') + '\n');
+  assert.equal(runCli(['--build'], { home }).status, 0);
+
+  withDb(home, (db) => {
+    db.prepare('INSERT INTO messages_fts(rowid, uuid, session_id, text) VALUES (?,?,?,?)')
+      .run(999999, 'poison', 'sess', 'poisonword');
+  });
+  clearBuildDebounce(home);
+  assert.equal(runCli(['--build'], { home }).status, 0);
+
+  withDb(home, (db) => {
+    assert.equal(ftsHits(db, 'poisonword'), 0, 'the force build regenerated the index from the content table');
+    assert.equal(markerPresent(db), true, 'the marker is re-recorded after DELETE FROM index_state');
+    assertFtsMatchesContentTable(db);
+  });
+});
+
+test('a pre-marker index gets exactly one healing rebuild on its next incremental build', () => {
+  const home = makeTempDir('obelisk-ftsmark-heal-');
+  const projDir = join(home, '.claude', 'projects', '-tmp-proj');
+  mkdirSync(projDir, { recursive: true });
+  const jsonl = join(projDir, 'sess.jsonl');
+  writeFileSync(jsonl, line('u1', 'user', '2026-06-10T10:00:00Z') + '\n');
+  assert.equal(runCli(['--build'], { home }).status, 0);
+
+  // Simulate an index written before trigger-only maintenance: drop the marker
+  // and poison the index, the way stale postings from INSERT OR REPLACE looked.
+  withDb(home, (db) => {
+    db.prepare('DELETE FROM index_state WHERE jsonl_path=?').run(SYNC_MARKER);
+    db.prepare('INSERT INTO messages_fts(rowid, uuid, session_id, text) VALUES (?,?,?,?)')
+      .run(999999, 'poison', 'sess', 'poisonword');
+  });
+
+  appendFileSync(jsonl, line('u2', 'user', '2026-06-10T10:01:00Z') + '\n');
+  const t = statSync(jsonl).mtimeMs / 1000 + 10;
+  utimesSync(jsonl, t, t);
+  clearBuildDebounce(home);
+  writeFileSync(join(home, 'q.mjs'), 'return sql("SELECT COUNT(*) c FROM messages")[0].c;');
+  assert.equal(runCli(['--query', join(home, 'q.mjs')], { home }).status, 0);
+
+  withDb(home, (db) => {
+    assert.equal(ftsHits(db, 'poisonword'), 0, 'the marker-less index was healed by a one-time rebuild');
+    assert.equal(markerPresent(db), true, 'the heal recorded the marker');
+    assertFtsMatchesContentTable(db);
+  });
+});
+
+test("persist's upsert and delete write shapes keep the triggers truthful", () => {
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+
+  // Same conflict clause shape as persist.ts st.msg — the write the finalize
+  // rebuild used to bail out.
+  const upsert = db.prepare(`
+    INSERT INTO messages (uuid, session_id, text) VALUES (?,?,?)
+    ON CONFLICT(uuid) DO UPDATE SET text=excluded.text`);
+  upsert.run('m1', 's1', 'oldword here');
+  assert.equal(ftsHits(db, 'oldword'), 1, 'insert path indexes the text');
+
+  upsert.run('m1', 's1', 'newword here');
+  assert.equal(ftsHits(db, 'oldword'), 0, 'the AU trigger removed the replaced text');
+  assert.equal(ftsHits(db, 'newword'), 1, 'the AU trigger indexed the replacement');
+
+  db.prepare('DELETE FROM messages WHERE session_id=?').run('s1');
+  assert.equal(ftsHits(db, 'newword'), 0, 'the AD trigger removed deleted rows from the index');
+  assertFtsMatchesContentTable(db);
+  db.close();
+});


### PR DESCRIPTION
Fixes #75.

## Root cause and reproduction

Every finalize runs `messages_fts('rebuild')`, regenerating the FTS index from the whole `messages` table. Cost is proportional to index size, not change size: measured on a 1.8 GB / 688k-message index, ~10.3 s under unicode61 and ~30.2 s under trigram (#14), out of a ~50 s incremental build. File stat-comparison (8,669 jsonl, 0.07 s) is not the bottleneck — the rebuild is.

The rebuild is redundant on the incremental path: `messages_fts` is external-content maintained by the `ai/au/ad` triggers, persist upserts messages via `ON CONFLICT DO UPDATE` (fires AU) and deletes via plain `DELETE` (fires AD). No current write shape bypasses the triggers; FTS5 `integrity-check` (rank=1) passes on the live index.

## Change

- Incremental finalize performs the rebuild **exactly once per index** (heals rows that predate trigger-only maintenance, e.g. written by an `INSERT OR REPLACE`-era version) and records `__messages_fts_synced__` in `index_state` **in the same transaction** — an interrupted build redoes the heal; the marker never runs ahead of the work (converges when re-run, per the contributing guide's destructive-work rule).
- The force path keeps its wholesale rebuild as the last line of defence and re-records the marker it wipes with `DELETE FROM index_state`.
- `rebuildMemoryFts` is deliberately untouched: `memories` is tiny, and `--attune` writes it outside build transactions, so the cheap belt-and-suspenders refresh stays.

## Verification

- New `tests/incremental-fts-sync-marker.test.mjs`:
  - poison-posting probe (an FTS row with no `messages` counterpart): survives an incremental build (rebuild skipped), cleared by a force build, cleared exactly once for a marker-less index (the heal), with `integrity-check` after each path;
  - pins the trigger semantics for persist's exact upsert/delete shapes — the writes the wholesale rebuild used to bail out.
- Full suite on this branch head: **469/469 pass, typecheck clean, lint 0 errors** (4 pre-existing warnings in unrelated app tests, present on main).
- Real-machine effect (daemon-style refresh loop): incremental build 40–56 s → 10.6–11.4 s with real changes, 2.4 s floor with none; search behavior verified unchanged against LIKE ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)