### PR TITLE
feat(core): guard trigram sub-3-codepoint search terms; hit-centered snippets

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -143,6 +143,61 @@ function buildSafeFtsQuery(text: unknown): string {
     .join(' ');
 }
 
+function queryTokens(text: unknown): string[] {
+  return String(text || '').match(/[\p{Letter}\p{Number}]+/gu) || [];
+}
+
+const FTS5_OPERATOR_TOKENS = new Set(['AND', 'OR', 'NOT', 'NEAR']);
+
+// A plain query is tokens and whitespace only — no phrases, parens, column
+// filters, or prefix stars — and none of its tokens is an FTS5 operator.
+// Anything else is honored as raw FTS5 syntax and left untouched.
+function isPlainQuery(text: unknown): boolean {
+  if (/[^\p{Letter}\p{Number}\s]/u.test(String(text || ''))) return false;
+  return !queryTokens(text).some((token) => FTS5_OPERATOR_TOKENS.has(token));
+}
+
+// The trigram tokenizer emits no tokens for terms shorter than three code
+// points. A lone short term can then only match nothing, and a short term
+// next to longer ones becomes an empty phrase that constrains nothing — the
+// query silently returns rows that do not contain the term at all. The guard
+// below only engages when messages_fts is actually built with trigram, which
+// is read from the live schema rather than configuration so it stays correct
+// across tokenizer migrations.
+function isTrigramMessagesFts(db: SqliteDb): boolean {
+  try {
+    const row = db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='messages_fts'").get();
+    return /tokenize\s*=\s*['"]*trigram/i.test(String(row?.sql ?? ''));
+  } catch {
+    return false;
+  }
+}
+
+const SNIPPET_BEFORE = 60;
+const SNIPPET_AFTER = 100;
+
+// Hit-centered snippet: the head of a long message often does not contain the
+// match at all, so slice a window around the earliest term occurrence instead
+// of truncating from the front. Returns null when no term appears literally
+// (e.g. raw FTS5 syntax queries), in which case the caller has message.text.
+function makeSnippet(rawText: unknown, terms: string[]): string | null {
+  const text = String(rawText ?? '');
+  if (!text || terms.length === 0) return null;
+  const hay = text.toLowerCase();
+  let hit = -1;
+  for (const term of terms) {
+    const idx = hay.indexOf(term.toLowerCase());
+    if (idx !== -1 && (hit === -1 || idx < hit)) hit = idx;
+  }
+  if (hit === -1) return null;
+  let start = Math.max(0, hit - SNIPPET_BEFORE);
+  let end = Math.min(text.length, hit + SNIPPET_AFTER);
+  // Never split a surrogate pair at a window edge.
+  if (start > 0 && (text.charCodeAt(start) & 0xFC00) === 0xDC00) start--;
+  if (end < text.length && (text.charCodeAt(end) & 0xFC00) === 0xDC00) end++;
+  return (start > 0 ? '…' : '') + text.slice(start, end) + (end < text.length ? '…' : '');
+}
+
 function createQueryApi(
   db: SqliteDb,
   {
@@ -174,35 +229,89 @@ function createQueryApi(
       includeMeta = false,
       includeInactive = false,
     } = opts;
-    let where = 'WHERE mf.text MATCH ?';
+    // Filters reference m./s. (not mf.) so the same clause serves both the
+    // MATCH statement and the LIKE fallback scan; the join makes them equal.
+    let filterWhere = '';
     const filterParams: any[] = [];
-    if (sessionId) { where += ' AND mf.session_id=?'; filterParams.push(sessionId); }
-    if (project)   { where += ' AND s.project LIKE ?'; filterParams.push(project); }
-    if (after)     { where += ' AND m.timestamp>?';    filterParams.push(after); }
-    if (before)    { where += ' AND m.timestamp<?';    filterParams.push(before); }
-    if (cwd)       { where += ' AND m.cwd LIKE ?';     filterParams.push(cwd); }
-    if (source && source !== 'all') { where += " AND COALESCE(m.source, s.source, 'claude')=?"; filterParams.push(source); }
-    if (!includeMeta) where += ' AND COALESCE(m.is_meta,0)=0';
-    where += ` AND ${visibilitySql('m', includeInactive)}`;
-    const stmt = db.prepare(`
+    if (sessionId) { filterWhere += ' AND m.session_id=?'; filterParams.push(sessionId); }
+    if (project)   { filterWhere += ' AND s.project LIKE ?'; filterParams.push(project); }
+    if (after)     { filterWhere += ' AND m.timestamp>?';    filterParams.push(after); }
+    if (before)    { filterWhere += ' AND m.timestamp<?';    filterParams.push(before); }
+    if (cwd)       { filterWhere += ' AND m.cwd LIKE ?';     filterParams.push(cwd); }
+    if (source && source !== 'all') { filterWhere += " AND COALESCE(m.source, s.source, 'claude')=?"; filterParams.push(source); }
+    if (!includeMeta) filterWhere += ' AND COALESCE(m.is_meta,0)=0';
+    filterWhere += ` AND ${visibilitySql('m', includeInactive)}`;
+    const selectCols = `
       SELECT m.uuid,m.session_id,m.text,m.content_type,m.is_meta,m.role,m.timestamp,m.model,m.cwd,
              COALESCE(m.visibility,'visible') AS visibility,m.source as m_source,
              s.id as s_id,s.title as s_title,s.project as s_project,s.started_at as s_started,
-             s.source as s_source,
+             s.source as s_source`;
+    const stmt = db.prepare(`${selectCols},
              rank
       FROM messages_fts mf JOIN messages m ON m.uuid=mf.uuid LEFT JOIN sessions s ON s.id=m.session_id
-      ${where} ORDER BY rank LIMIT ?`);
-    const runMatch = (matchText: string): DbRow[] => stmt.all(matchText, ...filterParams, limit);
-    // Honor raw FTS5 syntax when the query is valid, but never crash on ordinary
-    // input (hyphens, punctuation) that FTS5 would parse as operators: fall back
-    // to safe per-token quoting, the same tokenization memories() uses.
-    let rows;
-    try {
-      rows = runMatch(text);
-    } catch {
-      const safe = buildSafeFtsQuery(text);
-      rows = safe ? runMatch(safe) : [];
+      WHERE mf.text MATCH ?${filterWhere} ORDER BY rank LIMIT ?`);
+    const runMatch = (matchText: string, rowLimit: number = limit): DbRow[] =>
+      stmt.all(matchText, ...filterParams, rowLimit);
+
+    // Terms below the trigram minimum cannot go through MATCH; scan the
+    // content table instead. Tokens are alphanumeric-only, so no LIKE escaping
+    // is needed. rank is NULL — recency stands in for relevance here.
+    const runLikeScan = (terms: string[]): DbRow[] => {
+      const likeWhere = terms.map(() => 'm.text LIKE ?').join(' AND ');
+      const likeStmt = db.prepare(`${selectCols},
+             NULL as rank
+      FROM messages m LEFT JOIN sessions s ON s.id=m.session_id
+      WHERE ${likeWhere}${filterWhere} ORDER BY m.timestamp DESC LIMIT ?`);
+      return likeStmt.all(...terms.map((t) => `%${t}%`), ...filterParams, limit);
+    };
+
+    // Under trigram, terms shorter than three code points silently constrain
+    // nothing (false positives next to longer terms, zero hits alone). Split
+    // the tokens: MATCH the indexable ones, then require the short ones as
+    // literal substrings; with nothing indexable, fall back to a LIKE scan.
+    const runTokensGuarded = (tokens: string[]): { rows: DbRow[]; degraded: string | null } => {
+      const unique = [...new Set(tokens)];
+      const short = unique.filter((token) => [...token].length < 3);
+      const long = unique.filter((token) => [...token].length >= 3);
+      const matchText = long.slice(0, 12).map((token) => `"${token}"`).join(' ');
+      if (short.length === 0) return { rows: matchText ? runMatch(matchText) : [], degraded: null };
+      if (long.length === 0) return { rows: runLikeScan(short), degraded: 'like-scan' };
+      // Overselect to leave the post-filter room, bounded so a broad first
+      // term cannot turn the guard into a full-table crawl.
+      const scanLimit = Math.min(limit * 5, limit + 200);
+      const needles = short.map((token) => token.toLowerCase());
+      const rows = runMatch(matchText, scanLimit)
+        .filter((r: DbRow) => {
+          const hay = String(r.text ?? '').toLowerCase();
+          return needles.every((needle) => hay.includes(needle));
+        })
+        .slice(0, limit);
+      return { rows, degraded: 'short-token-post-filter' };
+    };
+
+    const trigram = isTrigramMessagesFts(db);
+    let rows: DbRow[];
+    let degraded: string | null = null;
+    if (trigram && isPlainQuery(text)) {
+      ({ rows, degraded } = runTokensGuarded(queryTokens(text)));
+    } else {
+      // Honor raw FTS5 syntax when the query is valid, but never crash on
+      // ordinary input (hyphens, punctuation) that FTS5 would parse as
+      // operators: fall back to safe per-token quoting — routed through the
+      // same short-token guard under trigram, since the extracted tokens can
+      // be short too ('gen-itgc ok').
+      try {
+        rows = runMatch(text);
+      } catch {
+        if (trigram) {
+          ({ rows, degraded } = runTokensGuarded(queryTokens(text)));
+        } else {
+          const safe = buildSafeFtsQuery(text);
+          rows = safe ? runMatch(safe) : [];
+        }
+      }
     }
+    const snippetTerms = queryTokens(text);
     return rows.map((r: DbRow) => {
       const metaClause = includeMeta ? '' : 'AND COALESCE(is_meta,0)=0';
       const ctx = db.prepare(
@@ -222,7 +331,7 @@ function createQueryApi(
       // is_invoking marks the session that ran this query; it is the agent's
       // own live context, not independent historical evidence.
       if (invokingSessionId && r.s_id === invokingSessionId) session.is_invoking = true;
-      return {
+      const result: DbRow = {
         message: {
           uuid: r.uuid,
           text: r.text,
@@ -239,6 +348,10 @@ function createQueryApi(
         rank: r.rank,
         context: ctx,
       };
+      const snippet = makeSnippet(r.text, snippetTerms);
+      if (snippet !== null) result.snippet = snippet;
+      if (degraded) result.degraded = degraded;
+      return result;
     });
   };
 

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -265,6 +265,20 @@ function createQueryApi(
       return likeStmt.all(...terms.map((t) => `%${t}%`), ...filterParams, limit);
     };
 
+    // MATCH the indexable terms with the short ones pushed down as SQL LIKE
+    // substring conditions: the filter runs over the full MATCH result set
+    // before LIMIT, so recall does not depend on where the combined hits rank.
+    // (A JS post-filter over an overselected window returned zero rows on a
+    // real index whose top bm25 hits for the long term lacked the short one.)
+    const runMatchWithSubstrings = (matchText: string, terms: string[]): DbRow[] => {
+      const likeAnd = terms.map(() => ' AND m.text LIKE ?').join('');
+      const guarded = db.prepare(`${selectCols},
+             rank
+      FROM messages_fts mf JOIN messages m ON m.uuid=mf.uuid LEFT JOIN sessions s ON s.id=m.session_id
+      WHERE mf.text MATCH ?${likeAnd}${filterWhere} ORDER BY rank LIMIT ?`);
+      return guarded.all(matchText, ...terms.map((t) => `%${t}%`), ...filterParams, limit);
+    };
+
     // Under trigram, terms shorter than three code points silently constrain
     // nothing (false positives next to longer terms, zero hits alone). Split
     // the tokens: MATCH the indexable ones, then require the short ones as
@@ -276,17 +290,7 @@ function createQueryApi(
       const matchText = long.slice(0, 12).map((token) => `"${token}"`).join(' ');
       if (short.length === 0) return { rows: matchText ? runMatch(matchText) : [], degraded: null };
       if (long.length === 0) return { rows: runLikeScan(short), degraded: 'like-scan' };
-      // Overselect to leave the post-filter room, bounded so a broad first
-      // term cannot turn the guard into a full-table crawl.
-      const scanLimit = Math.min(limit * 5, limit + 200);
-      const needles = short.map((token) => token.toLowerCase());
-      const rows = runMatch(matchText, scanLimit)
-        .filter((r: DbRow) => {
-          const hay = String(r.text ?? '').toLowerCase();
-          return needles.every((needle) => hay.includes(needle));
-        })
-        .slice(0, limit);
-      return { rows, degraded: 'short-token-post-filter' };
+      return { rows: runMatchWithSubstrings(matchText, short), degraded: 'short-token-post-filter' };
     };
 
     const trigram = isTrigramMessagesFts(db);

--- a/skill-doc/references/api-reference.md
+++ b/skill-doc/references/api-reference.md
@@ -112,12 +112,18 @@ Array<{
   message: { uuid, text, content_type, is_meta, role, timestamp, model, cwd, visibility, source },
   session: { id, title, project, started_at, source, is_invoking? },
   rank,
-  context
+  context,
+  snippet?,
+  degraded?
 }>
 ```
 
 `session.is_invoking` is `true` when the hit belongs to the invoking session
 (see Invocation Identity) and omitted otherwise.
+
+`snippet` is a hit-centered window into `message.text`: long messages often
+match far past the head, so read `snippet` first and fall back to `text` when
+it is absent (a raw-syntax query whose terms do not appear literally).
 
 `context` is temporal neighbor context in the same session, not a parent chain.
 Hits and neighbors carry `visibility`.
@@ -129,6 +135,15 @@ Valid FTS5 syntax in `text` is honored. Input that FTS5 would reject as
 malformed (for example a hyphenated term like `foo-bar`) does not error: it
 falls back to safe per-token quoting — the same tokenization `memories()` uses —
 so ordinary text never crashes the query.
+
+When `messages_fts` is built with the trigram tokenizer, terms shorter than
+three code points cannot go through MATCH (alone they match nothing; next to
+longer terms they silently match everything). Plain queries route around this
+automatically and say so via `degraded`: `"short-token-post-filter"` means the
+longer terms were MATCHed and the short ones enforced as literal substrings
+(rank preserved), `"like-scan"` means every term was short and the content
+table was scanned directly (`rank` is `null`, recency orders the hits).
+Queries using explicit FTS5 operators bypass the guard and are sent as-is.
 
 #### `context(uuid, opts?)`
 

--- a/tests/contract-helper-shapes.test.mjs
+++ b/tests/contract-helper-shapes.test.mjs
@@ -101,7 +101,9 @@ test('search() hit shape matches api-reference.md', () => {
   const db = fixture();
   const hit = createQueryApi(db).search('needle', { limit: 1 })[0];
 
-  exactKeys(hit, ['message', 'session', 'rank', 'context'], 'search() hit');
+  // snippet is present whenever a query term appears literally in the text,
+  // which a plain-token query like this one guarantees (api-reference.md).
+  exactKeys(hit, ['message', 'session', 'rank', 'context', 'snippet'], 'search() hit');
   exactKeys(hit.message, ['uuid', 'text', 'content_type', 'is_meta', 'role', 'timestamp', 'model', 'cwd', 'visibility', 'source'], 'search() hit.message');
   exactKeys(hit.session, ['id', 'title', 'project', 'started_at', 'source'], 'search() hit.session');
   assert.ok(Array.isArray(hit.context), 'search() hit.context is an array');

--- a/tests/search-short-token-guard.test.mjs
+++ b/tests/search-short-token-guard.test.mjs
@@ -1,0 +1,116 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Under the trigram tokenizer, a query term shorter than three code points
+// emits no tokens: alone it can only match nothing, and next to longer terms
+// it becomes an empty phrase that constrains nothing — search('quick ok')
+// silently returned rows without 'ok' in them. These tests pin the guard
+// (post-filter short terms, LIKE-scan all-short queries), prove the default
+// unicode61 behavior is untouched, and pin the hit-centered snippet.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+
+import { createQueryApi } from '../packages/core/src/query.ts';
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require('node:sqlite');
+const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+
+function seed(db) {
+  db.prepare("INSERT INTO sessions (id, title, project, started_at) VALUES ('s1','Guard tests','proj','2026-06-10T10:00:00Z')").run();
+  const ins = db.prepare('INSERT INTO messages (uuid, session_id, role, text, timestamp) VALUES (?,?,?,?,?)');
+  ins.run('m-quick-only', 's1', 'user', 'the quick brown fox jumped over the lazy dog', '2026-06-10T10:00:01Z');
+  ins.run('m-quick-ok', 's1', 'user', 'quick check says ok to proceed', '2026-06-10T10:00:02Z');
+  ins.run('m-ok-only', 's1', 'user', 'all fine and ok over here', '2026-06-10T10:00:03Z');
+  ins.run('m-cjk-fix', 's1', 'user', '悬空引用的问题已经彻底修复', '2026-06-10T10:00:04Z');
+  ins.run('m-cjk-fix-ok', 's1', 'user', '修复完了，ok 可以合并', '2026-06-10T10:00:05Z');
+  ins.run('m-hyphen-ok', 's1', 'user', 'running gen-itgc ok now', '2026-06-10T10:00:06Z');
+  ins.run('m-hyphen-only', 's1', 'user', 'gen-itgc failed with an error', '2026-06-10T10:00:07Z');
+}
+
+// Same shape as the tokenizer migration: dropping an external-content FTS
+// table leaves the content table and its triggers intact, and 'rebuild'
+// repopulates the new one.
+function trigramDb() {
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  db.exec('DROP TABLE messages_fts');
+  db.exec("CREATE VIRTUAL TABLE messages_fts USING fts5(uuid UNINDEXED, session_id UNINDEXED, text, content=messages, content_rowid=rowid, tokenize='trigram')");
+  seed(db);
+  db.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
+  return db;
+}
+
+function unicodeDb() {
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  seed(db);
+  return db;
+}
+
+test('trigram: a short term next to a long one filters instead of silently matching everything', () => {
+  const api = createQueryApi(trigramDb());
+  const hits = api.search('quick ok');
+  assert.deepEqual(hits.map((h) => h.message.uuid), ['m-quick-ok'],
+    "rows without 'ok' must not match a query that asks for it");
+  assert.equal(hits[0].degraded, 'short-token-post-filter');
+  assert.equal(typeof hits[0].rank, 'number', 'the long-term MATCH keeps relevance ranking');
+});
+
+test('trigram: an all-short query falls back to a LIKE scan instead of zero hits', () => {
+  const api = createQueryApi(trigramDb());
+  const hits = api.search('ok');
+  assert.deepEqual(new Set(hits.map((h) => h.message.uuid)),
+    new Set(['m-quick-ok', 'm-ok-only', 'm-cjk-fix-ok', 'm-hyphen-ok']));
+  assert.equal(hits[0].degraded, 'like-scan');
+  assert.equal(hits[0].rank, null, 'a scan has no FTS rank; recency orders it');
+});
+
+test('trigram: a two-code-point CJK word plus a short ASCII word both survive', () => {
+  const api = createQueryApi(trigramDb());
+  const hits = api.search('修复 ok');
+  assert.deepEqual(hits.map((h) => h.message.uuid), ['m-cjk-fix-ok'],
+    'only the row containing both short terms matches');
+});
+
+test('trigram: the punctuation fallback path routes through the same guard', () => {
+  const api = createQueryApi(trigramDb());
+  // 'gen-itgc ok' throws as raw FTS5 (column filter syntax), falls back to
+  // token quoting — where 'ok' must still be enforced, not dropped.
+  const hits = api.search('gen-itgc ok');
+  assert.deepEqual(hits.map((h) => h.message.uuid), ['m-hyphen-ok']);
+});
+
+test('trigram: raw FTS5 syntax is honored untouched', () => {
+  const api = createQueryApi(trigramDb());
+  const hits = api.search('"quick" OR "fine"');
+  assert.deepEqual(new Set(hits.map((h) => h.message.uuid)),
+    new Set(['m-quick-only', 'm-quick-ok', 'm-ok-only']));
+  assert.equal(hits[0].degraded, undefined, 'operator queries bypass the guard');
+});
+
+test('unicode61 default: short terms are real tokens and the guard stays out of the way', () => {
+  const api = createQueryApi(unicodeDb());
+  const hits = api.search('quick ok');
+  assert.deepEqual(hits.map((h) => h.message.uuid), ['m-quick-ok']);
+  assert.equal(hits[0].degraded, undefined);
+  assert.equal(typeof hits[0].rank, 'number');
+});
+
+test('snippet centers on the hit that head truncation would miss', () => {
+  const db = unicodeDb();
+  const filler = 'lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor. '.repeat(8);
+  db.prepare('INSERT INTO messages (uuid, session_id, role, text, timestamp) VALUES (?,?,?,?,?)')
+    .run('m-deep', 's1', 'user', `${filler}the elusive needleword appears only here${filler}`, '2026-06-10T10:00:08Z');
+  const api = createQueryApi(db);
+  const hits = api.search('needleword');
+  assert.equal(hits.length, 1);
+  assert.ok(!hits[0].message.text.slice(0, 240).includes('needleword'),
+    'precondition: head truncation alone would miss this hit');
+  assert.ok(hits[0].snippet.includes('needleword'), 'the snippet window contains the hit');
+  assert.ok(hits[0].snippet.startsWith('…') && hits[0].snippet.endsWith('…'));
+  assert.ok(hits[0].snippet.length <= 200, 'the snippet stays a window, not the whole message');
+});

--- a/tests/search-short-token-guard.test.mjs
+++ b/tests/search-short-token-guard.test.mjs
@@ -84,6 +84,30 @@ test('trigram: the punctuation fallback path routes through the same guard', () 
   assert.deepEqual(hits.map((h) => h.message.uuid), ['m-hyphen-ok']);
 });
 
+test('trigram: recall survives when top-ranked long-term hits lack the short term', () => {
+  // Regression: an early implementation post-filtered a small overselected
+  // window in JS; on a real index every top bm25 hit for the long term lacked
+  // the short one and the query returned zero rows. The substring condition
+  // must apply to the full MATCH set, before LIMIT.
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  db.exec('DROP TABLE messages_fts');
+  db.exec("CREATE VIRTUAL TABLE messages_fts USING fts5(uuid UNINDEXED, session_id UNINDEXED, text, content=messages, content_rowid=rowid, tokenize='trigram')");
+  db.prepare("INSERT INTO sessions (id, title, project, started_at) VALUES ('s1','t','p','2026-06-10T10:00:00Z')").run();
+  const ins = db.prepare('INSERT INTO messages (uuid, session_id, role, text, timestamp) VALUES (?,?,?,?,?)');
+  // Short, quick-dense messages rank far above the one real combined hit.
+  for (let i = 0; i < 40; i++) ins.run(`m-dense-${i}`, 's1', 'user', 'quick quick quick', '2026-06-10T10:00:01Z');
+  ins.run('m-real', 's1', 'user',
+    `quick note buried in prose ${'filler words here '.repeat(30)}and in the end it was ok`,
+    '2026-06-10T10:00:02Z');
+  db.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
+
+  const hits = createQueryApi(db).search('quick ok', { limit: 3 });
+  assert.deepEqual(hits.map((h) => h.message.uuid), ['m-real'],
+    'the only row containing both terms is found regardless of its bm25 position');
+  db.close();
+});
+
 test('trigram: raw FTS5 syntax is honored untouched', () => {
   const api = createQueryApi(trigramDb());
   const hits = api.search('"quick" OR "fine"');


### PR DESCRIPTION
Fixes #76 and #194. Follow-up to #9/#14 (configurable tokenizer).

## Root cause and reproduction

Under trigram, a term shorter than three code points emits no tokens. Alone it can only match nothing; next to longer terms it becomes an empty phrase constraining nothing. Real-index measurement: `MATCH 'quick ok'` → 799 rows, LIKE ground truth 442 — 357 silent false positives. Two-code-point CJK words (`修复`) hit the same wall, i.e. exactly the audience the trigram option serves.

## Change

`search()` detects the live tokenizer from `sqlite_master` (correct across migrations, no config dependency) and, for plain token-and-whitespace queries:

- terms ≥3 code points MATCH as before; shorter terms ride the same statement as `AND m.text LIKE ?` substring conditions, filtering the full MATCH set **before LIMIT** (rank preserved) — reported per-hit as `degraded: 'short-token-post-filter'`. An earlier draft post-filtered an overselected window in JS and collapsed to zero recall on the real index (top bm25 hits for the long term lacked the short one); the SQL push-down is recall-exact and is pinned by a buried-hit regression test.
- all-short queries fall back to a LIKE scan (`degraded: 'like-scan'`, `rank: null`, recency-ordered) instead of returning zero rows;
- the existing punctuation fallback (catch → per-token quoting) routes through the same guard.

On the default unicode61 index the guard never engages; behavior is byte-for-byte unchanged (pinned by test).

Every hit also gains `snippet` — a window centered on the earliest literal term occurrence (long transcript messages routinely match far past the head; head-truncating previews never show the match). Omitted when no term appears literally.

## Raw FTS5 syntax (#194, added 2026-09-21)

The first revision of this PR let explicit FTS5 syntax bypass the guard entirely. That was wrong, and it left the bug in place for the shape most likely to hit it: `search('"quick" ok')` returned rows without `ok` and reported `degraded: null`. Quoting one term was enough. The gate conflated "is this raw syntax" (may the text be rewritten?) with "does this query hold unindexable terms" (is a guard needed?) — the second is true either way.

Raw queries now take the same substring push-down, but only where it means the same thing:

- conjunctive raw query with at least one indexable term → short terms required as substrings, `degraded: 'short-token-post-filter'`, raw MATCH text untouched so ranking survives;
- `OR` / `NOT` / `NEAR` present, or no term long enough to MATCH → an added AND would answer a different question, so the rows stay exactly as FTS5 answered and the hit carries a new `degraded: 'short-token-unguarded'`.

FTS5 operator keywords are excluded from short-term detection, so `'"quick" OR "fine"'` is still untouched and unmarked (pinned by the existing test).

**Known limitation, documented rather than fixed:** an empty result carries no marker at all, because `degraded` rides on each hit — a query holding a short term that returns nothing may have dropped the term rather than missed it. Fixing that means changing the return shape, which felt like your call rather than mine; see #194.

## Existing-assertion change (own section per the contributing guide)

`contract-helper-shapes.test.mjs` `exactKeys` for the search() hit gains `'snippet'` — extended, not loosened: the fixture query guarantees a literal term hit, so the key is deterministically present. `api-reference.md` documents every `degraded` value and both new optional fields in the same commits (the doc-sync guard enforces this). No assertion was weakened for the #194 follow-up; the raw-syntax bypass test still asserts the operator query is untouched.

## Verification

Re-run on the current head after merging `upstream/main` (this branch was 54 commits behind; the merge conflicted only in `query.ts`, where #139's bounded temporal context landed beside the snippet-terms line — both sides kept).

- `tests/search-short-token-guard.test.mjs` now 11 tests: the original 8 plus raw-syntax filtering, raw-syntax unenforceable reporting, and unicode61-untouched-under-raw-syntax.
- Full suite: **768 tests, 746 pass, 22 fail — all 22 are `tests/kimi-manifest.test.mjs`**, failing identically on this branch with the change reverted. They are an environment incompatibility, not a regression: Node v26.4.0 with `--experimental-test-module-mocks` throws `TypeError: Cannot redefine property: constants` in `cjsMockModuleLoad` before any assertion runs. Please read the CI result as authoritative over my local numbers for that file.
- `npm run typecheck` clean (root and app tsconfig). `npm run lint` 0 errors, 11 warnings — all pre-existing in unrelated test files.
- `npm run test:electron:all` **not run**: this machine does not use the Electron app. No `app/` source is touched by either commit.
- Real-index spot check after deploy (880k messages, trigram): `search('"quick" ok')` now returns only rows containing both terms with numeric rank and `degraded: 'short-token-post-filter'`; `search('quick OR ok')` returns the disjunction unchanged with `degraded: 'short-token-unguarded'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
