### PR TITLE
fix(app): emit schema in electron-vite main builds

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Verify CLI package and runtime contract
         run: node --experimental-test-module-mocks --test tests/cli-package.test.mjs tests/runtime-cli-envelope.test.mjs tests/runtime.test.mjs
 
+      - name: Verify Electron main schema asset
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+        run: |
+          npm --prefix app ci
+          node --test app/tests/electron-vite-schema-asset.mjs
+
       - name: Verify POSIX bootstrap installer
         if: runner.os != 'Windows'
         run: node --test tests/cli-bootstrap-install.test.mjs

--- a/app/electron-vite.schema-plugin.mjs
+++ b/app/electron-vite.schema-plugin.mjs
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_SCHEMA_URL = new URL('../packages/core/src/schema.sql', import.meta.url);
+
+export function coreSchemaAssetPlugin({ schemaUrl = DEFAULT_SCHEMA_URL } = {}) {
+  const schemaPath = fileURLToPath(schemaUrl);
+  return {
+    name: 'obelisk-core-schema-asset',
+    buildStart() {
+      this.addWatchFile(schemaPath);
+    },
+    async generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'schema.sql',
+        source: await readFile(schemaUrl, 'utf8'),
+      });
+    },
+  };
+}

--- a/app/electron.vite.config.ts
+++ b/app/electron.vite.config.ts
@@ -4,6 +4,7 @@
 import { resolve } from 'node:path';
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 import vue from '@vitejs/plugin-vue';
+import { coreSchemaAssetPlugin } from './electron-vite.schema-plugin.mjs';
 
 // The app main/preload/renderer are TypeScript + ESM. Each main-process module
 // is its own rollup input so it is emitted to out/main/<name>.js and the
@@ -11,7 +12,7 @@ import vue from '@vitejs/plugin-vue';
 // resolve to the built .js at runtime.
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [externalizeDepsPlugin(), coreSchemaAssetPlugin()],
     build: {
       rollupOptions: {
         input: {

--- a/app/tests/electron-vite-schema-asset.mjs
+++ b/app/tests/electron-vite-schema-asset.mjs
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+import { coreSchemaAssetPlugin } from '../electron-vite.schema-plugin.mjs';
+
+const appDir = fileURLToPath(new URL('..', import.meta.url));
+const electronViteCli = fileURLToPath(
+  new URL('../node_modules/electron-vite/bin/electron-vite.js', import.meta.url),
+);
+
+test('electron-vite builds emit the executable Core schema beside the main modules', async () => {
+  execFileSync(process.execPath, [electronViteCli, 'build'], {
+    cwd: appDir,
+    encoding: 'utf8',
+  });
+
+  const expected = await readFile(new URL('../../packages/core/src/schema.sql', import.meta.url), 'utf8');
+  const emitted = await readFile(new URL('../out/main/schema.sql', import.meta.url), 'utf8');
+  assert.equal(emitted, expected);
+});
+
+test('the Core schema asset participates in electron-vite dev rebuilds', async () => {
+  const watched = [];
+  const emitted = [];
+  const plugin = coreSchemaAssetPlugin();
+  const context = {
+    addWatchFile(path) { watched.push(path); },
+    emitFile(asset) { emitted.push(asset); },
+  };
+
+  plugin.buildStart.call(context);
+  await plugin.generateBundle.call(context);
+
+  assert.equal(watched.length, 1);
+  assert.equal(emitted[0]?.fileName, 'schema.sql');
+});


### PR DESCRIPTION
## Problem

Running `npm --prefix app run dev` built the Electron bundles, then the main process crashed with `ENOENT` for `app/out/main/schema.sql`. Bundled Core modules resolve `schema.sql` beside the emitted main modules, while the existing electron-builder `extraResources` copy only applies to packaged apps.

## Change

- Add an Electron Vite main-build plugin that emits the canonical Core schema as `out/main/schema.sql`.
- Add the schema source to Rollup's watch graph so dev rebuilds track schema changes.
- Add a real electron-vite build test that compares the emitted asset byte-for-byte with `packages/core/src/schema.sql`.
- Run the integration test on Linux, macOS, and Windows CI while skipping the unnecessary Electron binary download.

## Verification

- `npm test`: 465/465
- `node --test app/tests/electron-vite-schema-asset.mjs`: 2/2
- `npm run typecheck`: passed
- `npm run lint`: 0 errors (4 pre-existing warnings)
- `npm run dev`: emits `out/main/schema.sql` and starts Electron without the prior ENOENT