### PR TITLE
feat(watcher): bounded hot-transcript polling overlay with watchHints seeding (ADR-0009, part 2)

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Verify adaptive watcher package
         run: |
           npm run build --workspace @obelisk-apps/adaptive-watcher
-          node --experimental-strip-types --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs
+          node --experimental-strip-types --experimental-sqlite --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs
 
       - name: Verify POSIX bootstrap installer
         if: runner.os != 'Windows'

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Verify adaptive watcher package
         run: |
           npm run build --workspace @obelisk-apps/adaptive-watcher
-          node --experimental-strip-types --test tests/adaptive-watcher.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs
+          node --experimental-strip-types --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs
 
       - name: Verify POSIX bootstrap installer
         if: runner.os != 'Windows'

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Verify adaptive watcher package
         run: |
           npm run build --workspace @obelisk-apps/adaptive-watcher
-          node --experimental-strip-types --experimental-sqlite --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs
+          node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs tests/app-main-settings.test.mjs
 
       - name: Verify POSIX bootstrap installer
         if: runner.os != 'Windows'

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Verify adaptive watcher package
         run: |
           npm run build --workspace @obelisk-apps/adaptive-watcher
-          node --experimental-strip-types --test tests/adaptive-watcher.test.mjs
+          node --experimental-strip-types --test tests/adaptive-watcher.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs
 
       - name: Verify POSIX bootstrap installer
         if: runner.os != 'Windows'

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1076,6 +1076,7 @@ ipcMain.handle('settings:rebuildIndex', async () => {
   }
   cleanupDbFiles(tempDbPath);
   let writerLease: ReturnType<typeof acquireWriterLease> = null;
+  let rebuildWatchHints: string[] = [];
   try {
     const writerLeasePath = writerLockPathFor(paths.dbPath);
     writerLease = acquireWriterLease({
@@ -1112,6 +1113,7 @@ ipcMain.handle('settings:rebuildIndex', async () => {
       writerLeasePath,
       writerLeaseMode: 'caller-held',
     });
+    rebuildWatchHints = result?.watchHints ?? [];
     if (result?.deferred || result?.complete !== true) {
       notifyIndexUpdated(result);
       return result;
@@ -1136,7 +1138,11 @@ ipcMain.handle('settings:rebuildIndex', async () => {
     } finally {
       writerLease?.release();
       if (loadPersistedSettings().autoRefresh !== false) {
-        startIndexerService({ buildOnStart: false });
+        const service = startIndexerService({ buildOnStart: false });
+        // The rebuild bypassed the service's own build path, so seed the hot
+        // set from its hints here — otherwise already-open transcripts would
+        // wait for the next reconcile to be re-seeded.
+        service?.promoteWatchHints?.(rebuildWatchHints);
       }
     }
   }

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1139,10 +1139,17 @@ ipcMain.handle('settings:rebuildIndex', async () => {
       writerLease?.release();
       if (loadPersistedSettings().autoRefresh !== false) {
         const service = startIndexerService({ buildOnStart: false });
-        // The rebuild bypassed the service's own build path, so seed the hot
-        // set from its hints here — otherwise already-open transcripts would
-        // wait for the next reconcile to be re-seeded.
-        service?.promoteWatchHints?.(rebuildWatchHints);
+        if (rebuildWatchHints.length) {
+          // The rebuild bypassed the service's own build path, so seed the
+          // hot set from its hints here.
+          service?.promoteWatchHints?.(rebuildWatchHints);
+        } else {
+          // A failed/deferred rebuild produced no hints and the old hot set
+          // died with the old watcher. Run one reconciling build through the
+          // service — its deferral retry absorbs writer-busy — so long-open
+          // transcripts are re-seeded now, not at the next 5-min reconcile.
+          service?.runBuildNow('reconcile');
+        }
       }
     }
   }

--- a/app/src/main/indexer-service.ts
+++ b/app/src/main/indexer-service.ts
@@ -29,12 +29,16 @@ interface Timers {
 
 interface Watcher {
   close(): unknown;
+  promote?(path: string): void;
   refreshMissingRoots?(): boolean;
 }
 
 interface IndexerBuildResult {
   deferred?: boolean;
   complete?: boolean;
+  /** Recently written transcripts, most recent first — seeded into the
+   * watcher's hot set (ADR-0009). */
+  watchHints?: string[];
   inventoryIssues?: Array<{
     provider: string;
     path: string;
@@ -64,6 +68,10 @@ interface IndexerServiceOptions {
   watchProjects?: (onChange: (changedPath?: string) => void) => Watcher | null;
   /** Injection point for the default watcher's @parcel/watcher subscribe (tests). */
   subscribe?: ParcelSubscribe;
+  /** Hot-overlay gate passthrough (tests); defaults to macOS-only. */
+  hotPolling?: boolean;
+  /** Poll interval passthrough for the watcher's file poller (tests). */
+  watchPollMs?: number;
   timers?: Timers;
   logger?: { warn?: (msg: string) => void };
 }
@@ -81,6 +89,8 @@ function createIndexerService({
   writeHeartbeat = () => {},
   watchProjects,
   subscribe,
+  hotPolling,
+  watchPollMs,
   timers = {
     setTimeout,
     clearTimeout,
@@ -99,6 +109,11 @@ function createIndexerService({
       logger,
       timers,
       retryDelayMs: watchRetryMs,
+      hotPolling,
+      pollIntervalMs: watchPollMs,
+      // The caller knows its transcripts; the package does not. Native events
+      // for transcripts promote the path into the hot set before delivery.
+      shouldPromote: (targetPath) => targetPath.endsWith('.jsonl') || targetPath.endsWith('.json'),
       onInvalidate: (invalidation) => {
         // A rescan means anything under the root may have changed — full
         // inventory. Path invalidations filter to transcripts here, at the
@@ -177,6 +192,9 @@ function createIndexerService({
     const buildChangedPaths = takeChangedPaths();
     idlePromise = (async () => {
       const result = await buildIndex({ reason, changedPaths: buildChangedPaths });
+      // Seed the watcher's hot set with the transcripts the build just saw
+      // as recently active (ADR-0009 hot-set closure, startup/reconcile leg).
+      for (const hint of result?.watchHints ?? []) watcher?.promote?.(hint);
       if (result?.complete === false) {
         for (const issue of result.inventoryIssues ?? []) {
           logger.warn?.(

--- a/app/src/main/indexer-service.ts
+++ b/app/src/main/indexer-service.ts
@@ -194,7 +194,11 @@ function createIndexerService({
       const result = await buildIndex({ reason, changedPaths: buildChangedPaths });
       // Seed the watcher's hot set with the transcripts the build just saw
       // as recently active (ADR-0009 hot-set closure, startup/reconcile leg).
-      for (const hint of result?.watchHints ?? []) watcher?.promote?.(hint);
+      // Hints arrive newest-first; promote oldest-first so the Map's
+      // insertion order leaves the NEWEST hint as the most-recently-used —
+      // otherwise the next promotion would evict the freshest transcript.
+      const hints = result?.watchHints ?? [];
+      for (const hint of [...hints].reverse()) watcher?.promote?.(hint);
       if (result?.complete === false) {
         for (const issue of result.inventoryIssues ?? []) {
           logger.warn?.(

--- a/app/src/main/indexer-service.ts
+++ b/app/src/main/indexer-service.ts
@@ -180,6 +180,15 @@ function createIndexerService({
     }
   };
 
+  const promoteWatchHints = (hints: string[] | undefined) => {
+    // Seed the watcher's hot set with the transcripts a build just saw as
+    // recently active (ADR-0009 hot-set closure, startup/reconcile leg).
+    // Hints arrive newest-first; promote oldest-first so the Map's insertion
+    // order leaves the NEWEST hint as the most-recently-used — otherwise the
+    // next promotion would evict the freshest transcript.
+    for (const hint of [...(hints ?? [])].reverse()) watcher?.promote?.(hint);
+  };
+
   const runBuildNow = (reason = "manual", paths: string[] | undefined = undefined) => {
     addChangedPath(paths);
     if (stopped) return idlePromise;
@@ -192,13 +201,7 @@ function createIndexerService({
     const buildChangedPaths = takeChangedPaths();
     idlePromise = (async () => {
       const result = await buildIndex({ reason, changedPaths: buildChangedPaths });
-      // Seed the watcher's hot set with the transcripts the build just saw
-      // as recently active (ADR-0009 hot-set closure, startup/reconcile leg).
-      // Hints arrive newest-first; promote oldest-first so the Map's
-      // insertion order leaves the NEWEST hint as the most-recently-used —
-      // otherwise the next promotion would evict the freshest transcript.
-      const hints = result?.watchHints ?? [];
-      for (const hint of [...hints].reverse()) watcher?.promote?.(hint);
+      promoteWatchHints(result?.watchHints);
       if (result?.complete === false) {
         for (const issue of result.inventoryIssues ?? []) {
           logger.warn?.(
@@ -337,6 +340,7 @@ function createIndexerService({
     stop,
     scheduleBuild,
     runBuildNow,
+    promoteWatchHints,
     idle: () => idlePromise,
   };
 }

--- a/app/src/main/indexer.ts
+++ b/app/src/main/indexer.ts
@@ -503,6 +503,7 @@ function buildIndex({
           complete: true,
           incompleteProviders,
           inventoryIssues,
+          watchHints: readRecentTranscriptHints(db),
         };
       }
 

--- a/app/src/main/indexer.ts
+++ b/app/src/main/indexer.ts
@@ -18,6 +18,7 @@ import {
   indexProviderPlan,
   indexProviderPlanStrict,
   ProviderIndexFailure,
+  readRecentTranscriptHints,
   writeProviderIndexMarkers,
   type ProviderInventoryIssue,
   type ProviderSessionProvenance,
@@ -265,6 +266,8 @@ interface BuildIndexResult {
   complete: boolean;
   incompleteProviders: string[];
   inventoryIssues: ProviderInventoryIssue[];
+  /** Most recently written transcripts (ADR-0009 hot-set seeding). */
+  watchHints?: string[];
   reason?: string;
 }
 
@@ -561,6 +564,7 @@ function buildIndex({
         complete: providerResult.complete,
         incompleteProviders,
         inventoryIssues,
+        watchHints: readRecentTranscriptHints(db),
       };
     } finally {
       if (messageFtsTriggersDropped) {

--- a/packages/adaptive-watcher/src/index.ts
+++ b/packages/adaptive-watcher/src/index.ts
@@ -13,6 +13,10 @@
 //   mis-cover them. Exact files are also the only way to reliably observe a
 //   writer that appends through a long-lived file descriptor: FSEvents
 //   delivers no event for such appends until the descriptor closes.
+// - A bounded LRU hot set extends the poller to recently active transcripts
+//   (promoted from native events via `shouldPromote`, seeded by
+//   `initialHotFiles` or `promote()` from caller build hints). macOS only by
+//   default; eviction degrades to the caller's periodic reconcile.
 // - Reliability lives inside the package: async existence probes, error
 //   classification (ENOENT/ENOTDIR is a quiet steady state, everything else
 //   warns once per root-and-failure), and a self-rescheduling retry loop.
@@ -34,6 +38,10 @@ export type WatchInvalidation =
   | { type: 'rescan'; roots: string[]; reason: string };
 
 export interface AdaptiveWatcher {
+  /** Move a path into the bounded hot set (LRU-refreshed if already hot).
+   * No-op when the hot overlay is disabled, the path is a pinned `file`
+   * target, or the watcher is closed. */
+  promote(path: string): void;
   close(): Promise<unknown>;
 }
 
@@ -58,6 +66,23 @@ export interface AdaptiveWatcherOptions {
   pollIntervalMs?: number;
   /** Delay before re-probing a missing or lost tree root. Default 5000 ms. */
   retryDelayMs?: number;
+  /**
+   * Enable the bounded hot-file overlay: promoted paths are polled like
+   * pinned `file` targets. Closes the macOS gap where FSEvents delivers no
+   * event for appends through a long-lived descriptor. Defaults to
+   * `process.platform === 'darwin'` (ADR-0009 platform policy: macOS first,
+   * other platforms only after their long-lived-writer matrix proves a need).
+   */
+  hotPolling?: boolean;
+  /** Hard cap on hot (non-pinned) polled files. Default 64. */
+  maxHotFiles?: number;
+  /** Seeds the hot set at creation — covers transcripts already open before
+   * the watcher started. */
+  initialHotFiles?: string[];
+  /** Decides whether a native tree event path enters the hot set (the
+   * package has no domain knowledge — the caller knows its transcripts).
+   * Promotion happens before the path invalidation is delivered. */
+  shouldPromote?: (path: string) => boolean;
   /** Injection point for @parcel/watcher.subscribe (tests). */
   subscribe?: ParcelSubscribe;
   /** Injection point for the root existence probe (tests). */
@@ -70,6 +95,7 @@ export interface AdaptiveWatcherOptions {
 
 const DEFAULT_POLL_INTERVAL_MS = 1000;
 const DEFAULT_RETRY_DELAY_MS = 5000;
+const DEFAULT_MAX_HOT_FILES = 64;
 
 function errorCode(error: unknown): string | undefined {
   return (error as NodeJS.ErrnoException)?.code;
@@ -84,6 +110,10 @@ export function createAdaptiveWatcher({
   onInvalidate,
   pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
   retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+  hotPolling,
+  maxHotFiles = DEFAULT_MAX_HOT_FILES,
+  initialHotFiles = [],
+  shouldPromote,
   subscribe = parcelWatcher.subscribe as ParcelSubscribe,
   access = fs.promises.access,
   stat = fs.promises.stat,
@@ -97,6 +127,10 @@ export function createAdaptiveWatcher({
   // A file covered by a tree target stays in the poller: polling is not
   // there to extend directory coverage but to close the update-latency gap.
   const fileTargets = [...new Set(targets.filter((t) => t.kind === 'file').map((t) => t.path))];
+  const pinnedFiles = new Set(fileTargets);
+  const hotEnabled = hotPolling ?? process.platform === 'darwin';
+  // Insertion-ordered LRU of hot (non-pinned) polled paths. Values unused.
+  const hotFiles = new Map<string, null>();
 
   let closed = false;
 
@@ -161,7 +195,16 @@ export function createAdaptiveWatcher({
           return;
         }
         const paths = (events ?? []).map((event) => event?.path).filter(Boolean);
-        if (paths.length) onInvalidate({ type: 'paths', paths });
+        if (paths.length) {
+          // Promotion precedes delivery: the caller's catch-up build reads
+          // content written before promotion, polling covers later appends.
+          if (hotEnabled && shouldPromote) {
+            for (const eventPath of paths) {
+              if (shouldPromote(eventPath)) promote(eventPath);
+            }
+          }
+          onInvalidate({ type: 'paths', paths });
+        }
       });
     } catch (error) {
       pending.delete(root);
@@ -253,18 +296,31 @@ export function createAdaptiveWatcher({
     polling = true;
     try {
       const changed: string[] = [];
-      for (const file of fileTargets) {
+      // Pinned first (never evicted), then hot files in LRU order.
+      const observed: Array<readonly [string, boolean]> = [
+        ...fileTargets.map((file) => [file, false] as const),
+        ...[...hotFiles.keys()].map((file) => [file, true] as const),
+      ];
+      for (const [file, isHot] of observed) {
         const prev = baselines.get(file);
         const next = await statFile(file);
         if (prev === undefined) {
           baselines.set(file, next);
-          if (next !== null) changed.push(file);
+          // Pinned: first observation of an existing file IS an appearance —
+          // a redundant incremental build beats a missed event. Hot: silent
+          // baseline, because promotion always follows a signal (a native
+          // event or a build hint) that already delivered the change.
+          if (!isHot && next !== null) changed.push(file);
           continue;
         }
         if (signatureChanged(prev ?? null, next)) {
           baselines.set(file, next);
           if (next !== null) lastWarned.delete(file);
           changed.push(file);
+          if (isHot) {
+            hotFiles.delete(file);
+            hotFiles.set(file, null);
+          }
         }
       }
       if (changed.length && !closed) onInvalidate({ type: 'paths', paths: changed });
@@ -274,15 +330,35 @@ export function createAdaptiveWatcher({
     }
   };
 
+  const promote = (path: string) => {
+    if (!hotEnabled || closed || pinnedFiles.has(path)) return;
+    if (hotFiles.has(path)) {
+      // LRU refresh; the baseline survives.
+      hotFiles.delete(path);
+      hotFiles.set(path, null);
+      return;
+    }
+    while (hotFiles.size >= maxHotFiles) {
+      const oldest = hotFiles.keys().next().value;
+      if (oldest === undefined) break;
+      hotFiles.delete(oldest);
+      baselines.delete(oldest);
+    }
+    hotFiles.set(path, null);
+    baselines.set(path, undefined);
+  };
+
   // ------------------------------------------------------------- lifecycle
 
   refreshTrees();
-  if (fileTargets.length) {
+  for (const file of initialHotFiles) promote(file);
+  if (fileTargets.length || hotEnabled) {
     for (const file of fileTargets) baselines.set(file, undefined);
     pollTimer = timers.setTimeout(pollTick, pollIntervalMs);
   }
 
   return {
+    promote,
     close() {
       closed = true;
       if (retryTimer !== null) timers.clearTimeout(retryTimer);

--- a/packages/adaptive-watcher/src/index.ts
+++ b/packages/adaptive-watcher/src/index.ts
@@ -50,7 +50,17 @@ export type ParcelSubscribe = (
   callback: (err: Error | null, events: Array<{ type: string; path: string }>) => void,
 ) => Promise<{ unsubscribe(): Promise<void> }>;
 
-export type FileSignature = { dev: number; ino: number; size: number; mtimeMs: number };
+export type FileSignature = { dev: number; ino: number; size: number; mtimeMs: number; isDirectory?: boolean };
+
+/** Real fs.Stats exposes isDirectory() as a method; test fakes may use a
+ * plain boolean. Both are accepted. */
+export type StatProbeResult = {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+  isDirectory?: boolean | (() => boolean);
+};
 
 export interface AdaptiveWatcherTimers {
   // `any` handles: whatever the injected setTimeout returns is only ever
@@ -88,7 +98,7 @@ export interface AdaptiveWatcherOptions {
   /** Injection point for the root existence probe (tests). */
   access?: (path: string) => Promise<unknown>;
   /** Injection point for the file metadata probe (tests). */
-  stat?: (path: string) => Promise<FileSignature>;
+  stat?: (path: string) => Promise<StatProbeResult>;
   timers?: AdaptiveWatcherTimers;
   logger?: { warn?: (msg: string) => void };
 }
@@ -131,6 +141,10 @@ export function createAdaptiveWatcher({
   const hotEnabled = hotPolling ?? process.platform === 'darwin';
   // Insertion-ordered LRU of hot (non-pinned) polled paths. Values unused.
   const hotFiles = new Map<string, null>();
+  // Hot paths promoted by a native event baseline silently on first
+  // observation — the event itself already delivered the change. Hint-seeded
+  // paths (public promote) must report their first observation instead.
+  const silentFirstBaseline = new Set<string>();
 
   let closed = false;
 
@@ -198,9 +212,13 @@ export function createAdaptiveWatcher({
         if (paths.length) {
           // Promotion precedes delivery: the caller's catch-up build reads
           // content written before promotion, polling covers later appends.
+          // Deletes never promote — a removed transcript would hold a hot
+          // slot while permanently missing and evict live files.
           if (hotEnabled && shouldPromote) {
-            for (const eventPath of paths) {
-              if (shouldPromote(eventPath)) promote(eventPath);
+            for (const event of events ?? []) {
+              if (event?.path && event.type !== 'delete' && shouldPromote(event.path)) {
+                promoteHot(event.path, { silent: true });
+              }
             }
           }
           onInvalidate({ type: 'paths', paths });
@@ -276,7 +294,15 @@ export function createAdaptiveWatcher({
   const statFile = async (file: string): Promise<FileSignature | null> => {
     try {
       const stats = await stat(file);
-      return { dev: stats.dev, ino: stats.ino, size: stats.size, mtimeMs: stats.mtimeMs };
+      return {
+        dev: stats.dev,
+        ino: stats.ino,
+        size: stats.size,
+        mtimeMs: stats.mtimeMs,
+        isDirectory: typeof stats.isDirectory === 'function'
+          ? stats.isDirectory()
+          : stats.isDirectory === true,
+      };
     } catch (error) {
       const code = errorCode(error);
       if (code === 'ENOENT' || code === 'ENOTDIR') return null;
@@ -304,13 +330,27 @@ export function createAdaptiveWatcher({
       for (const [file, isHot] of observed) {
         const prev = baselines.get(file);
         const next = await statFile(file);
+        // Evicted while its stat was in flight: stay evicted — do not
+        // re-insert a baseline or report (the hard cap must hold).
+        if (isHot && !hotFiles.has(file)) continue;
+        // Unit keys are not always files (Kimi's key is the session
+        // directory); polling a directory cannot see appends to the wire
+        // file inside it, and the tree watch already covers it.
+        if (isHot && next !== null && next.isDirectory) {
+          hotFiles.delete(file);
+          baselines.delete(file);
+          silentFirstBaseline.delete(file);
+          continue;
+        }
         if (prev === undefined) {
           baselines.set(file, next);
-          // Pinned: first observation of an existing file IS an appearance —
-          // a redundant incremental build beats a missed event. Hot: silent
-          // baseline, because promotion always follows a signal (a native
-          // event or a build hint) that already delivered the change.
-          if (!isHot && next !== null) changed.push(file);
+          // Pinned targets and hint-promoted hot files report their first
+          // observation of an existing file as an appearance (a redundant
+          // incremental build beats a missed event); event-promoted hot
+          // files baseline silently because the event already delivered
+          // the change.
+          const silent = isHot && silentFirstBaseline.delete(file);
+          if (next !== null && !silent) changed.push(file);
           continue;
         }
         if (signatureChanged(prev ?? null, next)) {
@@ -330,7 +370,7 @@ export function createAdaptiveWatcher({
     }
   };
 
-  const promote = (path: string) => {
+  const promoteHot = (path: string, { silent }: { silent: boolean }) => {
     if (!hotEnabled || closed || pinnedFiles.has(path)) return;
     if (hotFiles.has(path)) {
       // LRU refresh; the baseline survives.
@@ -343,10 +383,18 @@ export function createAdaptiveWatcher({
       if (oldest === undefined) break;
       hotFiles.delete(oldest);
       baselines.delete(oldest);
+      silentFirstBaseline.delete(oldest);
     }
     hotFiles.set(path, null);
     baselines.set(path, undefined);
+    if (silent) silentFirstBaseline.add(path);
   };
+
+  // The build-hint channel: a hint means "the build saw this as recently
+  // active", but appends after the build finished are covered by no
+  // delivered signal — the first observation must report, never baseline
+  // silently.
+  const promote = (path: string) => promoteHot(path, { silent: false });
 
   // ------------------------------------------------------------- lifecycle
 

--- a/packages/adaptive-watcher/src/index.ts
+++ b/packages/adaptive-watcher/src/index.ts
@@ -358,8 +358,18 @@ export function createAdaptiveWatcher({
           if (next !== null) lastWarned.delete(file);
           changed.push(file);
           if (isHot) {
-            hotFiles.delete(file);
-            hotFiles.set(file, null);
+            if (next === null) {
+              // A hot file that disappeared reports once and releases its
+              // slot — recreation is a directory-level event and will
+              // re-promote it; otherwise deleted transcripts would fill the
+              // hot set over the app's lifetime.
+              hotFiles.delete(file);
+              baselines.delete(file);
+              silentFirstBaseline.delete(file);
+            } else {
+              hotFiles.delete(file);
+              hotFiles.set(file, null);
+            }
           }
         }
       }

--- a/packages/core/src/indexer.ts
+++ b/packages/core/src/indexer.ts
@@ -30,6 +30,19 @@ interface SkippedFile {
   diagnostics?: unknown;
 }
 
+// Hot-file seeding for the adaptive watcher (ADR-0009): after a build, the
+// most recently written transcripts are the best guess for what is still
+// being appended through long-lived descriptors. index_state.mtime holds the
+// source file mtime per unit; marker rows carry `__` prefixes and are not
+// transcripts. Cheap because the build already persisted every cursor.
+const WATCH_HINT_LIMIT = 64;
+
+function readWatchHints(db: SqliteDb): string[] {
+  return db.prepare(
+    "SELECT jsonl_path FROM index_state WHERE jsonl_path NOT LIKE '\\_\\_%' ESCAPE '\\' ORDER BY mtime DESC LIMIT ?",
+  ).all(WATCH_HINT_LIMIT).map((row: SqliteRow) => String(row.jsonl_path));
+}
+
 interface BuildCheckOptions {
   now?: number;
   ignoreRecentBuild?: boolean;
@@ -287,6 +300,7 @@ function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwne
           inventoryIssues,
           skipped: 0,
           skippedFiles,
+          watchHints: readWatchHints(db),
         };
       }
 
@@ -352,6 +366,7 @@ function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwne
         inventoryIssues,
         skipped: skippedFiles.length,
         skippedFiles,
+        watchHints: readWatchHints(db),
       };
     } finally {
       db.close();

--- a/packages/core/src/indexer.ts
+++ b/packages/core/src/indexer.ts
@@ -10,6 +10,7 @@ import {
   indexProviderPlan,
   indexProviderPlanStrict,
   ProviderIndexFailure,
+  readRecentTranscriptHints,
   writeProviderIndexMarkers,
 } from './provider-indexing.ts';
 import { nodeSqliteTransactionAdapter } from './tx.ts';
@@ -28,19 +29,6 @@ interface SkippedFile {
   path: string;
   error: string;
   diagnostics?: unknown;
-}
-
-// Hot-file seeding for the adaptive watcher (ADR-0009): after a build, the
-// most recently written transcripts are the best guess for what is still
-// being appended through long-lived descriptors. index_state.mtime holds the
-// source file mtime per unit; marker rows carry `__` prefixes and are not
-// transcripts. Cheap because the build already persisted every cursor.
-const WATCH_HINT_LIMIT = 64;
-
-function readWatchHints(db: SqliteDb): string[] {
-  return db.prepare(
-    "SELECT jsonl_path FROM index_state WHERE jsonl_path NOT LIKE '\\_\\_%' ESCAPE '\\' ORDER BY mtime DESC LIMIT ?",
-  ).all(WATCH_HINT_LIMIT).map((row: SqliteRow) => String(row.jsonl_path));
 }
 
 interface BuildCheckOptions {
@@ -300,7 +288,7 @@ function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwne
           inventoryIssues,
           skipped: 0,
           skippedFiles,
-          watchHints: readWatchHints(db),
+          watchHints: readRecentTranscriptHints(db),
         };
       }
 
@@ -366,7 +354,7 @@ function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwne
         inventoryIssues,
         skipped: skippedFiles.length,
         skippedFiles,
-        watchHints: readWatchHints(db),
+        watchHints: readRecentTranscriptHints(db),
       };
     } finally {
       db.close();

--- a/packages/core/src/provider-indexing.ts
+++ b/packages/core/src/provider-indexing.ts
@@ -68,11 +68,15 @@ export class ProviderIndexFailure extends Error {
 // dropped. Both run in the indexer worker, never on the Electron main thread.
 const WATCH_HINT_LIMIT = 64;
 const HINT_DIRECTORY_FILE_LIMIT = 4;
+// Candidates collected before ranking by mtime — a Kimi session dir holds
+// several wire files (main + agents), and readdir order says nothing about
+// which one is actively appended.
+const HINT_DIRECTORY_CANDIDATE_LIMIT = 16;
 
 function expandHintDirectory(dir: string): string[] {
-  const found: string[] = [];
+  const candidates: string[] = [];
   const walk = (current: string, depth: number) => {
-    if (found.length >= HINT_DIRECTORY_FILE_LIMIT || depth > 4) return;
+    if (candidates.length >= HINT_DIRECTORY_CANDIDATE_LIMIT || depth > 4) return;
     let entries: Dirent[];
     try {
       entries = readdirSync(current, { withFileTypes: true });
@@ -80,14 +84,27 @@ function expandHintDirectory(dir: string): string[] {
       return;
     }
     for (const entry of entries) {
-      if (found.length >= HINT_DIRECTORY_FILE_LIMIT) return;
+      if (candidates.length >= HINT_DIRECTORY_CANDIDATE_LIMIT) return;
       const full = join(current, entry.name);
       if (entry.isDirectory()) walk(full, depth + 1);
-      else if (entry.name.endsWith('.jsonl')) found.push(full);
+      else if (entry.name.endsWith('.jsonl')) candidates.push(full);
     }
   };
   walk(dir, 0);
-  return found;
+  // Rank by file mtime: the actively appended wire (the main one in
+  // practice) is the most recently written, while a plain readdir/DFS order
+  // would systematically pick stale agent wires first.
+  return candidates
+    .map((file) => {
+      try {
+        return { file, mtimeMs: statSync(file).mtimeMs };
+      } catch {
+        return { file, mtimeMs: 0 };
+      }
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .slice(0, HINT_DIRECTORY_FILE_LIMIT)
+    .map(({ file }) => file);
 }
 
 export function readRecentTranscriptHints(db: SqliteDb, limit = WATCH_HINT_LIMIT): string[] {

--- a/packages/core/src/provider-indexing.ts
+++ b/packages/core/src/provider-indexing.ts
@@ -53,8 +53,22 @@ export class ProviderIndexFailure extends Error {
   }
 }
 
-export function storedProviderCursor(db: SqliteDb, key: string): Cursor {
-  const row = db.prepare('SELECT mtime, lines_processed, cursor FROM index_state WHERE jsonl_path = ?').get(key);
+// Hot-file seeding for the adaptive watcher (ADR-0009): after a build, the
+// most recently written transcripts are the best guess for what is still
+// being appended through long-lived descriptors. index_state.mtime holds the
+// source file mtime per unit; marker rows carry `__` prefixes and are not
+// transcripts. Unit keys are not always files (Kimi's key is a session
+// directory) — the watcher drops non-file hints itself. Keep the limit in
+// sync with the watcher's DEFAULT_MAX_HOT_FILES.
+const WATCH_HINT_LIMIT = 64;
+
+export function readRecentTranscriptHints(db: SqliteDb, limit = WATCH_HINT_LIMIT): string[] {
+  return db.prepare(
+    "SELECT jsonl_path FROM index_state WHERE jsonl_path NOT LIKE '\\_\\_%' ESCAPE '\\' ORDER BY mtime DESC LIMIT ?",
+  ).all(limit).map((row) => String(row.jsonl_path));
+}
+
+export function storedProviderCursor(db: SqliteDb, key: string): Cursor {  const row = db.prepare('SELECT mtime, lines_processed, cursor FROM index_state WHERE jsonl_path = ?').get(key);
   if (!row) return null;
   return typeof row.cursor === 'string'
     ? row.cursor

--- a/packages/core/src/provider-indexing.ts
+++ b/packages/core/src/provider-indexing.ts
@@ -1,6 +1,9 @@
 // Copyright (C) 2026 tommy0103 and contributors.
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { readdirSync, statSync, type Dirent } from 'node:fs';
+import { join } from 'node:path';
+
 import { persist } from './persist.ts';
 import type { ProviderRegistry } from './providers/registry.ts';
 import type {
@@ -57,15 +60,60 @@ export class ProviderIndexFailure extends Error {
 // most recently written transcripts are the best guess for what is still
 // being appended through long-lived descriptors. index_state.mtime holds the
 // source file mtime per unit; marker rows carry `__` prefixes and are not
-// transcripts. Unit keys are not always files (Kimi's key is a session
-// directory) — the watcher drops non-file hints itself. Keep the limit in
-// sync with the watcher's DEFAULT_MAX_HOT_FILES.
+// transcripts. Keep the limit in sync with the watcher's DEFAULT_MAX_HOT_FILES.
+//
+// Unit keys are not always files: Kimi's key is the session directory, whose
+// mtime does not track appends to the wire files inside. Directory keys are
+// expanded to the transcripts they contain (bounded); missing keys are
+// dropped. Both run in the indexer worker, never on the Electron main thread.
 const WATCH_HINT_LIMIT = 64;
+const HINT_DIRECTORY_FILE_LIMIT = 4;
+
+function expandHintDirectory(dir: string): string[] {
+  const found: string[] = [];
+  const walk = (current: string, depth: number) => {
+    if (found.length >= HINT_DIRECTORY_FILE_LIMIT || depth > 4) return;
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (found.length >= HINT_DIRECTORY_FILE_LIMIT) return;
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) walk(full, depth + 1);
+      else if (entry.name.endsWith('.jsonl')) found.push(full);
+    }
+  };
+  walk(dir, 0);
+  return found;
+}
 
 export function readRecentTranscriptHints(db: SqliteDb, limit = WATCH_HINT_LIMIT): string[] {
-  return db.prepare(
+  const rows = db.prepare(
     "SELECT jsonl_path FROM index_state WHERE jsonl_path NOT LIKE '\\_\\_%' ESCAPE '\\' ORDER BY mtime DESC LIMIT ?",
-  ).all(limit).map((row) => String(row.jsonl_path));
+  ).all(limit * 4);
+  const hints: string[] = [];
+  for (const row of rows) {
+    if (hints.length >= limit) break;
+    const key = String(row.jsonl_path);
+    let isDirectory = false;
+    try {
+      isDirectory = statSync(key).isDirectory();
+    } catch {
+      continue; // deleted between build and hint collection
+    }
+    if (!isDirectory) {
+      hints.push(key);
+      continue;
+    }
+    for (const file of expandHintDirectory(key)) {
+      if (hints.length >= limit) break;
+      hints.push(file);
+    }
+  }
+  return hints;
 }
 
 export function storedProviderCursor(db: SqliteDb, key: string): Cursor {  const row = db.prepare('SELECT mtime, lines_processed, cursor FROM index_state WHERE jsonl_path = ?').get(key);

--- a/packages/core/src/provider-indexing.ts
+++ b/packages/core/src/provider-indexing.ts
@@ -64,8 +64,13 @@ export class ProviderIndexFailure extends Error {
 //
 // Unit keys are not always files: Kimi's key is the session directory, whose
 // mtime does not track appends to the wire files inside. Directory keys are
-// expanded to the transcripts they contain (bounded); missing keys are
-// dropped. Both run in the indexer worker, never on the Electron main thread.
+// expanded to the transcripts they contain (bounded, mtime-ranked); missing
+// keys are dropped. Both run in the indexer worker, never on the Electron
+// main thread. The authoritative wire-layout knowledge lives in the Kimi
+// provider (kimi.ts sessionDirectoryFromWirePath and its discover walk) —
+// this generic expansion deliberately relies on file mtime instead of
+// duplicating that layout logic; if the Kimi wire layout changes, revisit
+// both.
 const WATCH_HINT_LIMIT = 64;
 const HINT_DIRECTORY_FILE_LIMIT = 4;
 // Candidates collected before ranking by mtime — a Kimi session dir holds

--- a/tests/adaptive-watcher.test.mjs
+++ b/tests/adaptive-watcher.test.mjs
@@ -362,7 +362,7 @@ test('close awaits the unsubscribe of a subscription dropped by a stream error',
 
 // ---------------------------------------------------------------- hot overlay
 
-test('a promoted hot file baselines silently, then later appends are detected', async () => {
+test('a hint-promoted hot file reports its first observation, then later appends are detected', async () => {
   const root = makeTempDir('obelisk-adw-hot-');
   const file = join(root, 'active.jsonl');
   const timers = fakeTimers();
@@ -384,13 +384,17 @@ test('a promoted hot file baselines silently, then later appends are detected', 
   };
 
   try {
+    // The public promote() is the build-hint channel: appends after the
+    // build finished are covered by no delivered signal, so the first
+    // observation must report — never baseline silently.
     watcher.promote(file);
     await tick();
-    assert.deepEqual(invalidations, [], 'promotion baselines silently — the promoting signal already delivered the change');
+    assert.deepEqual(invalidations, [{ type: 'paths', paths: [file] }],
+      'a hint-promoted file reports its first observation as an appearance');
 
     state = { ...state, size: 180, mtimeMs: 2000 };
     await tick();
-    assert.deepEqual(invalidations, [{ type: 'paths', paths: [file] }], 'a post-promotion append is detected');
+    assert.equal(invalidations.length, 2, 'a post-promotion append is detected');
     assert.ok(statCalls.every((p) => p === file), 'only the hot file is polled');
   } finally {
     await watcher.close();
@@ -446,17 +450,24 @@ test('native events promote matching paths before delivering the invalidation', 
   const root = makeTempDir('obelisk-adw-promote-');
   const timers = fakeTimers();
   const { subscriptions, subscribe } = fakeSubscribeStore();
+  const invalidations = [];
+  let state = { dev: 1, ino: 11, size: 10, mtimeMs: 1000 };
   const statCalls = [];
   const watcher = createAdaptiveWatcher({
     targets: [{ kind: 'tree', path: root }],
-    onInvalidate: () => {},
+    onInvalidate: (inv) => invalidations.push(inv),
     hotPolling: true,
     shouldPromote: (p) => p.endsWith('.jsonl'),
     subscribe,
-    stat: async (p) => { statCalls.push(p); return { dev: 1, ino: 1, size: 1, mtimeMs: 1 }; },
+    stat: async (p) => { statCalls.push(p); return { ...state }; },
     timers,
     logger: { warn: () => {} },
   });
+
+  const tick = async () => {
+    timers.flush();
+    assert.ok(await waitFor(() => timers.pendingCount === 1), 'the next poll tick is scheduled');
+  };
 
   try {
     assert.ok(await waitFor(() => subscriptions.length === 1), 'the tree root is subscribed');
@@ -464,10 +475,63 @@ test('native events promote matching paths before delivering the invalidation', 
       { type: 'create', path: join(root, 'new-session.jsonl') },
       { type: 'create', path: join(root, 'notes.txt') },
     ]);
-    timers.flush();
-    assert.ok(await waitFor(() => statCalls.length > 0), 'the promoted path is polled');
+    await tick();
     assert.deepEqual([...new Set(statCalls)], [join(root, 'new-session.jsonl')],
       'only shouldPromote-matching paths enter the hot set');
+    const afterPromotion = invalidations.length;
+    assert.ok(afterPromotion >= 1, 'the event itself was delivered');
+
+    // Event promotion baselines silently (the event already delivered the
+    // change); a later append through a possibly-invisible writer is polled.
+    state = { ...state, size: 40, mtimeMs: 2000 };
+    await tick();
+    const appended = invalidations.slice(afterPromotion)
+      .some((inv) => inv.type === 'paths' && inv.paths.includes(join(root, 'new-session.jsonl')));
+    assert.ok(appended, 'a post-promotion append on an event-promoted file is detected');
+
+    // Delete events never promote: the removed transcript would otherwise
+    // hold a hot slot while permanently missing.
+    subscriptions[0].callback(null, [{ type: 'delete', path: join(root, 'gone.jsonl') }]);
+    statCalls.length = 0;
+    await tick();
+    assert.ok(!statCalls.includes(join(root, 'gone.jsonl')), 'a delete event does not promote');
+  } finally {
+    await watcher.close();
+  }
+});
+
+test('a directory hint is dropped from the hot set instead of being polled forever', async () => {
+  // Kimi's unit key is the session directory, so watchHints can contain
+  // directories; polling one cannot see appends to the wire file inside.
+  const root = makeTempDir('obelisk-adw-dirhint-');
+  const dirTarget = join(root, 'session-dir');
+  const timers = fakeTimers();
+  const invalidations = [];
+  const statCalls = [];
+  const watcher = createAdaptiveWatcher({
+    targets: [],
+    onInvalidate: (inv) => invalidations.push(inv),
+    hotPolling: true,
+    stat: async (p) => {
+      statCalls.push(p);
+      return { dev: 1, ino: 1, size: 64, mtimeMs: 1000, isDirectory: true };
+    },
+    timers,
+    logger: { warn: () => {} },
+  });
+
+  const tick = async () => {
+    timers.flush();
+    assert.ok(await waitFor(() => timers.pendingCount === 1), 'the next poll tick is scheduled');
+  };
+
+  try {
+    watcher.promote(dirTarget);
+    await tick();
+    assert.equal(statCalls.length, 1, 'a promoted path is probed once');
+    assert.deepEqual(invalidations, [], 'a directory hint reports nothing');
+    await tick();
+    assert.equal(statCalls.length, 1, 'a directory hint is evicted from the hot set, not polled again');
   } finally {
     await watcher.close();
   }

--- a/tests/adaptive-watcher.test.mjs
+++ b/tests/adaptive-watcher.test.mjs
@@ -73,6 +73,7 @@ test('tree events arrive as batched path invalidations, duplicate roots subscrib
       { kind: 'tree', path: root },
       { kind: 'tree', path: root },
     ],
+    hotPolling: false,
     onInvalidate: (inv) => invalidations.push(inv),
     subscribe,
     logger: { warn: () => {} },
@@ -104,6 +105,7 @@ test('a missing tree root is retried quietly and repeatedly, then established wi
   const { subscriptions, subscribe } = fakeSubscribeStore();
   const watcher = createAdaptiveWatcher({
     targets: [{ kind: 'tree', path: root }],
+    hotPolling: false,
     onInvalidate: (inv) => invalidations.push(inv),
     subscribe,
     // The real fs probe through the injection point: ENOENT is genuine.
@@ -153,6 +155,7 @@ test('an inaccessible tree root warns once per failure, and again after a recurr
   };
   const watcher = createAdaptiveWatcher({
     targets: [{ kind: 'tree', path: root }],
+    hotPolling: false,
     onInvalidate: () => {},
     subscribe,
     access,
@@ -210,6 +213,7 @@ test('file targets are polled for appearance, append, replacement, and disappear
   };
   const watcher = createAdaptiveWatcher({
     targets: [{ kind: 'file', path: file }],
+    hotPolling: false,
     onInvalidate: (inv) => invalidations.push(inv),
     subscribe,
     stat,
@@ -264,6 +268,7 @@ test('close unsubscribes trees and leaves no timers behind', async () => {
   const { subscriptions, subscribe } = fakeSubscribeStore();
   const watcher = createAdaptiveWatcher({
     targets: [{ kind: 'tree', path: root }, { kind: 'file', path: file }],
+    hotPolling: false,
     onInvalidate: () => {},
     subscribe,
     stat: async () => ({ dev: 1, ino: 1, size: 1, mtimeMs: 1 }),
@@ -293,6 +298,7 @@ test('close waits for an in-flight subscribe, and no invalidation fires after cl
   };
   const watcher = createAdaptiveWatcher({
     targets: [{ kind: 'tree', path: root }],
+    hotPolling: false,
     onInvalidate: (inv) => invalidations.push(inv),
     subscribe,
     logger: { warn: () => {} },
@@ -329,6 +335,7 @@ test('close awaits the unsubscribe of a subscription dropped by a stream error',
   };
   const watcher = createAdaptiveWatcher({
     targets: [{ kind: 'tree', path: root }],
+    hotPolling: false,
     onInvalidate: () => {},
     subscribe,
     logger: { warn: () => {} },
@@ -350,4 +357,198 @@ test('close awaits the unsubscribe of a subscription dropped by a stream error',
   releaseUnsubscribe();
   await closePromise;
   assert.ok(closeResolved, 'close completes once the cleanup lands');
+});
+
+
+// ---------------------------------------------------------------- hot overlay
+
+test('a promoted hot file baselines silently, then later appends are detected', async () => {
+  const root = makeTempDir('obelisk-adw-hot-');
+  const file = join(root, 'active.jsonl');
+  const timers = fakeTimers();
+  const invalidations = [];
+  let state = { dev: 1, ino: 11, size: 100, mtimeMs: 1000 };
+  const statCalls = [];
+  const watcher = createAdaptiveWatcher({
+    targets: [],
+    onInvalidate: (inv) => invalidations.push(inv),
+    hotPolling: true,
+    stat: async (p) => { statCalls.push(p); return { ...state }; },
+    timers,
+    logger: { warn: () => {} },
+  });
+
+  const tick = async () => {
+    timers.flush();
+    assert.ok(await waitFor(() => timers.pendingCount === 1), 'the next poll tick is scheduled');
+  };
+
+  try {
+    watcher.promote(file);
+    await tick();
+    assert.deepEqual(invalidations, [], 'promotion baselines silently — the promoting signal already delivered the change');
+
+    state = { ...state, size: 180, mtimeMs: 2000 };
+    await tick();
+    assert.deepEqual(invalidations, [{ type: 'paths', paths: [file] }], 'a post-promotion append is detected');
+    assert.ok(statCalls.every((p) => p === file), 'only the hot file is polled');
+  } finally {
+    await watcher.close();
+  }
+});
+
+test('the hot set never exceeds its cap and evicted files stop being polled', async () => {
+  const root = makeTempDir('obelisk-adw-cap-');
+  const timers = fakeTimers();
+  const statCalls = [];
+  const watcher = createAdaptiveWatcher({
+    targets: [],
+    onInvalidate: () => {},
+    hotPolling: true,
+    maxHotFiles: 2,
+    stat: async (p) => { statCalls.push(p); return { dev: 1, ino: 1, size: 1, mtimeMs: 1 }; },
+    timers,
+    logger: { warn: () => {} },
+  });
+
+  const tick = async () => {
+    timers.flush();
+    assert.ok(await waitFor(() => timers.pendingCount === 1), 'the next poll tick is scheduled');
+  };
+
+  try {
+    const files = ['a', 'b', 'c', 'd'].map((name) => join(root, `${name}.jsonl`));
+    for (const file of files) watcher.promote(file);
+    await tick();
+    const polled = new Set(statCalls);
+    assert.deepEqual([...polled].sort(), [files[2], files[3]].sort(),
+      'only the two most recently promoted files are polled');
+
+    statCalls.length = 0;
+    await tick();
+    assert.ok(!statCalls.includes(files[0]) && !statCalls.includes(files[1]),
+      'evicted files are never polled again');
+
+    // Re-promoting an existing hot file only refreshes its LRU position.
+    watcher.promote(files[3]);
+    watcher.promote(files[2]);
+    watcher.promote(files[0]);
+    statCalls.length = 0;
+    await tick();
+    assert.deepEqual(new Set(statCalls), new Set([files[2], files[0]]),
+      're-promotion evicts the least recently active, not the just-refreshed');
+  } finally {
+    await watcher.close();
+  }
+});
+
+test('native events promote matching paths before delivering the invalidation', async () => {
+  const root = makeTempDir('obelisk-adw-promote-');
+  const timers = fakeTimers();
+  const { subscriptions, subscribe } = fakeSubscribeStore();
+  const statCalls = [];
+  const watcher = createAdaptiveWatcher({
+    targets: [{ kind: 'tree', path: root }],
+    onInvalidate: () => {},
+    hotPolling: true,
+    shouldPromote: (p) => p.endsWith('.jsonl'),
+    subscribe,
+    stat: async (p) => { statCalls.push(p); return { dev: 1, ino: 1, size: 1, mtimeMs: 1 }; },
+    timers,
+    logger: { warn: () => {} },
+  });
+
+  try {
+    assert.ok(await waitFor(() => subscriptions.length === 1), 'the tree root is subscribed');
+    subscriptions[0].callback(null, [
+      { type: 'create', path: join(root, 'new-session.jsonl') },
+      { type: 'create', path: join(root, 'notes.txt') },
+    ]);
+    timers.flush();
+    assert.ok(await waitFor(() => statCalls.length > 0), 'the promoted path is polled');
+    assert.deepEqual([...new Set(statCalls)], [join(root, 'new-session.jsonl')],
+      'only shouldPromote-matching paths enter the hot set');
+  } finally {
+    await watcher.close();
+  }
+});
+
+test('hotPolling disabled makes promote and initialHotFiles no-ops', async () => {
+  const root = makeTempDir('obelisk-adw-disabled-');
+  const file = join(root, 'active.jsonl');
+  const timers = fakeTimers();
+  const statCalls = [];
+  const watcher = createAdaptiveWatcher({
+    targets: [],
+    onInvalidate: () => {},
+    hotPolling: false,
+    initialHotFiles: [file],
+    stat: async (p) => { statCalls.push(p); return { dev: 1, ino: 1, size: 1, mtimeMs: 1 }; },
+    timers,
+    logger: { warn: () => {} },
+  });
+
+  try {
+    watcher.promote(file);
+    timers.flush();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(statCalls.length, 0, 'nothing is polled while the overlay is disabled');
+    assert.equal(timers.pendingCount, 0, 'no poll timer is scheduled at all');
+  } finally {
+    await watcher.close();
+  }
+});
+
+test('a transcript opened before watching and appended without close is detected by polling', async () => {
+  // The production Codex write pattern (docs/watcher-backend-options-research.md):
+  // one fd opened before subscription, appended continuously, never closed
+  // during the session. FSEvents delivers nothing until close; the poller
+  // must still see the growth. Uses the real fs stat against a real file —
+  // only Parcel is faked (it stays silent, worst case).
+  const root = makeTempDir('obelisk-adw-longopen-');
+  const file = join(root, 'live-session.jsonl');
+  fs.writeFileSync(file, '{"line":0}\n');
+  const fd = fs.openSync(file, 'a');
+
+  const timers = fakeTimers();
+  const invalidations = [];
+  const { subscriptions, subscribe } = fakeSubscribeStore();
+  const watcher = createAdaptiveWatcher({
+    targets: [{ kind: 'tree', path: root }],
+    onInvalidate: (inv) => invalidations.push(inv),
+    hotPolling: true,
+    initialHotFiles: [file],
+    subscribe,
+    pollIntervalMs: 40,
+    stat: fs.promises.stat,
+    access: fs.promises.access,
+    timers,
+    logger: { warn: () => {} },
+  });
+
+  const tick = async () => {
+    timers.flush();
+    assert.ok(await waitFor(() => timers.pendingCount > 0), 'the next tick is scheduled');
+  };
+
+  try {
+    assert.ok(await waitFor(() => subscriptions.length === 1), 'the tree root is subscribed');
+    await tick(); // silent baseline for the seeded hot file
+    const baselineCount = invalidations.length;
+
+    // Append through the still-open descriptor — no close, no FSEvents.
+    for (let i = 1; i <= 5; i++) fs.writeSync(fd, `{"line":${i}}\n`);
+    fs.fsyncSync(fd);
+
+    let detected = false;
+    for (let attempt = 0; attempt < 10 && !detected; attempt++) {
+      await tick();
+      detected = invalidations.slice(baselineCount)
+        .some((inv) => inv.type === 'paths' && inv.paths.includes(file));
+    }
+    assert.ok(detected, 'appends through the long-open fd are detected within a few poll ticks');
+  } finally {
+    fs.closeSync(fd);
+    await watcher.close();
+  }
 });

--- a/tests/app-indexer-watcher.test.mjs
+++ b/tests/app-indexer-watcher.test.mjs
@@ -230,27 +230,102 @@ test('build watchHints are promoted into the hot set and polled for later append
     hotPolling: true,
   });
 
-  try {
-    service.start({ buildOnStart: false });
-    await service.runBuildNow('startup');
-    // Poll timers live in the manual set alongside service timers; drive
-    // ticks and let microtasks settle between them.
-    timers.flush();
-    await new Promise((resolve) => setTimeout(resolve, 30));
-
-    // The hint was promoted (silently baselined); a later append — possibly
-    // invisible to the tree backend — must surface through the poller.
-    fs.appendFileSync(hinted, '{"line":1}\n');
-    let detected = false;
-    for (let attempt = 0; attempt < 20 && !detected; attempt++) {
+  const drive = async (rounds) => {
+    for (let i = 0; i < rounds; i++) {
       timers.flush();
       await new Promise((resolve) => setTimeout(resolve, 30));
       await service.idle();
-      detected = builds.some((b) => (b.changedPaths ?? []).includes(hinted));
     }
-    assert.ok(detected, 'the hinted transcript is polled and its append schedules a build');
-    const hit = builds.find((b) => (b.changedPaths ?? []).includes(hinted));
-    assert.equal(hit.reason, 'watch');
+  };
+
+  try {
+    service.start({ buildOnStart: false });
+    await service.runBuildNow('startup');
+    // Hint promotion is report-first: the first poll fires an appearance
+    // build. Drain those before appending, so the assertion below can only
+    // be satisfied by detecting the append itself.
+    await drive(3);
+    const beforeAppend = builds.length;
+    assert.ok(beforeAppend > 0, 'the hint-driven first-observation build happened');
+
+    fs.appendFileSync(hinted, '{"line":1}\n');
+    let appended = false;
+    for (let attempt = 0; attempt < 20 && !appended; attempt++) {
+      timers.flush();
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      await service.idle();
+      appended = builds.slice(beforeAppend).some((b) => (b.changedPaths ?? []).includes(hinted));
+    }
+    assert.ok(appended, 'the append — possibly invisible to the tree backend — is detected by polling');
+  } finally {
+    service.stop();
+    await service.idle();
+  }
+});
+
+test('an evicted hot file is re-seeded by a later reconcile hint', async () => {
+  const root = makeTempDir('obelisk-reseed-');
+  const hinted = join(root, 'live.jsonl');
+  fs.writeFileSync(hinted, '{"line":0}\n');
+  const fillers = Array.from({ length: 64 }, (_, i) => join(root, `filler-${i}.jsonl`));
+  for (const filler of fillers) fs.writeFileSync(filler, '{}\n');
+  const timers = manualTimers();
+  const builds = [];
+  let nextHints = [hinted];
+  const service = createIndexerService({
+    watchTargets: [{ kind: 'tree', path: root }],
+    buildIndex: async (args) => { builds.push(args); return { watchHints: nextHints }; },
+    subscribe: () => Promise.resolve({ unsubscribe: () => Promise.resolve() }),
+    writeHeartbeat: () => {},
+    logger: { warn: () => {} },
+    timers,
+    stabilityMs: 0,
+    debounceMs: 0,
+    watchRetryMs: 0,
+    hotPolling: true,
+  });
+
+  const drive = async (rounds) => {
+    for (let i = 0; i < rounds; i++) {
+      timers.flush();
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      await service.idle();
+    }
+  };
+
+  try {
+    service.start({ buildOnStart: false });
+    await service.runBuildNow('startup');
+    await drive(3);
+    assert.ok(
+      builds.some((b) => (b.changedPaths ?? []).includes(hinted)),
+      'the hinted file is hot after seeding',
+    );
+
+    // Evict it by filling the 64-slot hot set with fillers.
+    nextHints = fillers;
+    await service.runBuildNow('reconcile');
+    const afterEvict = builds.length;
+    await drive(3);
+    fs.appendFileSync(hinted, '{"line":1}\n');
+    await drive(6);
+    assert.ok(
+      !builds.slice(afterEvict).some((b) => (b.changedPaths ?? []).includes(hinted)),
+      'the evicted file is no longer polled',
+    );
+
+    // The periodic reconcile returns it as a hint: it is re-seeded and its
+    // first observation reports again — the degradation loop closes.
+    nextHints = [hinted];
+    await service.runBuildNow('reconcile');
+    let reseeded = false;
+    for (let attempt = 0; attempt < 20 && !reseeded; attempt++) {
+      timers.flush();
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      await service.idle();
+      reseeded = builds.slice(afterEvict).some((b) => (b.changedPaths ?? []).includes(hinted));
+    }
+    assert.ok(reseeded, 'a reconcile hint re-seeds the evicted file into the hot set');
   } finally {
     service.stop();
     await service.idle();

--- a/tests/app-indexer-watcher.test.mjs
+++ b/tests/app-indexer-watcher.test.mjs
@@ -209,3 +209,50 @@ test('silently missed watcher events are reconciled by a periodic full-inventory
     service.stop();
   }
 });
+
+
+test('build watchHints are promoted into the hot set and polled for later appends', async () => {
+  const root = makeTempDir('obelisk-hints-');
+  const hinted = join(root, 'live-session.jsonl');
+  fs.writeFileSync(hinted, '{"line":0}\n');
+  const timers = manualTimers();
+  const builds = [];
+  const service = createIndexerService({
+    watchTargets: [{ kind: 'tree', path: root }],
+    buildIndex: async (args) => { builds.push(args); return { watchHints: [hinted] }; },
+    subscribe: () => Promise.resolve({ unsubscribe: () => Promise.resolve() }),
+    writeHeartbeat: () => {},
+    logger: { warn: () => {} },
+    timers,
+    stabilityMs: 0,
+    debounceMs: 0,
+    watchRetryMs: 0,
+    hotPolling: true,
+  });
+
+  try {
+    service.start({ buildOnStart: false });
+    await service.runBuildNow('startup');
+    // Poll timers live in the manual set alongside service timers; drive
+    // ticks and let microtasks settle between them.
+    timers.flush();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    // The hint was promoted (silently baselined); a later append — possibly
+    // invisible to the tree backend — must surface through the poller.
+    fs.appendFileSync(hinted, '{"line":1}\n');
+    let detected = false;
+    for (let attempt = 0; attempt < 20 && !detected; attempt++) {
+      timers.flush();
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      await service.idle();
+      detected = builds.some((b) => (b.changedPaths ?? []).includes(hinted));
+    }
+    assert.ok(detected, 'the hinted transcript is polled and its append schedules a build');
+    const hit = builds.find((b) => (b.changedPaths ?? []).includes(hinted));
+    assert.equal(hit.reason, 'watch');
+  } finally {
+    service.stop();
+    await service.idle();
+  }
+});

--- a/tests/app-indexer-watcher.test.mjs
+++ b/tests/app-indexer-watcher.test.mjs
@@ -81,9 +81,9 @@ test('default watcher reports deep new files in freshly created directories', as
     const sawFile = () =>
       builds.some((b) => (b.changedPaths ?? []).some((p) => p.endsWith('agent-1.jsonl')));
     let sawIt = false;
-    for (let attempt = 0; attempt < 10 && !sawIt; attempt++) {
+    for (let attempt = 0; attempt < 20 && !sawIt; attempt++) {
       fs.appendFileSync(newFile, '{"probe":1}\n');
-      sawIt = await waitFor(sawFile);
+      sawIt = await waitFor(sawFile, 1500);
     }
     assert.ok(sawIt, 'the deep new transcript reached buildIndex as a changed path');
     const hit = builds.find((b) => (b.changedPaths ?? []).some((p) => p.endsWith('agent-1.jsonl')));
@@ -112,21 +112,33 @@ test('default watcher filters non-transcript files', async () => {
   service.start({ buildOnStart: false });
 
   try {
+    // Establish the subscription first: FSEvents latency on CI runners is
+    // real and unbounded, so without a probe the test races subscription
+    // setup and flakes (macOS CI waited ~11 s and saw nothing).
+    let established = false;
+    for (let attempt = 0; attempt < 20 && !established; attempt++) {
+      fs.appendFileSync(join(root, 'probe.json'), '{}\n');
+      established = await waitFor(() =>
+        builds.some((b) => (b.changedPaths ?? []).some((p) => p.endsWith('probe.json'))), 1500);
+    }
+    assert.ok(established, 'the subscription is delivering events');
+
+    const noiseStart = builds.length;
     fs.writeFileSync(join(root, 'noise.txt'), 'not a transcript');
     // Give a wrong-positive time to surface, then send a real one as a control.
     await new Promise((resolve) => setTimeout(resolve, 700));
-    const noiseBuilds = builds.length;
-    const realFile = join(root, 'real.json');
-    const sawReal = () =>
-      builds.slice(noiseBuilds).some((b) => (b.changedPaths ?? []).some((p) => p.endsWith('real.json')));
-    let sawIt = false;
-    for (let attempt = 0; attempt < 10 && !sawIt; attempt++) {
-      fs.appendFileSync(realFile, '{}\n');
-      sawIt = await waitFor(sawReal);
-    }
+    const sawNoise = builds.slice(noiseStart)
+      .some((b) => (b.changedPaths ?? []).some((p) => p.endsWith('noise.txt')));
+    assert.equal(sawNoise, false, 'a .txt write alone must not schedule a build');
 
-    assert.equal(noiseBuilds, 0, 'a .txt write alone must not schedule a build');
-    assert.ok(sawIt, 'the .json control write does schedule a build');
+    const realFile = join(root, 'real.json');
+    let sawReal = false;
+    for (let attempt = 0; attempt < 20 && !sawReal; attempt++) {
+      fs.appendFileSync(realFile, '{}\n');
+      sawReal = await waitFor(() =>
+        builds.slice(noiseStart).some((b) => (b.changedPaths ?? []).some((p) => p.endsWith('real.json'))), 1500);
+    }
+    assert.ok(sawReal, 'the .json control write does schedule a build');
   } finally {
     service.stop();
     await service.idle();

--- a/tests/app-indexer-watcher.test.mjs
+++ b/tests/app-indexer-watcher.test.mjs
@@ -139,6 +139,12 @@ test('default watcher filters non-transcript files', async () => {
         builds.slice(noiseStart).some((b) => (b.changedPaths ?? []).some((p) => p.endsWith('real.json'))), 1500);
     }
     assert.ok(sawReal, 'the .json control write does schedule a build');
+
+    // Re-scan after the control succeeded: at unbounded CI event latency a
+    // wrong-positive .txt build could arrive long after the 700 ms probe.
+    const sawNoiseLate = builds.slice(noiseStart)
+      .some((b) => (b.changedPaths ?? []).some((p) => p.endsWith('noise.txt')));
+    assert.equal(sawNoiseLate, false, 'a .txt write never schedules a build, even at CI event latency');
   } finally {
     service.stop();
     await service.idle();

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -96,6 +96,30 @@ function electronNamespace({ app, BrowserWindow, ipcMain }) {
   };
 }
 
+// Assigning undefined to process.env leaves the literal string "undefined"
+// instead of removing the variable — restore must delete in that case.
+function restoreEnvVar(name, value) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+// Captures app event handlers so a test can fire window-all-closed, which is
+// what makes the main module close its database handle.
+function captureAppHandlers(map) {
+  return {
+    whenReady: () => Promise.resolve(),
+    on(event, handler) { map.set(event, handler); },
+    quit() {},
+  };
+}
+
+// Windows refuses to unlink an open SQLite file; fire window-all-closed and
+// let the async close land before removing the temp home.
+async function closeMainProcessDb(appHandlers) {
+  appHandlers.get('window-all-closed')?.();
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
 function noopWatcher() {
   return {
     createAdaptiveWatcher: () => ({
@@ -187,8 +211,8 @@ async function loadMainForWindowFlags(flags, { settingsText } = {}) {
   } finally {
     restore();
     process.argv = originalArgv;
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalProfile;
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('USERPROFILE', originalProfile);
     rmSync(home, { recursive: true, force: true });
   }
 }
@@ -304,8 +328,8 @@ test('main process watches every root declared by the built-in provider registry
     assert.deepEqual(workerCalls[0].providerSettings, {});
   } finally {
     restore();
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalProfile;
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('USERPROFILE', originalProfile);
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -416,8 +440,8 @@ test('main process forwards committed IDs without reopening after a deferred bui
     });
   } finally {
     restore();
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalProfile;
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('USERPROFILE', originalProfile);
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -511,8 +535,8 @@ test('session IPC hides Codex rows by default and supports explicit source opt-i
     );
   } finally {
     restore();
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalProfile;
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('USERPROFILE', originalProfile);
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -577,6 +601,7 @@ test('usage IPC aggregates normalized tokens across all indexed providers', asyn
   setup.close();
 
   const ipcHandlers = new Map();
+  const appHandlers = new Map();
 
   class FakeBrowserWindow {
     constructor() {
@@ -592,6 +617,7 @@ test('usage IPC aggregates normalized tokens across all indexed providers', asyn
   const restore = registerMocks([
     [ELECTRON_URL, {
       namedExports: electronNamespace({
+        app: captureAppHandlers(appHandlers),
         BrowserWindow: FakeBrowserWindow,
         ipcMain: {
           handle(channel, handler) {
@@ -632,8 +658,9 @@ test('usage IPC aggregates normalized tokens across all indexed providers', asyn
     assert.equal(piOnly.totalTokens, 35);
   } finally {
     restore();
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalProfile;
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('USERPROFILE', originalProfile);
+    await closeMainProcessDb(appHandlers);
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -676,6 +703,7 @@ test('main process migrates an existing app database before source-filtered IPC 
   legacy.close();
 
   const ipcHandlers = new Map();
+  const appHandlers = new Map();
 
   class FakeBrowserWindow {
     constructor() {
@@ -691,6 +719,7 @@ test('main process migrates an existing app database before source-filtered IPC 
   const restore = registerMocks([
     [ELECTRON_URL, {
       namedExports: electronNamespace({
+        app: captureAppHandlers(appHandlers),
         BrowserWindow: FakeBrowserWindow,
         ipcMain: {
           handle(channel, handler) {
@@ -719,8 +748,9 @@ test('main process migrates an existing app database before source-filtered IPC 
     });
   } finally {
     restore();
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalProfile;
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('USERPROFILE', originalProfile);
+    await closeMainProcessDb(appHandlers);
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -745,6 +775,7 @@ test('main process keeps schema and memory mutations behind the writer lease', a
   });
   assert.ok(holder);
   const ipcHandlers = new Map();
+  const appHandlers = new Map();
 
   class FakeBrowserWindow {
     constructor() {
@@ -760,6 +791,7 @@ test('main process keeps schema and memory mutations behind the writer lease', a
   const restore = registerMocks([
     [ELECTRON_URL, {
       namedExports: electronNamespace({
+        app: captureAppHandlers(appHandlers),
         BrowserWindow: FakeBrowserWindow,
         ipcMain: {
           handle(channel, handler) { ipcHandlers.set(channel, handler); },
@@ -786,8 +818,9 @@ test('main process keeps schema and memory mutations behind the writer lease', a
   } finally {
     restore();
     holder.release();
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalProfile;
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('USERPROFILE', originalProfile);
+    await closeMainProcessDb(appHandlers);
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -902,8 +935,8 @@ test('closing the last macOS window releases background resources until activati
     assert.equal(serviceEvents.filter(e => e === 'service-start').length, 2);
   } finally {
     restore();
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalProfile;
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('USERPROFILE', originalProfile);
     if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
     rmSync(home, { recursive: true, force: true });
   }
@@ -1092,8 +1125,8 @@ test('settings rebuild reopens the database from the configured Claude path', as
     postRebuildLease.release();
   } finally {
     restore();
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalProfile;
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('USERPROFILE', originalProfile);
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -1206,8 +1239,8 @@ test('settings rebuild keeps the existing database after a worker failure', asyn
     assert.ok(serviceEvents.lastIndexOf('start') > serviceEvents.indexOf('build'));
   } finally {
     restore();
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalProfile;
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('USERPROFILE', originalProfile);
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -1313,8 +1346,8 @@ test('settings rebuild cancels an in-flight background build instead of waiting 
     assert.ok(serviceEvents.some(event => event.startsWith('build-')));
   } finally {
     restore();
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalProfile;
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('USERPROFILE', originalProfile);
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -1425,8 +1458,8 @@ test('settings changes during rebuild keep one watcher and re-enable with a catc
     assert.equal(services[1].stops, 0);
   } finally {
     restore();
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalProfile;
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('USERPROFILE', originalProfile);
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -1513,8 +1546,8 @@ test('main process watches OBELISK_DIR as a tree target and debounces recap noti
   } finally {
     restore();
     mock.timers.reset();
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalProfile;
+    restoreEnvVar('HOME', originalHome);
+    restoreEnvVar('USERPROFILE', originalProfile);
     rmSync(home, { recursive: true, force: true });
   }
 });

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -909,6 +909,7 @@ test('settings rebuild reopens the database from the configured Claude path', as
   const buildCalls = [];
   const serviceEvents = [];
   const sent = [];
+  const promotedHints = [];
   let competingLeaseDuringBuild;
   let publishRebuild = false;
 
@@ -964,6 +965,7 @@ test('settings rebuild reopens the database from the configured Claude path', as
           stop() { serviceEvents.push('stop'); },
           idle: async () => { serviceEvents.push('idle'); },
           runBuildNow() { serviceEvents.push('runBuildNow'); return Promise.resolve(); },
+          promoteWatchHints(hints) { promotedHints.push(hints); },
         }),
       },
     }],
@@ -993,6 +995,7 @@ test('settings rebuild reopens the database from the configured Claude path', as
                     path: '/tmp/pi/structurally-invalid.jsonl',
                     error: 'Malformed Pi message at line 2',
                   }],
+              watchHints: publishRebuild ? ['/hint/live-session.jsonl'] : [],
             };
           },
           stop() { return Promise.resolve(); },
@@ -1010,6 +1013,10 @@ test('settings rebuild reopens the database from the configured Claude path', as
     const beforeIncomplete = require('node:fs').readFileSync(liveDbPath, 'utf8');
     const incomplete = await rebuild();
     assert.equal(incomplete.complete, false);
+    assert.ok(
+      serviceEvents.includes('runBuildNow'),
+      'a rebuild without hints schedules a reconciling build to reseed the hot set',
+    );
     assert.deepEqual(sent.findLast(message => message.channel === 'obelisk:index-updated'), {
       channel: 'obelisk:index-updated',
       payload: {
@@ -1048,6 +1055,8 @@ test('settings rebuild reopens the database from the configured Claude path', as
       'rebuilt temp db',
     );
     assert.ok(serviceEvents.indexOf('build') > serviceEvents.indexOf('stop'));
+    assert.deepEqual(promotedHints, [['/hint/live-session.jsonl']],
+      'a successful rebuild seeds the recreated watcher with its watch hints');
     const postRebuildLease = acquireWriterLease({
       lockPath: join(home, '.obelisk', 'writer.lock.sqlite'),
       openDb: lockPath => new DatabaseSync(lockPath),

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -127,6 +127,7 @@ function defaultIndexerWorkerClient() {
 async function loadMainForWindowFlags(flags, { settingsText } = {}) {
   const originalArgv = process.argv;
   const originalHome = process.env.HOME;
+  const originalProfile = process.env.USERPROFILE;
   const home = makeTempDir(`obelisk-window-flags-${Date.now()}-${Math.random()}`);
   mkdirSync(join(home, '.obelisk'), { recursive: true });
   writeFileSync(join(home, '.obelisk', 'obelisk.sqlite'), '');
@@ -134,6 +135,7 @@ async function loadMainForWindowFlags(flags, { settingsText } = {}) {
     writeFileSync(join(home, '.obelisk', 'settings.json'), settingsText);
   }
   process.env.HOME = home;
+  process.env.USERPROFILE = home; // os.homedir() reads USERPROFILE on Windows
   process.argv = [originalArgv[0] || 'node', originalArgv[1] || 'electron', ...flags];
 
   const windows = [];
@@ -186,6 +188,7 @@ async function loadMainForWindowFlags(flags, { settingsText } = {}) {
     restore();
     process.argv = originalArgv;
     process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalProfile;
     rmSync(home, { recursive: true, force: true });
   }
 }
@@ -216,6 +219,7 @@ test('malformed settings keep the desktop recovery window available', async () =
 
 test('main process watches every root declared by the built-in provider registry', async () => {
   const originalHome = process.env.HOME;
+  const originalProfile = process.env.USERPROFILE;
   const home = makeTempDir(`obelisk-main-watch-dirs-${Date.now()}`);
   const claudeDir = join(home, '.claude');
   const codexDir = join(home, '.codex');
@@ -225,6 +229,7 @@ test('main process watches every root declared by the built-in provider registry
   mkdirSync(join(home, '.obelisk'), { recursive: true });
   writeFileSync(join(home, '.obelisk', 'obelisk.sqlite'), '');
   process.env.HOME = home;
+  process.env.USERPROFILE = home; // os.homedir() reads USERPROFILE on Windows
 
   const serviceOptions = [];
   const workerCalls = [];
@@ -300,18 +305,21 @@ test('main process watches every root declared by the built-in provider registry
   } finally {
     restore();
     process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalProfile;
     rmSync(home, { recursive: true, force: true });
   }
 });
 
 test('main process forwards committed IDs without reopening after a deferred build', async () => {
   const originalHome = process.env.HOME;
+  const originalProfile = process.env.USERPROFILE;
   const home = makeTempDir(`obelisk-main-deferred-build-${Date.now()}`);
   mkdirSync(join(home, '.claude', 'projects'), { recursive: true });
   mkdirSync(join(home, '.codex', 'sessions'), { recursive: true });
   mkdirSync(join(home, '.obelisk'), { recursive: true });
   writeFileSync(join(home, '.obelisk', 'obelisk.sqlite'), '');
   process.env.HOME = home;
+  process.env.USERPROFILE = home; // os.homedir() reads USERPROFILE on Windows
 
   let databaseOpens = 0;
   let serviceOptions;
@@ -409,16 +417,19 @@ test('main process forwards committed IDs without reopening after a deferred bui
   } finally {
     restore();
     process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalProfile;
     rmSync(home, { recursive: true, force: true });
   }
 });
 
 test('session IPC hides Codex rows by default and supports explicit source opt-in', async () => {
   const originalHome = process.env.HOME;
+  const originalProfile = process.env.USERPROFILE;
   const home = makeTempDir(`obelisk-main-source-filter-${Date.now()}`);
   mkdirSync(join(home, '.obelisk'), { recursive: true });
   writeFileSync(join(home, '.obelisk', 'obelisk.sqlite'), '');
   process.env.HOME = home;
+  process.env.USERPROFILE = home; // os.homedir() reads USERPROFILE on Windows
 
   const ipcHandlers = new Map();
   const queries = [];
@@ -501,16 +512,19 @@ test('session IPC hides Codex rows by default and supports explicit source opt-i
   } finally {
     restore();
     process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalProfile;
     rmSync(home, { recursive: true, force: true });
   }
 });
 
 test('usage IPC aggregates normalized tokens across all indexed providers', async () => {
   const originalHome = process.env.HOME;
+  const originalProfile = process.env.USERPROFILE;
   const home = makeTempDir(`obelisk-main-usage-${Date.now()}`);
   const obeliskDir = join(home, '.obelisk');
   mkdirSync(obeliskDir, { recursive: true });
   process.env.HOME = home;
+  process.env.USERPROFILE = home; // os.homedir() reads USERPROFILE on Windows
 
   const dbPath = join(obeliskDir, 'obelisk.sqlite');
   const setup = new DatabaseSync(dbPath);
@@ -619,16 +633,19 @@ test('usage IPC aggregates normalized tokens across all indexed providers', asyn
   } finally {
     restore();
     process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalProfile;
     rmSync(home, { recursive: true, force: true });
   }
 });
 
 test('main process migrates an existing app database before source-filtered IPC queries', async () => {
   const originalHome = process.env.HOME;
+  const originalProfile = process.env.USERPROFILE;
   const home = makeTempDir(`obelisk-main-db-migration-${Date.now()}`);
   const obeliskDir = join(home, '.obelisk');
   mkdirSync(obeliskDir, { recursive: true });
   process.env.HOME = home;
+  process.env.USERPROFILE = home; // os.homedir() reads USERPROFILE on Windows
 
   const { DatabaseSync } = require('node:sqlite');
   const dbPath = join(obeliskDir, 'obelisk.sqlite');
@@ -703,17 +720,20 @@ test('main process migrates an existing app database before source-filtered IPC 
   } finally {
     restore();
     process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalProfile;
     rmSync(home, { recursive: true, force: true });
   }
 });
 
 test('main process keeps schema and memory mutations behind the writer lease', async () => {
   const originalHome = process.env.HOME;
+  const originalProfile = process.env.USERPROFILE;
   const home = makeTempDir(`obelisk-main-migration-lease-${Date.now()}`);
   const obeliskDir = join(home, '.obelisk');
   const dbPath = join(obeliskDir, 'obelisk.sqlite');
   mkdirSync(obeliskDir, { recursive: true });
   process.env.HOME = home;
+  process.env.USERPROFILE = home; // os.homedir() reads USERPROFILE on Windows
 
   const legacy = new DatabaseSync(dbPath);
   legacy.exec('CREATE TABLE sessions (id TEXT PRIMARY KEY)');
@@ -767,6 +787,7 @@ test('main process keeps schema and memory mutations behind the writer lease', a
     restore();
     holder.release();
     process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalProfile;
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -774,10 +795,12 @@ test('main process keeps schema and memory mutations behind the writer lease', a
 test('closing the last macOS window releases background resources until activation', async () => {
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
   const originalHome = process.env.HOME;
+  const originalProfile = process.env.USERPROFILE;
   const home = makeTempDir(`obelisk-main-window-${Date.now()}`);
   mkdirSync(join(home, '.obelisk'), { recursive: true });
   writeFileSync(join(home, '.obelisk', 'obelisk.sqlite'), '');
   process.env.HOME = home;
+  process.env.USERPROFILE = home; // os.homedir() reads USERPROFILE on Windows
   Object.defineProperty(process, 'platform', { value: 'darwin' });
 
   const appHandlers = new Map();
@@ -880,6 +903,7 @@ test('closing the last macOS window releases background resources until activati
   } finally {
     restore();
     process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalProfile;
     if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
     rmSync(home, { recursive: true, force: true });
   }
@@ -902,7 +926,10 @@ test('settings rebuild reopens the database from the configured Claude path', as
   }));
 
   const originalHome = process.env.HOME;
+
+  const originalProfile = process.env.USERPROFILE;
   process.env.HOME = home;
+  process.env.USERPROFILE = home; // os.homedir() reads USERPROFILE on Windows
 
   const ipcHandlers = new Map();
   const openedDbPaths = [];
@@ -1066,6 +1093,7 @@ test('settings rebuild reopens the database from the configured Claude path', as
   } finally {
     restore();
     process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalProfile;
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -1084,7 +1112,10 @@ test('settings rebuild keeps the existing database after a worker failure', asyn
   }));
 
   const originalHome = process.env.HOME;
+
+  const originalProfile = process.env.USERPROFILE;
   process.env.HOME = home;
+  process.env.USERPROFILE = home; // os.homedir() reads USERPROFILE on Windows
 
   const ipcHandlers = new Map();
   const openedDbPaths = [];
@@ -1176,6 +1207,7 @@ test('settings rebuild keeps the existing database after a worker failure', asyn
   } finally {
     restore();
     process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalProfile;
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -1194,7 +1226,10 @@ test('settings rebuild cancels an in-flight background build instead of waiting 
   }));
 
   const originalHome = process.env.HOME;
+
+  const originalProfile = process.env.USERPROFILE;
   process.env.HOME = home;
+  process.env.USERPROFILE = home; // os.homedir() reads USERPROFILE on Windows
 
   const ipcHandlers = new Map();
   const serviceEvents = [];
@@ -1279,6 +1314,7 @@ test('settings rebuild cancels an in-flight background build instead of waiting 
   } finally {
     restore();
     process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalProfile;
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -1289,7 +1325,9 @@ test('settings changes during rebuild keep one watcher and re-enable with a catc
   writeFileSync(join(home, '.obelisk', 'obelisk.sqlite'), '');
   writeFileSync(join(home, '.obelisk', 'settings.json'), JSON.stringify({ autoRefresh: true }));
   const originalHome = process.env.HOME;
+  const originalProfile = process.env.USERPROFILE;
   process.env.HOME = home;
+  process.env.USERPROFILE = home; // os.homedir() reads USERPROFILE on Windows
 
   const ipcHandlers = new Map();
   const services = [];
@@ -1388,6 +1426,7 @@ test('settings changes during rebuild keep one watcher and re-enable with a catc
   } finally {
     restore();
     process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalProfile;
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -1395,10 +1434,12 @@ test('settings changes during rebuild keep one watcher and re-enable with a catc
 
 test('main process watches OBELISK_DIR as a tree target and debounces recap notifications', async () => {
   const originalHome = process.env.HOME;
+  const originalProfile = process.env.USERPROFILE;
   const home = makeTempDir(`obelisk-watch-retry-${Date.now()}`);
   mkdirSync(join(home, '.obelisk'), { recursive: true });
   writeFileSync(join(home, '.obelisk', 'obelisk.sqlite'), '');
   process.env.HOME = home;
+  process.env.USERPROFILE = home; // os.homedir() reads USERPROFILE on Windows
 
   let watcherOptions = null;
   const windows = [];
@@ -1473,6 +1514,7 @@ test('main process watches OBELISK_DIR as a tree target and debounces recap noti
     restore();
     mock.timers.reset();
     process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalProfile;
     rmSync(home, { recursive: true, force: true });
   }
 });

--- a/tests/core-watch-hints.test.mjs
+++ b/tests/core-watch-hints.test.mjs
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Tests for readRecentTranscriptHints (ADR-0009 hot-set seeding): hints are
+// the most recently written transcripts read from index_state — markers
+// excluded, missing keys dropped, directory unit keys (Kimi session dirs)
+// expanded to the transcripts they contain.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { join } from 'node:path';
+
+import { readRecentTranscriptHints } from '../packages/core/src/provider-indexing.ts';
+import { makeTempDir } from './temp-dirs.mjs';
+
+function fakeDb(rows) {
+  const captured = { sql: null };
+  const db = {
+    prepare(sql) {
+      captured.sql = sql;
+      return { all: (limit) => rows.slice(0, limit) };
+    },
+  };
+  return { db, captured };
+}
+
+test('hints are most-recent-first, markers excluded by the query', () => {
+  const root = makeTempDir('obelisk-hints-core-');
+  const fileA = join(root, 'a.jsonl');
+  const fileB = join(root, 'b.jsonl');
+  fs.writeFileSync(fileA, '{}\n');
+  fs.writeFileSync(fileB, '{}\n');
+  const { db, captured } = fakeDb([{ jsonl_path: fileB }, { jsonl_path: fileA }]);
+
+  const hints = readRecentTranscriptHints(db);
+  assert.deepEqual(hints, [fileB, fileA], 'rows arrive mtime-ordered from the query');
+  assert.match(captured.sql, /NOT LIKE/, 'marker rows are excluded in SQL');
+});
+
+test('missing keys are dropped and directory keys expand to contained transcripts', () => {
+  const root = makeTempDir('obelisk-hints-dir-');
+  const file = join(root, 'plain.jsonl');
+  fs.writeFileSync(file, '{}\n');
+  // A Kimi-style unit key: a session directory with a nested wire file.
+  const sessionDir = join(root, 'session-1');
+  const wire = join(sessionDir, 'agents', 'main', 'wire.jsonl');
+  fs.mkdirSync(join(sessionDir, 'agents', 'main'), { recursive: true });
+  fs.writeFileSync(wire, '{}\n');
+  const gone = join(root, 'deleted.jsonl');
+
+  const { db } = fakeDb([
+    { jsonl_path: file },
+    { jsonl_path: sessionDir },
+    { jsonl_path: gone },
+  ]);
+
+  const hints = readRecentTranscriptHints(db);
+  assert.ok(hints.includes(file), 'plain file keys pass through');
+  assert.ok(hints.includes(wire), 'a directory key expands to the wire transcript inside');
+  assert.ok(!hints.includes(sessionDir), 'the directory key itself is not a hint');
+  assert.ok(!hints.includes(gone), 'a key deleted after the build is dropped');
+});

--- a/tests/core-watch-hints.test.mjs
+++ b/tests/core-watch-hints.test.mjs
@@ -1,41 +1,51 @@
 // Copyright (C) 2026 tommy0103 and contributors.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Tests for readRecentTranscriptHints (ADR-0009 hot-set seeding): hints are
-// the most recently written transcripts read from index_state — markers
-// excluded, missing keys dropped, directory unit keys (Kimi session dirs)
-// expanded to the transcripts they contain.
+// Tests for readRecentTranscriptHints (ADR-0009 hot-set seeding). The SQL
+// semantics (mtime ordering, marker exclusion, LIMIT) run against a real
+// in-memory SQLite — a fake db with pre-ordered rows would pass even if the
+// ORDER BY were deleted. Directory expansion uses temp files.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 
 import { readRecentTranscriptHints } from '../packages/core/src/provider-indexing.ts';
 import { makeTempDir } from './temp-dirs.mjs';
 
-function fakeDb(rows) {
-  const captured = { sql: null };
-  const db = {
-    prepare(sql) {
-      captured.sql = sql;
-      return { all: (limit) => rows.slice(0, limit) };
-    },
-  };
-  return { db, captured };
+function hintsDb(rows) {
+  const db = new DatabaseSync(':memory:');
+  db.exec('CREATE TABLE index_state (jsonl_path TEXT, mtime INTEGER, lines_processed INTEGER, cursor TEXT)');
+  const insert = db.prepare('INSERT INTO index_state (jsonl_path, mtime, lines_processed) VALUES (?, ?, 0)');
+  for (const row of rows) insert.run(row.path, row.mtime);
+  return db;
 }
 
-test('hints are most-recent-first, markers excluded by the query', () => {
-  const root = makeTempDir('obelisk-hints-core-');
-  const fileA = join(root, 'a.jsonl');
-  const fileB = join(root, 'b.jsonl');
-  fs.writeFileSync(fileA, '{}\n');
-  fs.writeFileSync(fileB, '{}\n');
-  const { db, captured } = fakeDb([{ jsonl_path: fileB }, { jsonl_path: fileA }]);
+test('hints are the most recently written transcripts, markers excluded, limit honored', () => {
+  const root = makeTempDir('obelisk-hints-sql-');
+  // 70 real transcript files with shuffled mtimes, plus two marker rows
+  // whose Date.now() mtimes would sort first if markers leaked through.
+  const files = Array.from({ length: 70 }, (_, i) => {
+    const file = join(root, `session-${String(i).padStart(3, '0')}.jsonl`);
+    fs.writeFileSync(file, '{}\n');
+    return file;
+  });
+  const rows = files.map((path, i) => ({ path, mtime: (i * 37) % 70 }));
+  rows.push({ path: '__last_build__', mtime: Date.now() });
+  rows.push({ path: '__claude_canonical_transcript_v1__', mtime: Date.now() });
+  const db = hintsDb(rows);
 
   const hints = readRecentTranscriptHints(db);
-  assert.deepEqual(hints, [fileB, fileA], 'rows arrive mtime-ordered from the query');
-  assert.match(captured.sql, /NOT LIKE/, 'marker rows are excluded in SQL');
+  assert.equal(hints.length, 64, 'the hint limit applies');
+  assert.ok(hints.every((h) => !h.startsWith('__')), 'marker rows never leak into hints');
+  const mtimeOf = (file) => (files.indexOf(file) * 37) % 70;
+  const mtimes = hints.map(mtimeOf);
+  assert.deepEqual(mtimes, [...mtimes].sort((a, b) => b - a),
+    'hints arrive in non-increasing mtime order');
+  assert.equal(mtimes[0], 69, 'the most recently written transcript sorts first');
+  db.close();
 });
 
 test('missing keys are dropped and directory keys expand to contained transcripts', () => {
@@ -49,10 +59,10 @@ test('missing keys are dropped and directory keys expand to contained transcript
   fs.writeFileSync(wire, '{}\n');
   const gone = join(root, 'deleted.jsonl');
 
-  const { db } = fakeDb([
-    { jsonl_path: file },
-    { jsonl_path: sessionDir },
-    { jsonl_path: gone },
+  const db = hintsDb([
+    { path: file, mtime: 300 },
+    { path: sessionDir, mtime: 200 },
+    { path: gone, mtime: 100 },
   ]);
 
   const hints = readRecentTranscriptHints(db);
@@ -60,4 +70,35 @@ test('missing keys are dropped and directory keys expand to contained transcript
   assert.ok(hints.includes(wire), 'a directory key expands to the wire transcript inside');
   assert.ok(!hints.includes(sessionDir), 'the directory key itself is not a hint');
   assert.ok(!hints.includes(gone), 'a key deleted after the build is dropped');
+  db.close();
+});
+
+test('directory expansion ranks wire files by mtime, not readdir order', () => {
+  // A real Kimi session dir holds several wire files; the actively appended
+  // main wire is the most recently written one. DFS order would pick stale
+  // agent wires first and never seed the main transcript.
+  const root = makeTempDir('obelisk-hints-order-');
+  const sessionDir = join(root, 'session-9');
+  const mainDir = join(sessionDir, 'agents', 'main');
+  fs.mkdirSync(mainDir, { recursive: true });
+  const mainWire = join(mainDir, 'wire.jsonl');
+  fs.writeFileSync(mainWire, '{}\n');
+  const agentWires = [];
+  for (let i = 0; i < 7; i++) {
+    const wire = join(sessionDir, 'agents', `agent-${i}`, 'wire.jsonl');
+    fs.mkdirSync(join(sessionDir, 'agents', `agent-${i}`), { recursive: true });
+    fs.writeFileSync(wire, '{}\n');
+    agentWires.push(wire);
+  }
+  // agent-* wires sort before main in readdir order; give them all OLDER
+  // mtimes and make the main wire the newest.
+  const old = new Date('2026-08-01T00:00:00Z');
+  for (const wire of agentWires) fs.utimesSync(wire, old, old);
+  fs.utimesSync(mainWire, new Date(), new Date());
+
+  const db = hintsDb([{ path: sessionDir, mtime: 100 }]);
+  const hints = readRecentTranscriptHints(db);
+  assert.ok(hints.includes(mainWire), 'the actively written main wire is selected');
+  assert.ok(hints.length <= 4, 'directory expansion stays bounded');
+  db.close();
 });


### PR DESCRIPTION
Implements the second half of #87 (ADR-0009). **Stacked on #88** — base is `feat/adaptive-watcher`; retarget after the stack below merges. Stack: #83 (parcel swap + recovery/reconcile) → #88 (package + typed targets + exact-file poller) → this PR (hot-transcript overlay).

## Problem this closes

Verified on a live Codex tree (evidence: `docs/watcher-backend-options-research.md`): a transcript opened before subscription and appended through a long-lived fd produces **zero FSEvents until the fd closes** — for Node `fs.watch` recursive and @parcel/watcher alike. After #88, actively running sessions are only picked up by the 5-minute reconcile. This PR restores near-real-time indexing for them without returning to per-path fd cost.

## Change

**Package (`@obelisk-apps/adaptive-watcher`)**
- The PR A poller now covers a **bounded LRU hot set** alongside pinned `file` targets. `maxHotFiles` (default 64) is a hard cap; pinned entries never evict; hot evicts least-recently-active. Eviction is the ADR's deliberate degradation boundary — an evicted file that resumes appending is rediscovered by the next full reconcile and re-seeded via hints.
- `promote(path)` on the public interface; `initialHotFiles` seeds at creation; `shouldPromote(path)` lets the caller decide which native tree events enter the hot set (promotion happens **before** the invalidation is delivered — the catch-up build reads pre-promotion content, polling covers later appends). Eviction while a stat is in flight stays evicted — a late stat result never re-inserts a hot entry past the cap.
- Platform policy per ADR: the overlay defaults to **macOS only** (`hotPolling ?? platform === 'darwin'`); Linux/Windows stay on their native update path until the long-lived-writer matrix proves a need. The gate is injectable, and tests run both modes on every platform.

**Core + app wiring**
- `watchHints`: after a successful build, the 64 most recently written transcripts are read from `index_state` (file mtime per unit, markers excluded) via a shared `readRecentTranscriptHints` helper in `provider-indexing.ts` — returned by **both** build entry points: the core indexer (CLI path) and `app/src/main/indexer.ts` (the one the app worker actually calls), on both incremental and force paths. Unit keys are not always transcript files: Kimi's key is the session **directory**, whose mtime does not track appends to the wire files inside — so the helper (worker-side, where sync fs is allowed) drops keys missing at collection time and expands directory keys to their contained `.jsonl` transcripts **ranked by file mtime** (a real Kimi session dir holds ~8 wire files; readdir/DFS order would systematically pick stale agent wires and never seed the actively appended main wire). The manual `settings:rebuildIndex` path bypasses the service's build loop: on success the app seeds the recreated watcher's hot set from the rebuild's hints; on failure/deferral (no hints, old hot set gone with the old watcher) it schedules one reconciling build through the service — whose deferral retry absorbs writer-busy — instead of waiting out the 5-minute reconcile.
- A hot file that disappears reports once and **releases its slot** (recreation is a directory-level event and re-promotes it) — otherwise deleted transcripts would fill the hot set over the app's lifetime.
- `indexer-service` promotes hints after each build, oldest-first so the newest hint lands as MRU (hints arrive newest-first; naive insertion order would evict the freshest transcript first). `shouldPromote` is the transcript filter (`.jsonl`/`.json`); `hotPolling`/`watchPollMs` are test passthroughs. Debounce/stability, cursors, and reconcile are untouched.
- Two promotion semantics, deliberately different: **hint-promoted** files report their first observation (appends after the build finished are covered by no delivered signal — a redundant incremental build beats a missed event); **event-promoted** files baseline silently (the event itself delivered the change). `delete` events never promote — a removed transcript would hold a hot slot while permanently missing.

## Tests

Package level (`tests/adaptive-watcher.test.mjs`, runs in CI):
- Promotion baselines silently; later appends detected. Hot set never exceeds the cap; evicted files are never polled again; re-promotion refreshes LRU order. `shouldPromote` gates event-driven promotion. `hotPolling: false` makes `promote`/`initialHotFiles` no-ops with no poll timer at all.
- **Long-open-fd writer probe**: a real file opened before watching and appended through the still-open descriptor (fsync, no close — the production Codex write pattern) is detected within a few poll ticks while the (faked, silent) tree backend emits nothing.

Service level (`tests/app-indexer-watcher.test.mjs`): a build returning `watchHints` gets the hinted transcript promoted and polled — the test drains the report-first appearance builds before appending, so the assertion can only be satisfied by detecting the append itself; a separate test proves the full degradation loop: hot file evicted by 64 filler hints → appends no longer detected → a later reconcile hint re-seeds it → detected again.

Core level (`tests/core-watch-hints.test.mjs`): the SQL semantics run against a real in-memory SQLite (a fake db with pre-ordered rows would pass even without the ORDER BY) — mtime ordering, marker exclusion, LIMIT; missing keys dropped; directory keys expanded with **mtime-ranked** wire selection.

## Verification

- `npm test`: 488/488 on the final head (includes all pre-existing suites). `npm run typecheck` clean (root + app). Tracked-file lint: 0 errors. CI runs the package build plus package-, core-hints-, service-, and main-process-level watcher tests on all three platforms (with app dependencies installed for the module-mock harness); the real-FSEvents delivery tests first prove the subscription is live with a probe file before asserting, since CI runner event latency is unbounded.
- `test:electron:all`: 4/5, with the `electron-session-virtualization` failure reproduced identically on `origin/main` (pre-existing, tracked as #89).
- p95 ≤ 4s end-to-end is the ADR acceptance target for real workloads; the unit-level guarantee asserted here is detection within a few poll ticks (poll interval 1s in production).

## Out of scope

- Exact-file kqueue native overlay (only if measurement proves ~64 async stats/sec inadequate); Linux/Windows hot-overlay enablement; npm publication. Debounce tightening is #86.
