### PR TITLE
feat(app): replace chokidar with @parcel/watcher, add dead-stream recovery and reconcile loop

### DIFF
--- a/app/electron.vite.config.ts
+++ b/app/electron.vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
           'indexer-worker': resolve('src/main/indexer-worker.ts'),
           'indexer-worker-client': resolve('src/main/indexer-worker-client.ts'),
           'recap-capture-query': resolve('src/main/recap-capture-query.ts'),
+          watcher: resolve('src/main/watcher.ts'),
         },
       },
     },

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,8 +8,8 @@
       "name": "obelisk",
       "version": "0.2.3",
       "dependencies": {
-        "better-sqlite3": "^13.0.2",
-        "chokidar": "^4.0.3"
+        "@parcel/watcher": "^2.6.0",
+        "better-sqlite3": "^13.0.2"
       },
       "devDependencies": {
         "@tanstack/vue-virtual": "^3.13.32",
@@ -1221,6 +1221,304 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+      "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.6.0",
+        "@parcel/watcher-darwin-arm64": "2.6.0",
+        "@parcel/watcher-darwin-x64": "2.6.0",
+        "@parcel/watcher-freebsd-x64": "2.6.0",
+        "@parcel/watcher-linux-arm-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm-musl": "2.6.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm64-musl": "2.6.0",
+        "@parcel/watcher-linux-x64-glibc": "2.6.0",
+        "@parcel/watcher-linux-x64-musl": "2.6.0",
+        "@parcel/watcher-win32-arm64": "2.6.0",
+        "@parcel/watcher-win32-x64": "2.6.0"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+      "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+      "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+      "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+      "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+      "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+      "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+      "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+      "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+      "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+      "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+      "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+      "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/@peculiar/asn1-schema": {
       "version": "2.8.0",
@@ -2507,21 +2805,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/chromium-pickle-js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
@@ -2804,6 +3087,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-node": {
@@ -3850,6 +4142,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3858,6 +4159,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/isarray": {
@@ -4480,7 +4793,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4702,19 +5014,6 @@
       },
       "bin": {
         "read-binary-file-arch": "cli.js"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/require-directory": {

--- a/app/package.json
+++ b/app/package.json
@@ -63,7 +63,8 @@
       "out/**"
     ],
     "asarUnpack": [
-      "node_modules/better-sqlite3/**/*"
+      "node_modules/better-sqlite3/**/*",
+      "node_modules/@parcel/watcher/**/*"
     ],
     "extraResources": [
       {
@@ -73,8 +74,8 @@
     ]
   },
   "dependencies": {
-    "better-sqlite3": "^13.0.2",
-    "chokidar": "^4.0.3"
+    "@parcel/watcher": "^2.6.0",
+    "better-sqlite3": "^13.0.2"
   },
   "devDependencies": {
     "@tanstack/vue-virtual": "^3.13.32",

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -443,6 +443,16 @@ function flushObeliskChanges() {
   for (const changedPath of changedPaths) onObeliskChange(changedPath);
 }
 
+function scheduleObeliskWatchRetry() {
+  if (obeliskRetryTimer) return;
+  obeliskRetryTimer = setTimeout(() => {
+    obeliskRetryTimer = null;
+    // Mirror the indexer service's retry loop: keep retrying while any root
+    // is unwatched, so a deleted-and-recreated OBELISK_DIR is picked up too.
+    if (obeliskWatcher?.refreshMissingRoots() === false) scheduleObeliskWatchRetry();
+  }, 5000);
+}
+
 function startObeliskWatcher() {
   if (obeliskWatcher) return obeliskWatcher;
   if (!fs.existsSync(OBELISK_DIR)) {
@@ -458,13 +468,7 @@ function startObeliskWatcher() {
         obeliskNotifyTimer = setTimeout(flushObeliskChanges, 300);
       }
     },
-    onRootLost: () => {
-      if (obeliskRetryTimer) return;
-      obeliskRetryTimer = setTimeout(() => {
-        obeliskRetryTimer = null;
-        obeliskWatcher?.refreshMissingRoots();
-      }, 5000);
-    },
+    onRootLost: () => scheduleObeliskWatchRetry(),
   });
   return obeliskWatcher;
 }

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -7,9 +7,9 @@ import os from 'node:os';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
-import chokidar from 'chokidar';
 import { writeHeartbeat } from './indexer.ts';
 import { createIndexerService } from './indexer-service.ts';
+import { createRecursiveWatcher } from './watcher.ts';
 import { createWorkerBuildIndex } from './indexer-worker-client.ts';
 import { buildRecapExportQuery } from './recap-capture-query.ts';
 import { buildEditorUrl, DEFAULT_EDITOR_SCHEME, EDITOR_SCHEMES, resolveFileReference } from './file-reference.ts';
@@ -341,6 +341,9 @@ async function stopBackgroundResources({ stopWorker = false } = {}) {
   if (obeliskWatcher) {
     const watcher = obeliskWatcher;
     obeliskWatcher = null;
+    if (obeliskNotifyTimer) { clearTimeout(obeliskNotifyTimer); obeliskNotifyTimer = null; }
+    if (obeliskRetryTimer) { clearTimeout(obeliskRetryTimer); obeliskRetryTimer = null; }
+    pendingObeliskChanges.clear();
     if (typeof watcher.close === 'function') await Promise.resolve(watcher.close());
   }
   closeDb();
@@ -428,25 +431,41 @@ function createWindow() {
 
 const OBELISK_DIR = path.join(os.homedir(), '.obelisk');
 const RECAP_DIR = path.join(OBELISK_DIR, 'recap');
-let obeliskWatcher: import("chokidar").FSWatcher | null = null;
+let obeliskWatcher: ReturnType<typeof createRecursiveWatcher> = null;
+let obeliskNotifyTimer: ReturnType<typeof setTimeout> | null = null;
+let obeliskRetryTimer: ReturnType<typeof setTimeout> | null = null;
+const pendingObeliskChanges = new Set<string>();
+
+function flushObeliskChanges() {
+  obeliskNotifyTimer = null;
+  const changedPaths = [...pendingObeliskChanges];
+  pendingObeliskChanges.clear();
+  for (const changedPath of changedPaths) onObeliskChange(changedPath);
+}
 
 function startObeliskWatcher() {
   if (obeliskWatcher) return obeliskWatcher;
   if (!fs.existsSync(OBELISK_DIR)) {
     fs.mkdirSync(OBELISK_DIR, { recursive: true });
   }
-  obeliskWatcher = chokidar.watch(OBELISK_DIR, {
-    ignoreInitial: true,
-    awaitWriteFinish: { stabilityThreshold: 300, pollInterval: 100 },
-    ignored: (p, stats) => {
-      if (stats?.isDirectory()) return false;
-      if (!stats) return false;
-      return !p.endsWith('.md') && !p.endsWith('.json');
+  obeliskWatcher = createRecursiveWatcher({
+    roots: [OBELISK_DIR],
+    filter: (targetPath) => targetPath.endsWith('.md') || targetPath.endsWith('.json'),
+    onChange: (changedPath) => {
+      // A trailing 300 ms debounce replaces chokidar's awaitWriteFinish.
+      if (changedPath) pendingObeliskChanges.add(changedPath);
+      if (pendingObeliskChanges.size && !obeliskNotifyTimer) {
+        obeliskNotifyTimer = setTimeout(flushObeliskChanges, 300);
+      }
+    },
+    onRootLost: () => {
+      if (obeliskRetryTimer) return;
+      obeliskRetryTimer = setTimeout(() => {
+        obeliskRetryTimer = null;
+        obeliskWatcher?.refreshMissingRoots();
+      }, 5000);
     },
   });
-  obeliskWatcher.on('add', onObeliskChange);
-  obeliskWatcher.on('change', onObeliskChange);
-  obeliskWatcher.on('unlink', onObeliskChange);
   return obeliskWatcher;
 }
 

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -455,18 +455,22 @@ function scheduleObeliskWatchRetry() {
 
 function startObeliskWatcher() {
   if (obeliskWatcher) return obeliskWatcher;
-  if (!fs.existsSync(OBELISK_DIR)) {
-    fs.mkdirSync(OBELISK_DIR, { recursive: true });
-  }
+  // Idempotent ensure, off the main thread (mkdir recursive does not need an
+  // existence check). The watcher tolerates the directory appearing late —
+  // that is what the probe + retry loop is for — so there is no ordering
+  // dependency between the two.
+  void fs.promises.mkdir(OBELISK_DIR, { recursive: true }).catch(() => {});
   obeliskWatcher = createRecursiveWatcher({
     roots: [OBELISK_DIR],
     filter: (targetPath) => targetPath.endsWith('.md') || targetPath.endsWith('.json'),
     onChange: (changedPath) => {
-      // A trailing 300 ms debounce replaces chokidar's awaitWriteFinish.
-      if (changedPath) pendingObeliskChanges.add(changedPath);
-      if (pendingObeliskChanges.size && !obeliskNotifyTimer) {
-        obeliskNotifyTimer = setTimeout(flushObeliskChanges, 300);
-      }
+      // True trailing debounce — reset on every event so an actively written
+      // file notifies only after its writes settle (the awaitWriteFinish
+      // replacement). Without the reset this would be a throttle.
+      if (!changedPath) return;
+      pendingObeliskChanges.add(changedPath);
+      if (obeliskNotifyTimer) clearTimeout(obeliskNotifyTimer);
+      obeliskNotifyTimer = setTimeout(flushObeliskChanges, 300);
     },
     onRootLost: () => scheduleObeliskWatchRetry(),
   });

--- a/app/src/main/indexer-service.ts
+++ b/app/src/main/indexer-service.ts
@@ -1,10 +1,9 @@
 // Copyright (C) 2026 tommy0103 and contributors.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import chokidarModule from 'chokidar';
+import { createRecursiveWatcher, type ParcelSubscribe } from './watcher.ts';
 
 const DEFAULT_PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects');
 const DEFAULT_DEBOUNCE_MS = 2000;
@@ -12,6 +11,7 @@ const DEFAULT_STABILITY_MS = 500;
 const DEFAULT_HEARTBEAT_MS = 30000;
 const DEFAULT_WATCH_RETRY_MS = 5000;
 const DEFAULT_DEFERRED_RETRY_MS = 250;
+const DEFAULT_RECONCILE_MS = 5 * 60 * 1000;
 const MAX_INVENTORY_RETRY_MS = 10 * 60 * 1000;
 
 type TimerHandle = ReturnType<typeof setTimeout>;
@@ -51,10 +51,14 @@ interface IndexerServiceOptions {
   heartbeatMs?: number;
   watchRetryMs?: number;
   deferredRetryMs?: number;
+  /** Interval for a periodic full-inventory reconcile build; bounds worst-case
+   * staleness from events the watcher silently drops. 0 disables it. */
+  reconcileMs?: number;
   buildIndex?: IndexerBuild;
   writeHeartbeat?: () => unknown;
   watchProjects?: (onChange: (changedPath?: string) => void) => Watcher | null;
-  chokidar?: any;
+  /** Injection point for the default watcher's @parcel/watcher subscribe (tests). */
+  subscribe?: ParcelSubscribe;
   timers?: Timers;
   logger?: { warn?: (msg: string) => void };
 }
@@ -67,10 +71,11 @@ function createIndexerService({
   heartbeatMs = DEFAULT_HEARTBEAT_MS,
   watchRetryMs = DEFAULT_WATCH_RETRY_MS,
   deferredRetryMs = DEFAULT_DEFERRED_RETRY_MS,
+  reconcileMs = DEFAULT_RECONCILE_MS,
   buildIndex,
   writeHeartbeat = () => {},
   watchProjects,
-  chokidar,
+  subscribe,
   timers = {
     setTimeout,
     clearTimeout,
@@ -82,63 +87,22 @@ function createIndexerService({
   if (typeof buildIndex !== 'function') throw new Error('createIndexerService() requires buildIndex');
   const watch = watchProjects || ((onChange) => {
     const roots = [...new Set((Array.isArray(watchDirs) ? watchDirs : [watchDirs]).filter(Boolean))];
-    if (!roots.length) return null;
-    const watchers: any[] = [];
-    const watchedRoots = new Set<string>();
-    const addRoot = (root: string) => {
-      if (watchedRoots.has(root) || !fs.existsSync(root)) return false;
-      const onFileChange = (filename) => {
-        const name = filename ? String(filename) : '';
-        if (!name || name.endsWith('.jsonl') || name.endsWith('.json')) {
-          onChange(name && !path.isAbsolute(name) ? path.join(root, name) : name);
-        }
-      };
-      const watcher = (chokidar || chokidarModule).watch(root, {
-        cwd: root,
-        ignoreInitial: true,
-        awaitWriteFinish: {
-          stabilityThreshold: Math.max(stabilityMs, 500),
-          pollInterval: 100,
-        },
-        ignored: (targetPath, stats) => {
-          if (stats?.isDirectory()) return false;
-          if (!stats) return false;
-          return !String(targetPath).endsWith('.jsonl') && !String(targetPath).endsWith('.json');
-        },
-      });
-      watcher
-        .on('add', onFileChange)
-        .on('change', onFileChange)
-        .on('unlink', onFileChange)
-        .on('error', (error) => {
-          logger.warn?.(`Obelisk watcher failed: ${(error as Error).message}`);
-        });
-      watchers.push(watcher);
-      watchedRoots.add(root);
-      return true;
-    };
-    const refreshMissingRoots = (notify: boolean) => {
-      let added = false;
-      for (const root of roots) {
-        if (addRoot(root)) added = true;
-      }
-      if (added && notify) onChange();
-      return watchedRoots.size === roots.length;
-    };
-    refreshMissingRoots(false);
-    return {
-      close() {
-        return Promise.all(watchers.map(w => Promise.resolve(w.close?.())));
-      },
-      refreshMissingRoots() {
-        return refreshMissingRoots(true);
-      },
-    };
+    return createRecursiveWatcher({
+      roots,
+      filter: (targetPath) => targetPath.endsWith('.jsonl') || targetPath.endsWith('.json'),
+      subscribe,
+      logger,
+      onChange,
+      // A subscription that died (async error) is re-attached through the
+      // same retry loop that picks up late-appearing roots.
+      onRootLost: () => scheduleWatchRetry(),
+    });
   });
 
   let buildTimer: TimerHandle | null = null;
   let stabilityTimer: TimerHandle | null = null;
   let heartbeatTimer: TimerHandle | null = null;
+  let reconcileTimer: TimerHandle | null = null;
   let watchRetryTimer: TimerHandle | null = null;
   let retryTimer: TimerHandle | null = null;
   let watcher: Watcher | null = null;
@@ -299,6 +263,13 @@ function createIndexerService({
       heartbeatTimer = timers.setInterval(() => {
         publishHeartbeat();
       }, heartbeatMs);
+      // Periodic full-inventory reconcile: bounds worst-case staleness from
+      // events the watcher silently drops (no error signal) to one interval.
+      if (reconcileMs > 0) {
+        reconcileTimer = timers.setInterval(() => {
+          scheduleBuild('reconcile');
+        }, reconcileMs);
+      }
     }
   };
 
@@ -314,8 +285,12 @@ function createIndexerService({
     if (retryTimer) timers.clearTimeout(retryTimer);
     retryTimer = null;
     nextInventoryRetryMs = heartbeatMs;
-    if (heartbeatTimer && typeof timers.clearInterval === 'function') timers.clearInterval(heartbeatTimer);
+    if (typeof timers.clearInterval === 'function') {
+      if (heartbeatTimer) timers.clearInterval(heartbeatTimer);
+      if (reconcileTimer) timers.clearInterval(reconcileTimer);
+    }
     heartbeatTimer = null;
+    reconcileTimer = null;
     if (watcher?.close) watcher.close();
     watcher = null;
   };

--- a/app/src/main/watcher.ts
+++ b/app/src/main/watcher.ts
@@ -13,8 +13,12 @@
 //   Electron main process (CONTRIBUTING.md). A stat on a network mount must
 //   not freeze the UI.
 // - A missing root is a normal steady state (e.g. no ~/.codex), not an
-//   error: the existence check stays quiet and only drives the retry loop
-//   through onRootLost. Only a genuine subscribe failure logs a warning.
+//   error: the probe classifies ENOENT/ENOTDIR as "not there yet" and stays
+//   quiet, only driving the retry loop through onRootLost. Anything else
+//   (EACCES, EIO, ENAMETOOLONG, ...) is a genuine problem and is warned —
+//   once per (root, failure), so a permanent misconfiguration does not spam
+//   on every retry tick; the entry clears when the root establishes, so a
+//   later recurrence reports again.
 // - A subscription that errors after establishing is dropped from the
 //   watched set and re-attached through the same retry loop — a dead stream
 //   never lingers as "watched".
@@ -47,6 +51,8 @@ interface RecursiveWatcherOptions {
   filter: (path: string) => boolean;
   onChange: (changedPath?: string) => void;
   subscribe?: ParcelSubscribe;
+  /** Injection point for the root existence probe (tests). */
+  access?: (path: string) => Promise<unknown>;
   logger?: { warn?: (msg: string) => void };
   /** Called when a root needs a later retry: it does not exist yet, its
    * subscribe attempt failed, or its subscription errored. This callback is
@@ -59,6 +65,7 @@ function createRecursiveWatcher({
   filter,
   onChange,
   subscribe = parcelWatcher.subscribe as ParcelSubscribe,
+  access = fs.promises.access,
   logger = console,
   onRootLost,
 }: RecursiveWatcherOptions): RecursiveWatcher | null {
@@ -75,6 +82,17 @@ function createRecursiveWatcher({
     if (!initialPassDone && pending.size === 0) initialPassDone = true;
   };
 
+  // Warn once per (root, failure) pair: permanent problems (a bad configured
+  // path, permissions) would otherwise log on every retry tick. Cleared on
+  // establishment so a later recurrence reports again.
+  const lastWarned = new Map<string, string>();
+  const warnOnce = (root: string, error: unknown, message: string) => {
+    const key = `${(error as NodeJS.ErrnoException)?.code ?? ''}:${message}`;
+    if (lastWarned.get(root) === key) return;
+    lastWarned.set(root, key);
+    logger.warn?.(message);
+  };
+
   const dropRoot = (root: string) => {
     const sub = subscriptions.get(root);
     subscriptions.delete(root);
@@ -89,7 +107,7 @@ function createRecursiveWatcher({
     try {
       result = subscribe(root, (err, events) => {
         if (err) {
-          logger.warn?.(`Obelisk watcher failed for ${root}: ${(err as Error).message ?? err}`);
+          warnOnce(root, err, `Obelisk watcher failed for ${root}: ${(err as Error).message ?? err}`);
           dropRoot(root);
           return;
         }
@@ -100,7 +118,7 @@ function createRecursiveWatcher({
     } catch (error) {
       pending.delete(root);
       noteSettled();
-      logger.warn?.(`Obelisk watcher failed to subscribe ${root}: ${(error as Error).message}`);
+      warnOnce(root, error, `Obelisk watcher failed to subscribe ${root}: ${(error as Error).message}`);
       if (!closed) onRootLost?.(root);
       return;
     }
@@ -115,6 +133,7 @@ function createRecursiveWatcher({
         return;
       }
       subscriptions.set(root, sub);
+      lastWarned.delete(root);
       // The initial establishment pass is quiet — the startup build already
       // covers those roots. Later establishments are genuine coverage
       // increases and warrant a full-inventory build.
@@ -122,7 +141,7 @@ function createRecursiveWatcher({
     }, (error) => {
       pending.delete(root);
       noteSettled();
-      logger.warn?.(`Obelisk watcher failed to subscribe ${root}: ${(error as Error).message ?? error}`);
+      warnOnce(root, error, `Obelisk watcher failed to subscribe ${root}: ${(error as Error).message ?? error}`);
       if (!closed) onRootLost?.(root);
     });
   };
@@ -130,13 +149,16 @@ function createRecursiveWatcher({
   const addRoot = (root: string): boolean => {
     if (closed || subscriptions.has(root) || pending.has(root)) return false;
     pending.add(root);
-    fs.promises.access(root).then(() => {
+    Promise.resolve(access(root)).then(() => {
       if (closed || !pending.has(root)) return;
       subscribeRoot(root);
-    }, () => {
-      // The root does not exist (yet) — a normal steady state, not an error.
+    }, (error) => {
       pending.delete(root);
       noteSettled();
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+        warnOnce(root, error, `Obelisk watcher cannot access ${root}: ${(error as Error).message ?? error}`);
+      }
       if (!closed) onRootLost?.(root);
     });
     return true;

--- a/app/src/main/watcher.ts
+++ b/app/src/main/watcher.ts
@@ -1,0 +1,132 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Thin adapter over @parcel/watcher: one recursive native subscription per
+// root (FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW on
+// Windows), O(1) descriptors regardless of tree size. This replaces the
+// chokidar 4 default, which — having dropped fsevents — opened one fd per
+// file and one FSEventStream per directory and flooded EMFILE on real
+// transcript trees (~23k paths), leaving ~20% of files unwatched.
+//
+// Robustness model: a subscription that fails at creation time or errors
+// later is dropped from the watched set and reported through onRootLost, so
+// the caller's retry loop re-attaches it — a dead stream never lingers as
+// "watched". Missed events with no error signal are bounded by the service's
+// periodic full-inventory reconcile, not by this module.
+
+import fs from 'node:fs';
+import parcelWatcher from '@parcel/watcher';
+
+export type ParcelEvent = { type: string; path: string };
+export type ParcelSubscribe = (
+  root: string,
+  callback: (err: Error | null, events: ParcelEvent[]) => void,
+) => Promise<{ unsubscribe(): Promise<void> }>;
+
+export interface RecursiveWatcher {
+  close(): Promise<unknown>;
+  /** Attach any configured roots that are not yet watched. Returns true when
+   * every root is established or subscribing; false means the caller should
+   * retry later. */
+  refreshMissingRoots(notify?: boolean): boolean;
+}
+
+interface RecursiveWatcherOptions {
+  roots: string[];
+  filter: (path: string) => boolean;
+  onChange: (changedPath?: string) => void;
+  subscribe?: ParcelSubscribe;
+  logger?: { warn?: (msg: string) => void };
+  /** Called when a previously watched (or subscribing) root is lost, e.g. its
+   * subscription errored. The caller should schedule a refreshMissingRoots
+   * retry. */
+  onRootLost?: (root: string) => void;
+}
+
+function createRecursiveWatcher({
+  roots,
+  filter,
+  onChange,
+  subscribe = parcelWatcher.subscribe as ParcelSubscribe,
+  logger = console,
+  onRootLost,
+}: RecursiveWatcherOptions): RecursiveWatcher | null {
+  if (!roots.length) return null;
+  const subscriptions = new Map<string, { unsubscribe(): Promise<void> }>();
+  const pending = new Set<string>();
+  let closed = false;
+
+  const dropRoot = (root: string) => {
+    const sub = subscriptions.get(root);
+    subscriptions.delete(root);
+    pending.delete(root);
+    if (sub) void sub.unsubscribe().catch(() => {});
+    onRootLost?.(root);
+  };
+
+  const addRoot = (root: string): boolean => {
+    if (closed || subscriptions.has(root) || pending.has(root)) return false;
+    if (!fs.existsSync(root)) return false;
+    pending.add(root);
+    let result: ReturnType<ParcelSubscribe>;
+    try {
+      result = subscribe(root, (err, events) => {
+        if (err) {
+          logger.warn?.(`Obelisk watcher failed for ${root}: ${(err as Error).message ?? err}`);
+          dropRoot(root);
+          return;
+        }
+        for (const event of events ?? []) {
+          if (event?.path && filter(event.path)) onChange(event.path);
+        }
+      });
+    } catch (error) {
+      pending.delete(root);
+      logger.warn?.(`Obelisk watcher failed to subscribe ${root}: ${(error as Error).message}`);
+      onRootLost?.(root);
+      return false;
+    }
+    Promise.resolve(result).then((sub) => {
+      const wasPending = pending.delete(root);
+      if (closed || !wasPending) {
+        // The watcher was closed, or the subscription errored while it was
+        // still being established (dropRoot already ran) — don't leak it.
+        void sub.unsubscribe().catch(() => {});
+        return;
+      }
+      subscriptions.set(root, sub);
+    }, (error) => {
+      pending.delete(root);
+      logger.warn?.(`Obelisk watcher failed to subscribe ${root}: ${(error as Error).message ?? error}`);
+      onRootLost?.(root);
+    });
+    return true;
+  };
+
+  const refresh = (notify: boolean): boolean => {
+    let added = false;
+    for (const root of roots) {
+      if (addRoot(root)) added = true;
+    }
+    if (added && notify) onChange();
+    return roots.every((root) => subscriptions.has(root) || pending.has(root));
+  };
+
+  // Establish the roots that already exist; late-appearing roots are picked
+  // up by the caller's refreshMissingRoots retry loop.
+  refresh(false);
+
+  return {
+    close() {
+      closed = true;
+      const subs = [...subscriptions.values()];
+      subscriptions.clear();
+      return Promise.all(subs.map((sub) => sub.unsubscribe().catch(() => {})));
+    },
+    refreshMissingRoots(notify = true) {
+      return refresh(notify);
+    },
+  };
+}
+
+export { createRecursiveWatcher };

--- a/app/src/main/watcher.ts
+++ b/app/src/main/watcher.ts
@@ -8,11 +8,21 @@
 // file and one FSEventStream per directory and flooded EMFILE on real
 // transcript trees (~23k paths), leaving ~20% of files unwatched.
 //
-// Robustness model: a subscription that fails at creation time or errors
-// later is dropped from the watched set and reported through onRootLost, so
-// the caller's retry loop re-attaches it — a dead stream never lingers as
-// "watched". Missed events with no error signal are bounded by the service's
-// periodic full-inventory reconcile, not by this module.
+// Robustness model:
+// - All filesystem probes are async (fs.promises) — no synchronous IO in the
+//   Electron main process (CONTRIBUTING.md). A stat on a network mount must
+//   not freeze the UI.
+// - A missing root is a normal steady state (e.g. no ~/.codex), not an
+//   error: the existence check stays quiet and only drives the retry loop
+//   through onRootLost. Only a genuine subscribe failure logs a warning.
+// - A subscription that errors after establishing is dropped from the
+//   watched set and re-attached through the same retry loop — a dead stream
+//   never lingers as "watched".
+// - onChange (no path, i.e. full inventory) fires exactly when coverage
+//   increases — a subscription establishes — except during the initial
+//   establishment pass, which the caller's startup build already covers.
+// - Missed events with no error signal are bounded by the service's
+//   periodic full-inventory reconcile, not by this module.
 
 import fs from 'node:fs';
 import parcelWatcher from '@parcel/watcher';
@@ -25,10 +35,11 @@ export type ParcelSubscribe = (
 
 export interface RecursiveWatcher {
   close(): Promise<unknown>;
-  /** Attach any configured roots that are not yet watched. Returns true when
-   * every root is established or subscribing; false means the caller should
-   * retry later. */
-  refreshMissingRoots(notify?: boolean): boolean;
+  /** Start attaching any configured roots that are not yet watched. Returns
+   * true when every root is established or attaching. Attaching is async;
+   * a root that turns out to be missing or lost is reported through
+   * onRootLost — wire the caller's retry loop to it. */
+  refreshMissingRoots(): boolean;
 }
 
 interface RecursiveWatcherOptions {
@@ -37,9 +48,9 @@ interface RecursiveWatcherOptions {
   onChange: (changedPath?: string) => void;
   subscribe?: ParcelSubscribe;
   logger?: { warn?: (msg: string) => void };
-  /** Called when a previously watched (or subscribing) root is lost, e.g. its
-   * subscription errored. The caller should schedule a refreshMissingRoots
-   * retry. */
+  /** Called when a root needs a later retry: it does not exist yet, its
+   * subscribe attempt failed, or its subscription errored. This callback is
+   * what keeps late-appearing and recovered roots moving. */
   onRootLost?: (root: string) => void;
 }
 
@@ -55,19 +66,25 @@ function createRecursiveWatcher({
   const subscriptions = new Map<string, { unsubscribe(): Promise<void> }>();
   const pending = new Set<string>();
   let closed = false;
+  // The first wave of establishments is quiet — the startup build already
+  // covers roots present at creation. Once the initial pass settles, every
+  // further establishment is a genuine coverage increase worth a build.
+  let initialPassDone = false;
+
+  const noteSettled = () => {
+    if (!initialPassDone && pending.size === 0) initialPassDone = true;
+  };
 
   const dropRoot = (root: string) => {
     const sub = subscriptions.get(root);
     subscriptions.delete(root);
     pending.delete(root);
+    noteSettled();
     if (sub) void sub.unsubscribe().catch(() => {});
-    onRootLost?.(root);
+    if (!closed) onRootLost?.(root);
   };
 
-  const addRoot = (root: string): boolean => {
-    if (closed || subscriptions.has(root) || pending.has(root)) return false;
-    if (!fs.existsSync(root)) return false;
-    pending.add(root);
+  const subscribeRoot = (root: string) => {
     let result: ReturnType<ParcelSubscribe>;
     try {
       result = subscribe(root, (err, events) => {
@@ -82,12 +99,15 @@ function createRecursiveWatcher({
       });
     } catch (error) {
       pending.delete(root);
+      noteSettled();
       logger.warn?.(`Obelisk watcher failed to subscribe ${root}: ${(error as Error).message}`);
-      onRootLost?.(root);
-      return false;
+      if (!closed) onRootLost?.(root);
+      return;
     }
     Promise.resolve(result).then((sub) => {
       const wasPending = pending.delete(root);
+      const duringInitialPass = !initialPassDone;
+      noteSettled();
       if (closed || !wasPending) {
         // The watcher was closed, or the subscription errored while it was
         // still being established (dropRoot already ran) — don't leak it.
@@ -95,26 +115,41 @@ function createRecursiveWatcher({
         return;
       }
       subscriptions.set(root, sub);
+      // The initial establishment pass is quiet — the startup build already
+      // covers those roots. Later establishments are genuine coverage
+      // increases and warrant a full-inventory build.
+      if (!duringInitialPass) onChange();
     }, (error) => {
       pending.delete(root);
+      noteSettled();
       logger.warn?.(`Obelisk watcher failed to subscribe ${root}: ${(error as Error).message ?? error}`);
-      onRootLost?.(root);
+      if (!closed) onRootLost?.(root);
+    });
+  };
+
+  const addRoot = (root: string): boolean => {
+    if (closed || subscriptions.has(root) || pending.has(root)) return false;
+    pending.add(root);
+    fs.promises.access(root).then(() => {
+      if (closed || !pending.has(root)) return;
+      subscribeRoot(root);
+    }, () => {
+      // The root does not exist (yet) — a normal steady state, not an error.
+      pending.delete(root);
+      noteSettled();
+      if (!closed) onRootLost?.(root);
     });
     return true;
   };
 
-  const refresh = (notify: boolean): boolean => {
-    let added = false;
-    for (const root of roots) {
-      if (addRoot(root)) added = true;
-    }
-    if (added && notify) onChange();
+  const refresh = (): boolean => {
+    for (const root of roots) addRoot(root);
     return roots.every((root) => subscriptions.has(root) || pending.has(root));
   };
 
-  // Establish the roots that already exist; late-appearing roots are picked
-  // up by the caller's refreshMissingRoots retry loop.
-  refresh(false);
+  // Start attaching the roots that already exist; late-appearing roots are
+  // picked up by the caller's onRootLost-driven retry loop.
+  refresh();
 
   return {
     close() {
@@ -123,8 +158,8 @@ function createRecursiveWatcher({
       subscriptions.clear();
       return Promise.all(subs.map((sub) => sub.unsubscribe().catch(() => {})));
     },
-    refreshMissingRoots(notify = true) {
-      return refresh(notify);
+    refreshMissingRoots() {
+      return refresh();
     },
   };
 }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -202,8 +202,8 @@ export function resolveInvokingSessionId(
 
 // Poll bounds for the nonce freshness fallback. The poll runs only when the
 // incremental recovery build loses the writer lease (writer_busy); the cap
-// gives a concurrent build — the daemon's watcher-driven build is chokidar
-// debounced ~2s plus 0.5s write stability — time to publish the nonce.
+// gives a concurrent build — the daemon's watcher-driven build (@parcel/watcher
+// debounced ~2s plus 0.5s write stability) — time to publish the nonce.
 const INVOCATION_POLL_INTERVAL_MS = 300;
 const INVOCATION_POLL_CAP_MS = 4000;
 

--- a/tests/app-indexer-service.test.mjs
+++ b/tests/app-indexer-service.test.mjs
@@ -389,33 +389,29 @@ test('indexer service publishes daemon ownership as soon as it starts', () => {
   service.stop();
 });
 
-test('indexer service watches Claude JSON files through chokidar', async () => {
-  const projectsDir = makeTempDir('obelisk-chokidar-projects-');
+test('indexer service watches Claude JSON files through a recursive @parcel/watcher subscription', async () => {
+  const projectsDir = makeTempDir('obelisk-parcel-projects-');
   const timers = manualTimers();
   const calls = [];
   let watchArgs = null;
-  const handlers = {};
-  const watcher = {
-    on(event, handler) {
-      handlers[event] = handler;
-      return watcher;
-    },
-    closeCalled: false,
-    close() {
-      watcher.closeCalled = true;
+  let emit = null;
+  const subscription = {
+    unsubscribeCalled: false,
+    unsubscribe() {
+      subscription.unsubscribeCalled = true;
+      return Promise.resolve();
     },
   };
-  const chokidar = {
-    watch(paths, options) {
-      watchArgs = { paths, options };
-      return watcher;
-    },
+  const subscribe = (root, callback) => {
+    watchArgs = root;
+    emit = callback;
+    return Promise.resolve(subscription);
   };
 
   const service = createIndexerService({
     projectsDir,
     buildIndex: async ({ reason }) => calls.push(reason),
-    chokidar,
+    subscribe,
     writeHeartbeat: () => {},
     timers,
     stabilityMs: 0,
@@ -424,12 +420,9 @@ test('indexer service watches Claude JSON files through chokidar', async () => {
 
   try {
     service.start({ buildOnStart: false });
-    assert.equal(watchArgs.paths, projectsDir);
-    assert.equal(watchArgs.options.cwd, projectsDir);
-    assert.equal(watchArgs.options.ignoreInitial, true);
-    assert.ok(watchArgs.options.awaitWriteFinish);
+    assert.equal(watchArgs, projectsDir);
 
-    handlers.change('session.jsonl');
+    emit(null, [{ type: 'update', path: join(projectsDir, 'session.jsonl') }]);
     timers.flush();
     await service.idle();
     assert.deepEqual(calls, ['watch']);
@@ -437,31 +430,23 @@ test('indexer service watches Claude JSON files through chokidar', async () => {
     service.stop();
   }
 
-  assert.equal(watcher.closeCalled, true);
+  assert.equal(subscription.unsubscribeCalled, true);
 });
 
 test('indexer service passes changed JSONL paths to the build worker', async () => {
   const projectsDir = makeTempDir('obelisk-changed-paths-');
   const timers = manualTimers();
   const calls = [];
-  const handlers = {};
-  const watcher = {
-    on(event, handler) {
-      handlers[event] = handler;
-      return watcher;
-    },
-    close() {},
-  };
-  const chokidar = {
-    watch() {
-      return watcher;
-    },
+  let emit = null;
+  const subscribe = (_root, callback) => {
+    emit = callback;
+    return Promise.resolve({ unsubscribe: () => Promise.resolve() });
   };
 
   const service = createIndexerService({
     projectsDir,
     buildIndex: async (args) => calls.push(args),
-    chokidar,
+    subscribe,
     writeHeartbeat: () => {},
     timers,
     stabilityMs: 0,
@@ -469,8 +454,8 @@ test('indexer service passes changed JSONL paths to the build worker', async () 
   });
 
   service.start({ buildOnStart: false });
-  handlers.change('project-a/session-1.jsonl');
-  handlers.add('project-a/session-2.json');
+  emit(null, [{ type: 'update', path: join(projectsDir, 'project-a/session-1.jsonl') }]);
+  emit(null, [{ type: 'create', path: join(projectsDir, 'project-a/session-2.json') }]);
   timers.flush();
   await service.idle();
 
@@ -487,30 +472,19 @@ test('indexer service watches Claude projects and Codex sessions for app-side in
   const codexSessionsDir = makeTempDir('obelisk-watch-codex-sessions-');
   const timers = manualTimers();
   const calls = [];
-  const watchers = [];
+  const emitters = [];
   const watchArgs = [];
-  const chokidar = {
-    watch(paths, options) {
-      const handlers = {};
-      const watcher = {
-        handlers,
-        on(event, handler) {
-          handlers[event] = handler;
-          return watcher;
-        },
-        close() {},
-      };
-      watchers.push(watcher);
-      watchArgs.push({ paths, options });
-      return watcher;
-    },
+  const subscribe = (root, callback) => {
+    watchArgs.push(root);
+    emitters.push(callback);
+    return Promise.resolve({ unsubscribe: () => Promise.resolve() });
   };
 
   const service = createIndexerService({
     projectsDir: claudeProjectsDir,
     watchDirs: [claudeProjectsDir, codexSessionsDir],
     buildIndex: async (args) => calls.push(args),
-    chokidar,
+    subscribe,
     writeHeartbeat: () => {},
     timers,
     stabilityMs: 0,
@@ -518,10 +492,12 @@ test('indexer service watches Claude projects and Codex sessions for app-side in
   });
 
   service.start({ buildOnStart: false });
-  assert.deepEqual(watchArgs.map(arg => arg.paths), [claudeProjectsDir, codexSessionsDir]);
-  assert.deepEqual(watchArgs.map(arg => arg.options.cwd), [claudeProjectsDir, codexSessionsDir]);
+  assert.deepEqual(watchArgs, [claudeProjectsDir, codexSessionsDir]);
 
-  watchers[1].handlers.change('2026/06/15/rollout-2026-06-15T00-00-00-codex.jsonl');
+  emitters[1](null, [{
+    type: 'update',
+    path: join(codexSessionsDir, '2026/06/15/rollout-2026-06-15T00-00-00-codex.jsonl'),
+  }]);
   timers.flush();
   await service.idle();
 
@@ -538,22 +514,14 @@ test('indexer service starts watching a configured root that appears after start
   const timers = manualTimers();
   const calls = [];
   const watchArgs = [];
-  const chokidar = {
-    watch(root) {
-      watchArgs.push(root);
-      const watcher = {
-        on() {
-          return watcher;
-        },
-        close() {},
-      };
-      return watcher;
-    },
+  const subscribe = (root) => {
+    watchArgs.push(root);
+    return Promise.resolve({ unsubscribe: () => Promise.resolve() });
   };
   const service = createIndexerService({
     watchDirs: [existingRoot, lateRoot],
     buildIndex: async (args) => calls.push(args),
-    chokidar,
+    subscribe,
     writeHeartbeat: () => {},
     timers,
     stabilityMs: 0,

--- a/tests/app-indexer-service.test.mjs
+++ b/tests/app-indexer-service.test.mjs
@@ -32,6 +32,18 @@ function manualTimers() {
   };
 }
 
+// Polls with real timers — subscribing a root is async (the adapter probes
+// existence via fs.promises before subscribing), so tests cannot assert
+// subscription state synchronously after start().
+async function until(cond, ms = 2000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (cond()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  return cond();
+}
+
 test('indexer service debounces repeated build requests', async () => {
   const timers = manualTimers();
   const calls = [];
@@ -420,6 +432,7 @@ test('indexer service watches Claude JSON files through a recursive @parcel/watc
 
   try {
     service.start({ buildOnStart: false });
+    assert.ok(await until(() => watchArgs !== null), 'the root is subscribed');
     assert.equal(watchArgs, projectsDir);
 
     emit(null, [{ type: 'update', path: join(projectsDir, 'session.jsonl') }]);
@@ -430,7 +443,7 @@ test('indexer service watches Claude JSON files through a recursive @parcel/watc
     service.stop();
   }
 
-  assert.equal(subscription.unsubscribeCalled, true);
+  assert.ok(await until(() => subscription.unsubscribeCalled), 'the subscription is released on stop');
 });
 
 test('indexer service passes changed JSONL paths to the build worker', async () => {
@@ -454,6 +467,7 @@ test('indexer service passes changed JSONL paths to the build worker', async () 
   });
 
   service.start({ buildOnStart: false });
+  assert.ok(await until(() => emit !== null), 'the root is subscribed');
   emit(null, [{ type: 'update', path: join(projectsDir, 'project-a/session-1.jsonl') }]);
   emit(null, [{ type: 'create', path: join(projectsDir, 'project-a/session-2.json') }]);
   timers.flush();
@@ -492,7 +506,10 @@ test('indexer service watches Claude projects and Codex sessions for app-side in
   });
 
   service.start({ buildOnStart: false });
-  assert.deepEqual(watchArgs, [claudeProjectsDir, codexSessionsDir]);
+  assert.ok(await until(() => watchArgs.length === 2), 'both roots are subscribed');
+  // Subscription order is nondeterministic — the async existence probes
+  // complete in threadpool order. The requirement is coverage, not order.
+  assert.deepEqual([...watchArgs].sort(), [claudeProjectsDir, codexSessionsDir].sort());
 
   emitters[1](null, [{
     type: 'update',
@@ -531,11 +548,13 @@ test('indexer service starts watching a configured root that appears after start
 
   try {
     service.start({ buildOnStart: false });
+    assert.ok(await until(() => watchArgs.length === 1), 'the existing root is subscribed');
     assert.deepEqual(watchArgs, [existingRoot]);
 
     mkdirSync(lateRoot, { recursive: true });
     writeFileSync(join(lateRoot, 'pre-existing.jsonl'), '{}\n');
     timers.flush();
+    assert.ok(await until(() => watchArgs.length === 2), 'the late root is picked up by the retry');
     assert.deepEqual(watchArgs, [existingRoot, lateRoot]);
 
     timers.flush();

--- a/tests/app-indexer-watcher.test.mjs
+++ b/tests/app-indexer-watcher.test.mjs
@@ -1,0 +1,211 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Tests for the default watchProjects implementation, which delegates to
+// @parcel/watcher through app/src/main/watcher.ts: one recursive native
+// subscription per root instead of chokidar 4's per-path model (one fd per
+// file + one FSEventStream per directory — the EMFILE flood on ~23k-path
+// transcript trees that motivated the switch). These tests exercise the real
+// watcher for event delivery and filtering, and injected subscriptions for
+// the recovery and reconciliation layers built around it.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { join } from 'node:path';
+
+import { createIndexerService } from '../app/src/main/indexer-service.ts';
+import { makeTempDir } from './temp-dirs.mjs';
+
+async function waitFor(cond, ms = 1000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (cond()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return cond();
+}
+
+function manualTimers() {
+  const timers = new Set();
+  const intervals = [];
+  return {
+    intervals,
+    setTimeout(fn) {
+      timers.add(fn);
+      return fn;
+    },
+    clearTimeout(fn) {
+      timers.delete(fn);
+    },
+    setInterval(fn, ms) {
+      intervals.push({ fn, ms });
+      return fn;
+    },
+    clearInterval() {},
+    flush() {
+      const pending = [...timers];
+      timers.clear();
+      for (const fn of pending) fn();
+    },
+  };
+}
+
+test('default watcher reports deep new files in freshly created directories', async () => {
+  const root = makeTempDir('obelisk-parcelwatch-');
+  // A pre-existing populated tree: the per-path model needed one fd per file.
+  for (let i = 0; i < 50; i++) {
+    const dir = join(root, `proj-${i}`);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(join(dir, 'old.jsonl'), '{}\n');
+  }
+
+  const builds = [];
+  const service = createIndexerService({
+    watchDirs: [root],
+    debounceMs: 10,
+    stabilityMs: 0,
+    buildIndex: (args) => { builds.push(args); },
+    writeHeartbeat: () => {},
+    logger: { warn: () => {} },
+  });
+  service.start({ buildOnStart: false });
+
+  try {
+    // A brand-new nested directory plus transcript. The subscription may still
+    // be establishing when the test first writes, so rewrite on a deadline
+    // instead of assuming the first event lands.
+    const deep = join(root, 'proj-new', 'sess-id', 'subagents');
+    fs.mkdirSync(deep, { recursive: true });
+    const newFile = join(deep, 'agent-1.jsonl');
+    const sawFile = () =>
+      builds.some((b) => (b.changedPaths ?? []).some((p) => p.endsWith('agent-1.jsonl')));
+    let sawIt = false;
+    for (let attempt = 0; attempt < 10 && !sawIt; attempt++) {
+      fs.appendFileSync(newFile, '{"probe":1}\n');
+      sawIt = await waitFor(sawFile);
+    }
+    assert.ok(sawIt, 'the deep new transcript reached buildIndex as a changed path');
+    const hit = builds.find((b) => (b.changedPaths ?? []).some((p) => p.endsWith('agent-1.jsonl')));
+    // @parcel/watcher reports real paths — on macOS the temp dir's /var/...
+    // symlink resolves to /private/var/...
+    const realRoot = fs.realpathSync(root);
+    assert.ok(hit.changedPaths.every((p) => p.startsWith(root) || p.startsWith(realRoot)),
+      'changed paths are absolute paths under the watched root');
+  } finally {
+    service.stop();
+    await service.idle();
+  }
+});
+
+test('default watcher filters non-transcript files', async () => {
+  const root = makeTempDir('obelisk-parcelwatch-filter-');
+  const builds = [];
+  const service = createIndexerService({
+    watchDirs: [root],
+    debounceMs: 10,
+    stabilityMs: 0,
+    buildIndex: (args) => { builds.push(args); },
+    writeHeartbeat: () => {},
+    logger: { warn: () => {} },
+  });
+  service.start({ buildOnStart: false });
+
+  try {
+    fs.writeFileSync(join(root, 'noise.txt'), 'not a transcript');
+    // Give a wrong-positive time to surface, then send a real one as a control.
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    const noiseBuilds = builds.length;
+    const realFile = join(root, 'real.json');
+    const sawReal = () =>
+      builds.slice(noiseBuilds).some((b) => (b.changedPaths ?? []).some((p) => p.endsWith('real.json')));
+    let sawIt = false;
+    for (let attempt = 0; attempt < 10 && !sawIt; attempt++) {
+      fs.appendFileSync(realFile, '{}\n');
+      sawIt = await waitFor(sawReal);
+    }
+
+    assert.equal(noiseBuilds, 0, 'a .txt write alone must not schedule a build');
+    assert.ok(sawIt, 'the .json control write does schedule a build');
+  } finally {
+    service.stop();
+    await service.idle();
+  }
+});
+
+test('a subscription that errors is re-attached by the watch retry loop', async () => {
+  const root = makeTempDir('obelisk-watch-reattach-');
+  const timers = manualTimers();
+  const subscriptions = [];
+  const subscribe = (rootArg, callback) => {
+    const sub = {
+      root: rootArg,
+      callback,
+      unsubscribed: false,
+      unsubscribe() {
+        sub.unsubscribed = true;
+        return Promise.resolve();
+      },
+    };
+    subscriptions.push(sub);
+    return Promise.resolve(sub);
+  };
+  const service = createIndexerService({
+    watchDirs: [root],
+    buildIndex: async () => {},
+    subscribe,
+    writeHeartbeat: () => {},
+    logger: { warn: () => {} },
+    timers,
+    stabilityMs: 0,
+    debounceMs: 0,
+    watchRetryMs: 0,
+  });
+
+  try {
+    service.start({ buildOnStart: false });
+    assert.equal(subscriptions.length, 1);
+
+    // The stream dies asynchronously with an error; the root must not stay
+    // "watched" (a dead stream would never deliver another event).
+    subscriptions[0].callback(new Error('stream died'), []);
+    await waitFor(() => subscriptions[0].unsubscribed);
+    assert.equal(subscriptions[0].unsubscribed, true);
+
+    // The retry loop re-attaches the root.
+    timers.flush();
+    assert.equal(subscriptions.length, 2);
+  } finally {
+    service.stop();
+  }
+});
+
+test('silently missed watcher events are reconciled by a periodic full-inventory build', async () => {
+  const root = makeTempDir('obelisk-watch-reconcile-');
+  const timers = manualTimers();
+  const calls = [];
+  const service = createIndexerService({
+    watchDirs: [root],
+    buildIndex: async (args) => calls.push(args),
+    subscribe: () => Promise.resolve({ unsubscribe: () => Promise.resolve() }),
+    writeHeartbeat: () => {},
+    timers,
+    stabilityMs: 0,
+    debounceMs: 0,
+    reconcileMs: 60000,
+  });
+
+  try {
+    service.start({ buildOnStart: false });
+    const reconcile = timers.intervals.find((entry) => entry.ms === 60000);
+    assert.ok(reconcile, 'a reconcile interval is scheduled');
+
+    reconcile.fn();
+    timers.flush();
+    await service.idle();
+    assert.deepEqual(calls, [{ reason: 'reconcile', changedPaths: undefined }],
+      'the reconcile build is a full-inventory build, not a changed-paths build');
+  } finally {
+    service.stop();
+  }
+});

--- a/tests/app-indexer-watcher.test.mjs
+++ b/tests/app-indexer-watcher.test.mjs
@@ -164,17 +164,16 @@ test('a subscription that errors is re-attached by the watch retry loop', async 
 
   try {
     service.start({ buildOnStart: false });
-    assert.equal(subscriptions.length, 1);
+    assert.ok(await waitFor(() => subscriptions.length === 1), 'the root is subscribed');
 
     // The stream dies asynchronously with an error; the root must not stay
     // "watched" (a dead stream would never deliver another event).
     subscriptions[0].callback(new Error('stream died'), []);
-    await waitFor(() => subscriptions[0].unsubscribed);
-    assert.equal(subscriptions[0].unsubscribed, true);
+    assert.ok(await waitFor(() => subscriptions[0].unsubscribed), 'the dead stream is unsubscribed');
 
     // The retry loop re-attaches the root.
     timers.flush();
-    assert.equal(subscriptions.length, 2);
+    assert.ok(await waitFor(() => subscriptions.length === 2), 'the retry loop re-attaches the root');
   } finally {
     service.stop();
   }

--- a/tests/app-indexer-watcher.test.mjs
+++ b/tests/app-indexer-watcher.test.mjs
@@ -15,6 +15,7 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 
 import { createIndexerService } from '../app/src/main/indexer-service.ts';
+import { createRecursiveWatcher } from '../app/src/main/watcher.ts';
 import { makeTempDir } from './temp-dirs.mjs';
 
 async function waitFor(cond, ms = 1000) {
@@ -206,5 +207,88 @@ test('silently missed watcher events are reconciled by a periodic full-inventory
       'the reconcile build is a full-inventory build, not a changed-paths build');
   } finally {
     service.stop();
+  }
+});
+
+
+test('a missing root is retried quietly', async () => {
+  const root = join(makeTempDir('obelisk-watch-missing-'), 'not-there-yet');
+  const warns = [];
+  let probeCalls = 0;
+  let lost = 0;
+  const watcher = createRecursiveWatcher({
+    roots: [root],
+    filter: () => true,
+    onChange: () => {},
+    logger: { warn: (msg) => warns.push(msg) },
+    onRootLost: () => { lost += 1; },
+    // The real fs probe through the injection point: ENOENT is genuine.
+    access: async (p) => { probeCalls += 1; return fs.promises.access(p); },
+    subscribe: () => Promise.resolve({ unsubscribe: () => Promise.resolve() }),
+  });
+
+  try {
+    assert.ok(await waitFor(() => lost === 1), 'the missing root drives a retry');
+    watcher.refreshMissingRoots();
+    assert.ok(await waitFor(() => lost === 2), 'the retry re-probes the root');
+    assert.equal(probeCalls, 2);
+    assert.deepEqual(warns, [], 'a missing root never logs a warning');
+  } finally {
+    await watcher.close();
+  }
+});
+
+test('an inaccessible root warns once per failure, and again after a recurrence', async () => {
+  const root = makeTempDir('obelisk-watch-denied-');
+  const warns = [];
+  let denied = true;
+  let lost = 0;
+  let subscribeCalls = 0;
+  let emit = null;
+  const access = async () => {
+    if (!denied) return;
+    const error = new Error('permission denied');
+    error.code = 'EACCES';
+    throw error;
+  };
+  const watcher = createRecursiveWatcher({
+    roots: [root],
+    filter: () => true,
+    onChange: () => {},
+    logger: { warn: (msg) => warns.push(msg) },
+    onRootLost: () => { lost += 1; },
+    access,
+    subscribe: (_root, callback) => {
+      subscribeCalls += 1;
+      emit = callback;
+      return Promise.resolve({ unsubscribe: () => Promise.resolve() });
+    },
+  });
+
+  try {
+    assert.ok(await waitFor(() => lost === 1), 'the first failure drives a retry');
+    watcher.refreshMissingRoots();
+    assert.ok(await waitFor(() => lost === 2));
+    watcher.refreshMissingRoots();
+    assert.ok(await waitFor(() => lost === 3));
+    assert.equal(warns.length, 1, 'a permanent failure warns once, not on every retry tick');
+
+    // The root recovers: it establishes (which clears the dedup entry)...
+    denied = false;
+    watcher.refreshMissingRoots();
+    assert.ok(await waitFor(() => subscribeCalls === 1), 'the recovered root is subscribed');
+
+    // ...then its stream dies (one warn for the death) and the retry finds
+    // the root inaccessible again — reported again, because the dedup entry
+    // was cleared on establishment.
+    emit(new Error('stream died'), []);
+    assert.ok(await waitFor(() => lost === 4), 'the dead stream drives a retry');
+    denied = true;
+    watcher.refreshMissingRoots();
+    assert.ok(await waitFor(() => lost === 5), 'the recurrence is re-probed');
+    const accessWarns = warns.filter((msg) => msg.includes('cannot access'));
+    assert.equal(accessWarns.length, 2, 'the same access failure warns again after a recovery');
+  } finally {
+    await watcher.close();
   }
 });

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -1384,3 +1384,77 @@ test('settings changes during rebuild keep one watcher and re-enable with a catc
     rmSync(home, { recursive: true, force: true });
   }
 });
+
+
+test('the OBELISK_DIR watch retry repeats while the root stays unwatched', async () => {
+  const originalHome = process.env.HOME;
+  const home = makeTempDir(`obelisk-watch-retry-${Date.now()}`);
+  mkdirSync(join(home, '.obelisk'), { recursive: true });
+  writeFileSync(join(home, '.obelisk', 'obelisk.sqlite'), '');
+  process.env.HOME = home;
+
+  let watcherOptions = null;
+  let refreshCalls = 0;
+
+  class FakeDatabase {
+    pragma() {}
+    exec() {}
+    close() {}
+    prepare() {
+      return { get: () => null, all: () => [], run: () => ({}) };
+    }
+  }
+
+  class FakeBrowserWindow {
+    constructor() {
+      this.webContents = { on() {}, setWindowOpenHandler() {}, getURL() { return ''; }, setZoomLevel() {}, openDevTools() {}, send() {} };
+    }
+    loadFile() {}
+    loadURL() {}
+    close() {}
+    static getAllWindows() { return []; }
+    static fromWebContents() { return null; }
+  }
+
+  mock.timers.enable({ apis: ['setTimeout'] });
+  const restore = registerMocks([
+    [ELECTRON_URL, { namedExports: electronNamespace({ BrowserWindow: FakeBrowserWindow }) }],
+    [DATABASE_URL, { defaultExport: FakeDatabase }],
+    [WATCHER_URL, {
+      namedExports: {
+        createRecursiveWatcher: (options) => {
+          watcherOptions = options;
+          return {
+            close() { return Promise.resolve(); },
+            // The root never becomes watched — the retry must keep repeating
+            // rather than firing once.
+            refreshMissingRoots() { refreshCalls += 1; return false; },
+          };
+        },
+      },
+    }],
+    [INDEXER_URL, { namedExports: { writeHeartbeat() {} } }],
+    [INDEXER_SERVICE_URL, { namedExports: defaultIndexerService() }],
+    [INDEXER_WORKER_URL, { namedExports: defaultIndexerWorkerClient() }],
+  ]);
+
+  try {
+    await importMain();
+    assert.ok(watcherOptions, 'the OBELISK_DIR watcher was created');
+
+    // CONTRIBUTING: a periodic refresh point must be proven to actually fire
+    // repeatedly, not once.
+    watcherOptions.onRootLost('gone');
+    mock.timers.tick(5000);
+    assert.equal(refreshCalls, 1, 'a lost root schedules a retry');
+    mock.timers.tick(5000);
+    assert.equal(refreshCalls, 2, 'the retry repeats while the root stays unwatched');
+    mock.timers.tick(5000);
+    assert.equal(refreshCalls, 3, 'and keeps repeating');
+  } finally {
+    restore();
+    mock.timers.reset();
+    process.env.HOME = originalHome;
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -1416,6 +1416,19 @@ test('the OBELISK_DIR watch retry repeats while the root stays unwatched', async
     static fromWebContents() { return null; }
   }
 
+  // Model the real adapter's contract: refreshMissingRoots re-pends the
+  // missing root and returns true (it is attaching, not watched); the async
+  // probe then fails and reports through onRootLost — that callback, not a
+  // false return, is what drives the next retry in production.
+  const fakeWatcher = {
+    close() { return Promise.resolve(); },
+    refreshMissingRoots() {
+      refreshCalls += 1;
+      watcherOptions.onRootLost('still-gone');
+      return true;
+    },
+  };
+
   mock.timers.enable({ apis: ['setTimeout'] });
   const restore = registerMocks([
     [ELECTRON_URL, { namedExports: electronNamespace({ BrowserWindow: FakeBrowserWindow }) }],
@@ -1424,12 +1437,7 @@ test('the OBELISK_DIR watch retry repeats while the root stays unwatched', async
       namedExports: {
         createRecursiveWatcher: (options) => {
           watcherOptions = options;
-          return {
-            close() { return Promise.resolve(); },
-            // The root never becomes watched — the retry must keep repeating
-            // rather than firing once.
-            refreshMissingRoots() { refreshCalls += 1; return false; },
-          };
+          return fakeWatcher;
         },
       },
     }],
@@ -1443,7 +1451,8 @@ test('the OBELISK_DIR watch retry repeats while the root stays unwatched', async
     assert.ok(watcherOptions, 'the OBELISK_DIR watcher was created');
 
     // CONTRIBUTING: a periodic refresh point must be proven to actually fire
-    // repeatedly, not once.
+    // repeatedly, not once. The chain under test is the real one:
+    // onRootLost → retry timer → refresh → probe fails → onRootLost → …
     watcherOptions.onRootLost('gone');
     mock.timers.tick(5000);
     assert.equal(refreshCalls, 1, 'a lost root schedules a retry');

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -40,8 +40,8 @@ class SqliteCompatDatabase {
 // `mock.module` keys mocks by the *resolved* module URL. The app's dependencies
 // live in `app/node_modules`, so they are NOT resolvable from this test file's
 // directory, and bare specifiers ('electron', ...) would either fail to resolve
-// here or resolve to the wrong ESM entry (e.g. chokidar exposes esm/index.js via
-// its "exports" map, which differs from require.resolve's CJS entry). We instead
+// here or resolve to a different entry than the main module sees (a package's
+// "exports" map can give ESM and CJS importers different files). We instead
 // resolve each bare specifier exactly as the main module sees it (ESM resolution
 // relative to the main module's directory) and mock that URL. Relative deps are
 // resolved against the main module URL directly.
@@ -59,7 +59,7 @@ function esmResolve(specifier) {
 
 const ELECTRON_URL = esmResolve('electron');
 const DATABASE_URL = esmResolve('better-sqlite3');
-const CHOKIDAR_URL = esmResolve('chokidar');
+const WATCHER_URL = new URL('./watcher.ts', mainUrl).href;
 const INDEXER_URL = new URL('./indexer.ts', mainUrl).href;
 const INDEXER_SERVICE_URL = new URL('./indexer-service.ts', mainUrl).href;
 const INDEXER_WORKER_URL = new URL('./indexer-worker-client.ts', mainUrl).href;
@@ -96,8 +96,13 @@ function electronNamespace({ app, BrowserWindow, ipcMain }) {
   };
 }
 
-function noopChokidar() {
-  return { watch: () => ({ on() { return this; }, close() {} }) };
+function noopWatcher() {
+  return {
+    createRecursiveWatcher: () => ({
+      close() { return Promise.resolve(); },
+      refreshMissingRoots() { return true; },
+    }),
+  };
 }
 
 function defaultIndexerService() {
@@ -169,7 +174,7 @@ async function loadMainForWindowFlags(flags, { settingsText } = {}) {
   const restore = registerMocks([
     [ELECTRON_URL, { namedExports: electronNamespace({ BrowserWindow: FakeBrowserWindow }) }],
     [DATABASE_URL, { defaultExport: FakeDatabase }],
-    [CHOKIDAR_URL, { defaultExport: noopChokidar() }],
+    [WATCHER_URL, { namedExports: noopWatcher() }],
     [INDEXER_URL, { namedExports: { writeHeartbeat() {} } }],
     [INDEXER_SERVICE_URL, { namedExports: defaultIndexerService() }],
     [INDEXER_WORKER_URL, { namedExports: defaultIndexerWorkerClient() }],
@@ -248,7 +253,7 @@ test('main process watches every root declared by the built-in provider registry
   const restore = registerMocks([
     [ELECTRON_URL, { namedExports: electronNamespace({ BrowserWindow: FakeBrowserWindow }) }],
     [DATABASE_URL, { defaultExport: FakeDatabase }],
-    [CHOKIDAR_URL, { defaultExport: noopChokidar() }],
+    [WATCHER_URL, { namedExports: noopWatcher() }],
     [INDEXER_URL, { namedExports: { writeHeartbeat() {} } }],
     [INDEXER_SERVICE_URL, {
       namedExports: {
@@ -345,7 +350,7 @@ test('main process forwards committed IDs without reopening after a deferred bui
   const restore = registerMocks([
     [ELECTRON_URL, { namedExports: electronNamespace({ BrowserWindow: FakeBrowserWindow }) }],
     [DATABASE_URL, { defaultExport: FakeDatabase }],
-    [CHOKIDAR_URL, { defaultExport: noopChokidar() }],
+    [WATCHER_URL, { namedExports: noopWatcher() }],
     [INDEXER_URL, { namedExports: { writeHeartbeat() {} } }],
     [INDEXER_SERVICE_URL, {
       namedExports: {
@@ -467,7 +472,7 @@ test('session IPC hides Codex rows by default and supports explicit source opt-i
       }),
     }],
     [DATABASE_URL, { defaultExport: FakeDatabase }],
-    [CHOKIDAR_URL, { defaultExport: noopChokidar() }],
+    [WATCHER_URL, { namedExports: noopWatcher() }],
     [INDEXER_URL, { namedExports: { writeHeartbeat() {} } }],
     [INDEXER_SERVICE_URL, { namedExports: defaultIndexerService() }],
     [INDEXER_WORKER_URL, { namedExports: defaultIndexerWorkerClient() }],
@@ -583,7 +588,7 @@ test('usage IPC aggregates normalized tokens across all indexed providers', asyn
       }),
     }],
     [DATABASE_URL, { defaultExport: SqliteCompatDatabase }],
-    [CHOKIDAR_URL, { defaultExport: noopChokidar() }],
+    [WATCHER_URL, { namedExports: noopWatcher() }],
     [INDEXER_URL, { namedExports: { writeHeartbeat() {} } }],
     [INDEXER_SERVICE_URL, { namedExports: defaultIndexerService() }],
     [INDEXER_WORKER_URL, { namedExports: defaultIndexerWorkerClient() }],
@@ -679,7 +684,7 @@ test('main process migrates an existing app database before source-filtered IPC 
       }),
     }],
     [DATABASE_URL, { defaultExport: SqliteCompatDatabase }],
-    [CHOKIDAR_URL, { defaultExport: noopChokidar() }],
+    [WATCHER_URL, { namedExports: noopWatcher() }],
     [INDEXER_URL, { namedExports: { writeHeartbeat() {} } }],
     [INDEXER_SERVICE_URL, { namedExports: defaultIndexerService() }],
     [INDEXER_WORKER_URL, { namedExports: defaultIndexerWorkerClient() }],
@@ -743,7 +748,7 @@ test('main process keeps schema and memory mutations behind the writer lease', a
       }),
     }],
     [DATABASE_URL, { defaultExport: SqliteCompatDatabase }],
-    [CHOKIDAR_URL, { defaultExport: noopChokidar() }],
+    [WATCHER_URL, { namedExports: noopWatcher() }],
     [INDEXER_URL, { namedExports: { writeHeartbeat() {} } }],
     [INDEXER_SERVICE_URL, { namedExports: defaultIndexerService() }],
     [INDEXER_WORKER_URL, { namedExports: defaultIndexerWorkerClient() }],
@@ -816,10 +821,13 @@ test('closing the last macOS window releases background resources until activati
       }),
     }],
     [DATABASE_URL, { defaultExport: FakeDatabase }],
-    [CHOKIDAR_URL, {
-      defaultExport: {
-        watch: () => {
-          const watcher = { on() { return this; }, close() { serviceEvents.push('watcher-close'); } };
+    [WATCHER_URL, {
+      namedExports: {
+        createRecursiveWatcher: () => {
+          const watcher = {
+            close() { serviceEvents.push('watcher-close'); return Promise.resolve(); },
+            refreshMissingRoots() { return true; },
+          };
           watchers.push(watcher);
           return watcher;
         },
@@ -949,7 +957,7 @@ test('settings rebuild reopens the database from the configured Claude path', as
       }),
     }],
     [DATABASE_URL, { defaultExport: FakeDatabase }],
-    [CHOKIDAR_URL, { defaultExport: noopChokidar() }],
+    [WATCHER_URL, { namedExports: noopWatcher() }],
     [INDEXER_URL, { namedExports: { writeHeartbeat() {} } }],
     [INDEXER_SERVICE_URL, {
       namedExports: {
@@ -1116,7 +1124,7 @@ test('settings rebuild keeps the existing database after a worker failure', asyn
       }),
     }],
     [DATABASE_URL, { defaultExport: FakeDatabase }],
-    [CHOKIDAR_URL, { defaultExport: noopChokidar() }],
+    [WATCHER_URL, { namedExports: noopWatcher() }],
     [INDEXER_URL, { namedExports: { writeHeartbeat() {} } }],
     [INDEXER_SERVICE_URL, {
       namedExports: {
@@ -1220,7 +1228,7 @@ test('settings rebuild cancels an in-flight background build instead of waiting 
       }),
     }],
     [DATABASE_URL, { defaultExport: FakeDatabase }],
-    [CHOKIDAR_URL, { defaultExport: noopChokidar() }],
+    [WATCHER_URL, { namedExports: noopWatcher() }],
     [INDEXER_URL, { namedExports: { writeHeartbeat() {} } }],
     [INDEXER_SERVICE_URL, {
       namedExports: {
@@ -1315,7 +1323,7 @@ test('settings changes during rebuild keep one watcher and re-enable with a catc
       }),
     }],
     [DATABASE_URL, { defaultExport: FakeDatabase }],
-    [CHOKIDAR_URL, { defaultExport: noopChokidar() }],
+    [WATCHER_URL, { namedExports: noopWatcher() }],
     [INDEXER_URL, { namedExports: { writeHeartbeat() {} } }],
     [INDEXER_SERVICE_URL, {
       namedExports: {


### PR DESCRIPTION
Refs #79. Alternative to #80: instead of dropping chokidar for bare `fs.watch(root, { recursive: true })`, move the default watcher to [@parcel/watcher](https://github.com/parcel-bundler/watcher) and add the recovery/reconciliation layers that make watcher reliability non-load-bearing.

## Problem (from #79, confirmed)

chokidar 4 dropped fsevents, so on macOS it watches every path individually: one `O_EVTONLY` fd per file plus one FSEventStream per directory. On a ~23k-path transcript tree this floods `EMFILE` (a per-process FSEvents/mach ceiling, not rlimit) and leaves ~20% of files unwatched.

## Why not bare `fs.watch` (i.e. why not #80 as-is)

- A watcher that errors asynchronously is never re-attached — the root stays in `watchedRoots`, and `refreshMissingRoots` only covers roots that failed at creation time.
- The watcher is the sole source of change events; silently dropped events (FSEvents overflow, Windows buffer overflow) mean a permanently stale index.
- Linux `recursive` is emulated in Node core (per-directory inotify wired up in JS) with a documented race window for files created in a directory before its watch is installed.

## Change

The event contract between watcher and service is unchanged (`onChange(absolutePath | undefined)` → `scheduleBuild`), so `buildIndex`, debounce/stability, and the retry machinery are untouched.

**1. New `app/src/main/watcher.ts` — thin adapter over `@parcel/watcher`**
- One `subscribe(root, callback)` per root: native recursive backend per platform (FSEvents / inotify / ReadDirectoryChangesW), O(1) descriptors on macOS — the resource fix from #80 without hand-rolling the Linux emulation.
- Extension filter (`.jsonl`/`.json`) in the callback; events already arrive as absolute paths with `create/update/delete` types.
- All filesystem probes are async (`fs.promises.access`) — no synchronous IO in the main process (CONTRIBUTING.md). The probe classifies `ENOENT`/`ENOTDIR` as "not there yet" — a normal steady state (e.g. no `~/.codex`) that stays quiet and only drives the retry loop; anything else (`EACCES`, `EIO`, `ENAMETOOLONG`, …) is a genuine problem and warned — once per (root, failure), so a permanent misconfiguration does not spam on every retry tick, and cleared on establishment so a later recurrence reports again.
- `onChange` fires exactly when coverage increases (a subscription establishes), with the initial establishment pass kept quiet because the startup build already covers it — a permanently missing root never triggers spurious full-inventory builds.
- On subscription error (creation rejection or async stream error): log, unsubscribe, drop the root from the watched set, and report through `onRootLost` — a dead stream never lingers as "watched". A subscription that errors *while still establishing* is unsubscribed as soon as its promise settles rather than leaking.

**2. `indexer-service.ts` — two small changes**
- Default `watchProjects` delegates to the adapter; the test injection point is now a `subscribe` function (same signature as `@parcel/watcher.subscribe`). `onRootLost` is wired to the existing `scheduleWatchRetry` loop, which already owns late-appearing-root pickup.
- New `reconcileMs` interval (default 5 min, 0 disables) scheduling a full-inventory build via the existing `requestFullInventory` path — bounds worst-case staleness from any silently missed event to one interval.

**3. `index.ts` — one watcher library for the whole app**
- The shallow `OBELISK_DIR` watch moves to the same adapter: a true trailing 300 ms debounce (reset per event, so an actively written file notifies only after its writes settle) replaces chokidar's `awaitWriteFinish`; `onRootLost` drives a self-rescheduling retry identical in shape to the service's. The startup `existsSync`/`mkdirSync` is replaced by an idempotent fire-and-forget `fs.promises.mkdir` — the adapter tolerates the directory appearing late, so no ordering dependency. chokidar is removed from dependencies.

**4. Packaging**
- `app/package.json`: drop `chokidar`, add `@parcel/watcher`; `build.asarUnpack` gains `node_modules/@parcel/watcher/**` (precedent: `better-sqlite3`; N-API prebuilds need no electron-rebuild). `electron.vite.config.ts` adds `watcher` as a main-process rollup input per the one-module-one-input convention.
- Stale chokidar mention in `packages/core/src/core.ts` updated.

**Explicitly out of scope**: `writeSnapshot()`/`getEventsSince()` persistence (periodic full inventory covers its purpose), watchman backend configuration, and any `packages/cli` / `packages/core` behavior change (they have no watcher code).

## Existing-assertion changes (own section per the contributing guide)

- The four `app-indexer-service.test.mjs` tests that injected a `chokidar` mock now inject `subscribe` (same shape as `@parcel/watcher.subscribe`). Assertions on chokidar-specific options (`cwd`/`ignoreInitial`/`awaitWriteFinish`) are gone — those options no longer exist; the behaviors the tests pin (multi-root fan-out, late-appearing-root pickup, changed-path resolution, close-on-stop) are asserted unchanged. Because the adapter probes root existence asynchronously before subscribing, these tests poll for subscription state with a deadline instead of asserting it synchronously after `start()`.
- `app-main-settings.test.mjs` mocked the `chokidar` module URL for `index.ts`; it now mocks `./watcher.ts` (`createRecursiveWatcher`) the same way, including the watcher-close lifecycle assertion.
- One test needed a genuine fix, not just a re-pin: the deep-file assertion compares reported paths against the watched root, and @parcel/watcher reports real paths — on macOS the temp dir's `/var/...` symlink resolves to `/private/var/...`. The assertion accepts the realpath.

## Verification

- New `tests/app-indexer-watcher.test.mjs` exercises the real watcher: deep new-directory `.jsonl` reaches `buildIndex` as an absolute path, non-transcript files are filtered — plus injected-subscription tests for error → retry re-attach, reconcile → full-inventory build, quiet retries for missing roots, and warn-once-per-failure with re-report after recovery.
- New `app-main-settings.test.mjs` case proves the `OBELISK_DIR` retry loop actually fires repeatedly (mocked timers) while the root stays unwatched — per the CONTRIBUTING rule that a periodic refresh point must be proven to repeat. The mock models the real adapter contract (`refreshMissingRoots` re-pends and returns true; the async probe failure re-fires `onRootLost`), so the test exercises the production callback-driven retry chain, not the `=== false` fallback branch.
- `npm test`: 469/469 pass on the final head (includes the full pre-existing suite).
- `npm run typecheck`: clean. `eslint` on touched files: 0 errors.
- `electron-vite build`: `out/main/watcher.js` emitted with `@parcel/watcher` externalized.
