### PR TITLE
fix(app): replace per-path watching with one recursive fs.watch per root

### DIFF
--- a/app/src/main/indexer-service.ts
+++ b/app/src/main/indexer-service.ts
@@ -4,7 +4,6 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import chokidarModule from 'chokidar';
 
 const DEFAULT_PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects');
 const DEFAULT_DEBOUNCE_MS = 2000;
@@ -54,7 +53,8 @@ interface IndexerServiceOptions {
   buildIndex?: IndexerBuild;
   writeHeartbeat?: () => unknown;
   watchProjects?: (onChange: (changedPath?: string) => void) => Watcher | null;
-  chokidar?: any;
+  /** Injection point for the default watcher's fs.watch (tests). */
+  watchFs?: typeof fs.watch;
   timers?: Timers;
   logger?: { warn?: (msg: string) => void };
 }
@@ -70,7 +70,7 @@ function createIndexerService({
   buildIndex,
   writeHeartbeat = () => {},
   watchProjects,
-  chokidar,
+  watchFs = fs.watch,
   timers = {
     setTimeout,
     clearTimeout,
@@ -87,32 +87,36 @@ function createIndexerService({
     const watchedRoots = new Set<string>();
     const addRoot = (root: string) => {
       if (watchedRoots.has(root) || !fs.existsSync(root)) return false;
-      const onFileChange = (filename) => {
-        const name = filename ? String(filename) : '';
-        if (!name || name.endsWith('.jsonl') || name.endsWith('.json')) {
-          onChange(name && !path.isAbsolute(name) ? path.join(root, name) : name);
-        }
-      };
-      const watcher = (chokidar || chokidarModule).watch(root, {
-        cwd: root,
-        ignoreInitial: true,
-        awaitWriteFinish: {
-          stabilityThreshold: Math.max(stabilityMs, 500),
-          pollInterval: 100,
-        },
-        ignored: (targetPath, stats) => {
-          if (stats?.isDirectory()) return false;
-          if (!stats) return false;
-          return !String(targetPath).endsWith('.jsonl') && !String(targetPath).endsWith('.json');
-        },
+      // One recursive fs.watch per root — a single FSEvents stream / inotify
+      // tree instead of one watcher per path. A per-path model (chokidar 4
+      // without fsevents) opens an O_EVTONLY fd per file and an FSEventStream
+      // per directory; measured on a real ~23k-path transcript tree it
+      // exhausts a per-process FSEvents/mach resource long before
+      // RLIMIT_NOFILE and floods EMFILE, while stream creation degrades
+      // super-linearly (~7 ms each at 1k streams, minutes at 6k). The
+      // recursive watcher is O(1) on both axes and still reports events for
+      // files in directories created after it started. Write stability is
+      // owned by the service's debounce + stability timers, so no
+      // awaitWriteFinish equivalent is needed here.
+      let watcher: fs.FSWatcher;
+      try {
+        watcher = watchFs(
+          root,
+          { recursive: fs.statSync(root).isDirectory() },
+          (_eventType, filename) => {
+            const name = filename ? String(filename) : '';
+            if (!name || name.endsWith('.jsonl') || name.endsWith('.json')) {
+              onChange(name && !path.isAbsolute(name) ? path.join(root, name) : name);
+            }
+          },
+        );
+      } catch (error) {
+        logger.warn?.(`Obelisk watcher failed: ${(error as Error).message}`);
+        return false;
+      }
+      watcher.on('error', (error) => {
+        logger.warn?.(`Obelisk watcher failed: ${(error as Error).message}`);
       });
-      watcher
-        .on('add', onFileChange)
-        .on('change', onFileChange)
-        .on('unlink', onFileChange)
-        .on('error', (error) => {
-          logger.warn?.(`Obelisk watcher failed: ${(error as Error).message}`);
-        });
       watchers.push(watcher);
       watchedRoots.add(root);
       return true;

--- a/tests/app-indexer-service.test.mjs
+++ b/tests/app-indexer-service.test.mjs
@@ -389,33 +389,29 @@ test('indexer service publishes daemon ownership as soon as it starts', () => {
   service.stop();
 });
 
-test('indexer service watches Claude JSON files through chokidar', async () => {
-  const projectsDir = makeTempDir('obelisk-chokidar-projects-');
+test('indexer service watches Claude JSON files through one recursive watcher', async () => {
+  const projectsDir = makeTempDir('obelisk-recursive-projects-');
   const timers = manualTimers();
   const calls = [];
   let watchArgs = null;
-  const handlers = {};
+  let emit = null;
   const watcher = {
-    on(event, handler) {
-      handlers[event] = handler;
-      return watcher;
-    },
+    on() { return watcher; },
     closeCalled: false,
     close() {
       watcher.closeCalled = true;
     },
   };
-  const chokidar = {
-    watch(paths, options) {
-      watchArgs = { paths, options };
-      return watcher;
-    },
+  const watchFs = (root, options, listener) => {
+    watchArgs = { root, options };
+    emit = listener;
+    return watcher;
   };
 
   const service = createIndexerService({
     projectsDir,
     buildIndex: async ({ reason }) => calls.push(reason),
-    chokidar,
+    watchFs,
     writeHeartbeat: () => {},
     timers,
     stabilityMs: 0,
@@ -424,12 +420,10 @@ test('indexer service watches Claude JSON files through chokidar', async () => {
 
   try {
     service.start({ buildOnStart: false });
-    assert.equal(watchArgs.paths, projectsDir);
-    assert.equal(watchArgs.options.cwd, projectsDir);
-    assert.equal(watchArgs.options.ignoreInitial, true);
-    assert.ok(watchArgs.options.awaitWriteFinish);
+    assert.equal(watchArgs.root, projectsDir);
+    assert.equal(watchArgs.options.recursive, true);
 
-    handlers.change('session.jsonl');
+    emit('change', 'session.jsonl');
     timers.flush();
     await service.idle();
     assert.deepEqual(calls, ['watch']);
@@ -444,24 +438,17 @@ test('indexer service passes changed JSONL paths to the build worker', async () 
   const projectsDir = makeTempDir('obelisk-changed-paths-');
   const timers = manualTimers();
   const calls = [];
-  const handlers = {};
-  const watcher = {
-    on(event, handler) {
-      handlers[event] = handler;
-      return watcher;
-    },
-    close() {},
-  };
-  const chokidar = {
-    watch() {
-      return watcher;
-    },
+  let emit = null;
+  const watcher = { on() { return watcher; }, close() {} };
+  const watchFs = (_root, _options, listener) => {
+    emit = listener;
+    return watcher;
   };
 
   const service = createIndexerService({
     projectsDir,
     buildIndex: async (args) => calls.push(args),
-    chokidar,
+    watchFs,
     writeHeartbeat: () => {},
     timers,
     stabilityMs: 0,
@@ -469,8 +456,8 @@ test('indexer service passes changed JSONL paths to the build worker', async () 
   });
 
   service.start({ buildOnStart: false });
-  handlers.change('project-a/session-1.jsonl');
-  handlers.add('project-a/session-2.json');
+  emit('change', 'project-a/session-1.jsonl');
+  emit('rename', 'project-a/session-2.json');
   timers.flush();
   await service.idle();
 
@@ -487,30 +474,20 @@ test('indexer service watches Claude projects and Codex sessions for app-side in
   const codexSessionsDir = makeTempDir('obelisk-watch-codex-sessions-');
   const timers = manualTimers();
   const calls = [];
-  const watchers = [];
+  const emitters = [];
   const watchArgs = [];
-  const chokidar = {
-    watch(paths, options) {
-      const handlers = {};
-      const watcher = {
-        handlers,
-        on(event, handler) {
-          handlers[event] = handler;
-          return watcher;
-        },
-        close() {},
-      };
-      watchers.push(watcher);
-      watchArgs.push({ paths, options });
-      return watcher;
-    },
+  const watchFs = (root, options, listener) => {
+    watchArgs.push({ root, options });
+    emitters.push(listener);
+    const watcher = { on() { return watcher; }, close() {} };
+    return watcher;
   };
 
   const service = createIndexerService({
     projectsDir: claudeProjectsDir,
     watchDirs: [claudeProjectsDir, codexSessionsDir],
     buildIndex: async (args) => calls.push(args),
-    chokidar,
+    watchFs,
     writeHeartbeat: () => {},
     timers,
     stabilityMs: 0,
@@ -518,10 +495,10 @@ test('indexer service watches Claude projects and Codex sessions for app-side in
   });
 
   service.start({ buildOnStart: false });
-  assert.deepEqual(watchArgs.map(arg => arg.paths), [claudeProjectsDir, codexSessionsDir]);
-  assert.deepEqual(watchArgs.map(arg => arg.options.cwd), [claudeProjectsDir, codexSessionsDir]);
+  assert.deepEqual(watchArgs.map(arg => arg.root), [claudeProjectsDir, codexSessionsDir]);
+  assert.deepEqual(watchArgs.map(arg => arg.options.recursive), [true, true]);
 
-  watchers[1].handlers.change('2026/06/15/rollout-2026-06-15T00-00-00-codex.jsonl');
+  emitters[1]('change', '2026/06/15/rollout-2026-06-15T00-00-00-codex.jsonl');
   timers.flush();
   await service.idle();
 
@@ -538,22 +515,15 @@ test('indexer service starts watching a configured root that appears after start
   const timers = manualTimers();
   const calls = [];
   const watchArgs = [];
-  const chokidar = {
-    watch(root) {
-      watchArgs.push(root);
-      const watcher = {
-        on() {
-          return watcher;
-        },
-        close() {},
-      };
-      return watcher;
-    },
+  const watchFs = (root) => {
+    watchArgs.push(root);
+    const watcher = { on() { return watcher; }, close() {} };
+    return watcher;
   };
   const service = createIndexerService({
     watchDirs: [existingRoot, lateRoot],
     buildIndex: async (args) => calls.push(args),
-    chokidar,
+    watchFs,
     writeHeartbeat: () => {},
     timers,
     stabilityMs: 0,

--- a/tests/app-indexer-watch-recursive.test.mjs
+++ b/tests/app-indexer-watch-recursive.test.mjs
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// The default watchProjects implementation uses one recursive fs.watch per
+// root (O(1) descriptors) instead of a per-path watcher. These tests exercise
+// the real watcher: deep-file events must reach buildIndex with the resolved
+// absolute path, non-transcript files must be filtered out, and the descriptor
+// footprint must not scale with the number of files in the tree — the failure
+// mode that motivated the change (EMFILE on a ~23k-path transcript tree).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { join } from 'node:path';
+
+import { createIndexerService } from '../app/src/main/indexer-service.ts';
+import { makeTempDir } from './temp-dirs.mjs';
+
+const fdCount = () => fs.readdirSync('/dev/fd').length;
+
+async function waitFor(cond, ms = 5000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (cond()) return true;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return cond();
+}
+
+test('default watcher reports deep new files with O(1) descriptors', async () => {
+  const root = makeTempDir('obelisk-recwatch-');
+  // A pre-existing populated tree: per-path watchers would need one fd each.
+  for (let i = 0; i < 50; i++) {
+    const d = join(root, `proj-${i}`);
+    fs.mkdirSync(d, { recursive: true });
+    fs.writeFileSync(join(d, 'old.jsonl'), '{}\n');
+  }
+
+  const builds = [];
+  const before = fdCount();
+  const service = createIndexerService({
+    watchDirs: [root],
+    debounceMs: 10,
+    stabilityMs: 0,
+    buildIndex: ({ reason, changedPaths }) => { builds.push({ reason, changedPaths }); },
+    writeHeartbeat: () => {},
+    logger: { warn: () => {} },
+  });
+  service.start({ buildOnStart: false });
+  const after = fdCount();
+  assert.ok(after - before <= 5,
+    `watching a 100-entry tree must not cost per-path descriptors (fd ${before} -> ${after})`);
+
+  // A brand-new nested directory plus transcript — the worst case for
+  // per-path watchers, which have no watcher on the new directory yet.
+  const deep = join(root, 'proj-new', 'sess-id', 'subagents');
+  fs.mkdirSync(deep, { recursive: true });
+  const newFile = join(deep, 'agent-1.jsonl');
+  fs.writeFileSync(newFile, '{"probe":1}\n');
+
+  const sawIt = await waitFor(() =>
+    builds.some((b) => (b.changedPaths ?? []).some((p) => p.endsWith('agent-1.jsonl'))));
+  assert.ok(sawIt, 'the deep new transcript reached buildIndex as a changed path');
+  const hit = builds.find((b) => (b.changedPaths ?? []).some((p) => p.endsWith('agent-1.jsonl')));
+  assert.ok(hit.changedPaths.every((p) => p.startsWith(root)),
+    'changed paths are resolved to absolute paths under the watched root');
+
+  service.stop();
+  await service.idle();
+});
+
+test('default watcher filters non-transcript files', async () => {
+  const root = makeTempDir('obelisk-recwatch-filter-');
+  const builds = [];
+  const service = createIndexerService({
+    watchDirs: [root],
+    debounceMs: 10,
+    stabilityMs: 0,
+    buildIndex: (args) => { builds.push(args); },
+    writeHeartbeat: () => {},
+    logger: { warn: () => {} },
+  });
+  service.start({ buildOnStart: false });
+
+  fs.writeFileSync(join(root, 'noise.txt'), 'not a transcript');
+  // Give a wrong-positive time to surface, then send a real one as a control.
+  await new Promise((r) => setTimeout(r, 700));
+  const noiseBuilds = builds.length;
+  fs.writeFileSync(join(root, 'real.json'), '{}');
+  const sawReal = await waitFor(() =>
+    builds.slice(noiseBuilds).some((b) => (b.changedPaths ?? []).some((p) => p.endsWith('real.json'))));
+
+  assert.equal(noiseBuilds, 0, 'a .txt write alone must not schedule a build');
+  assert.ok(sawReal, 'the .json control write does schedule a build');
+
+  service.stop();
+  await service.idle();
+});


### PR DESCRIPTION
Fixes #79.

## Root cause and reproduction

chokidar 4 (no fsevents) watches every path individually: one `O_EVTONLY` fd per file, one FSEventStream per directory. On a ~23k-path transcript tree the watcher floods `EMFILE: too many open files, watch` and leaves ~20% of files unwatched. Reproduction data in #79: rlimit ruled out (49152 verified in-process), bare `fs.watch` × 20k files ruled out (no error), per-directory stream creation degrades super-linearly (~7 ms each at 1.2k, minutes at 6k) — a per-process FSEvents/mach ceiling that libuv surfaces as EMFILE.

## Change

One `fs.watch(root, { recursive: true })` per configured root (files get a plain watch). Single FSEvents stream on macOS, native recursive on Windows, supported on Linux since Node 20. O(1) descriptors; events fire for files in directories created after the watcher started. Event semantics unchanged: all event types funnel into the same `.jsonl`/`.json`-filtered `onChange` — exactly how the add/change/unlink trio was consumed before. Write stability stays with the service's debounce + stability timers (chokidar's `awaitWriteFinish` was a second, redundant layer). A synchronous `fs.watch` failure logs and returns false, so the existing `refreshMissingRoots` retry loop owns recovery.

chokidar remains a dependency: `app/src/main/index.ts` still uses it for the shallow `OBELISK_DIR` watch, deliberately out of scope (one PR, one thing).

## Existing-assertion changes (own section per the contributing guide)

The four tests that injected a `chokidar` mock now inject `watchFs` (same shape as `fs.watch`, the new narrow injection point). Assertions on chokidar-specific options (`cwd`/`ignoreInitial`/`awaitWriteFinish`) became assertions on `{ recursive: true }`; the behaviors those tests pin — multi-root fan-out, late-appearing-root pickup, relative-path resolution, close-on-stop — are asserted unchanged.

## Verification

- New `tests/app-indexer-watch-recursive.test.mjs` drives the **real** watcher over a populated temp tree: deep new file in a directory created after watch start reaches `buildIndex` with an absolute path; non-transcript writes are filtered; watching a 100-entry tree costs ≤5 fds (the O(1) property that motivated the change).
- Full suite on this branch head: **467/467 pass, typecheck clean, lint 0 errors** (4 pre-existing warnings in unrelated tests, present on main).
- Not run: `test:electron:all` — this machine runs the data layer headless and has no Electron environment; the change is main-process-only (no renderer surface). Flagging per the verification contract so CI / a maintainer run covers it.
- Real-machine effect (headless daemon, same tree): EMFILE lines 697/30s → **0**; process fds ~15.2k → **43**; watch-triggered incremental builds fire as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)