### PR TITLE
perf(app): make Activity usage stats index-backed

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -771,60 +771,49 @@ ipcMain.handle('db:getStats', (_, opts = {}) => {
 
 ipcMain.handle('db:getUsageStats', (_, opts = {}) => {
   if (!db) return { daily: [], totalTokens: 0, peakDay: null, longestTurn: null };
-  const sourceFilter = sourceWhereClause(opts, 'source');
-  const sourceSql = sourceFilter.sql ? `AND ${sourceFilter.sql}` : '';
-  const usageEvents = `
-    WITH usage_events AS (
-      SELECT timestamp, input_tokens, output_tokens, COALESCE(source, 'claude') AS source
-      FROM messages
-      UNION ALL
-      SELECT su.timestamp, su.input_tokens, su.output_tokens,
-             COALESCE(s.source, 'claude') AS source
-      FROM summaries su
-      LEFT JOIN sessions s ON s.id = su.session_id
-    )
-  `;
   // Visibility controls evidence display, not accounting. Abandoned model calls
   // still consumed tokens, so aggregate usage intentionally includes them.
-
-  const daily = db.prepare(`
-    ${usageEvents}
+  const messageSourceFilter = sourceWhereClause(opts, 'source');
+  const summarySourceFilter = sourceWhereClause(opts, 's.source');
+  const usageDays = db.prepare(`
+    WITH usage_events AS (
+      SELECT timestamp, input_tokens, output_tokens
+      FROM messages
+      WHERE (input_tokens IS NOT NULL OR output_tokens IS NOT NULL)
+        ${messageSourceFilter.sql ? `AND ${messageSourceFilter.sql}` : ''}
+      UNION ALL
+      SELECT su.timestamp, su.input_tokens, su.output_tokens
+      FROM summaries su
+      LEFT JOIN sessions s ON s.id = su.session_id
+      WHERE (su.input_tokens IS NOT NULL OR su.output_tokens IS NOT NULL)
+        ${summarySourceFilter.sql ? `AND ${summarySourceFilter.sql}` : ''}
+    )
     SELECT DATE(timestamp) as day,
            SUM(COALESCE(input_tokens,0) + COALESCE(output_tokens,0)) as tokens
     FROM usage_events
-    WHERE timestamp IS NOT NULL AND (input_tokens IS NOT NULL OR output_tokens IS NOT NULL)
-      ${sourceSql}
     GROUP BY DATE(timestamp)
     ORDER BY day
-  `).all(...sourceFilter.params);
+  `).all(...messageSourceFilter.params, ...summarySourceFilter.params);
 
-  const totalTokens = db.prepare(`
-    ${usageEvents}
-    SELECT SUM(COALESCE(input_tokens,0) + COALESCE(output_tokens,0)) as total
-    FROM usage_events
-    ${sourceFilter.sql ? `WHERE ${sourceFilter.sql}` : ''}
-  `).get(...sourceFilter.params)?.total || 0;
+  const totalTokens = usageDays.reduce((total, row) => total + (row.tokens || 0), 0);
+  const daily: Array<{ day: string; tokens: number }> = [];
+  for (const row of usageDays) {
+    if (row.day !== null) daily.push({ day: row.day, tokens: row.tokens || 0 });
+  }
 
-  const peakDay = db.prepare(`
-    ${usageEvents}
-    SELECT DATE(timestamp) as day,
-           SUM(COALESCE(input_tokens,0) + COALESCE(output_tokens,0)) as tokens
-    FROM usage_events
-    WHERE timestamp IS NOT NULL AND (input_tokens IS NOT NULL OR output_tokens IS NOT NULL)
-      ${sourceSql}
-    GROUP BY DATE(timestamp)
-    ORDER BY tokens DESC
-    LIMIT 1
-  `).get(...sourceFilter.params) || null;
+  let peakDay: { day: string; tokens: number } | null = null;
+  for (const day of daily) {
+    if (!peakDay || day.tokens > peakDay.tokens) peakDay = day;
+  }
 
   const longestTurn = db.prepare(`
     SELECT turn_duration_ms, uuid, session_id, timestamp
     FROM messages
     WHERE turn_duration_ms IS NOT NULL
-      ${sourceSql}
+      ${messageSourceFilter.sql ? `AND ${messageSourceFilter.sql}` : ''}
     ORDER BY turn_duration_ms DESC
     LIMIT 1
-  `).get(...sourceFilter.params) || null;
+  `).get(...messageSourceFilter.params) || null;
 
   return { daily, totalTokens, peakDay, longestTurn };
 });

--- a/packages/core/src/schema.sql
+++ b/packages/core/src/schema.sql
@@ -56,6 +56,12 @@ CREATE INDEX IF NOT EXISTS idx_messages_agent ON messages(agent_id);
 CREATE INDEX IF NOT EXISTS idx_messages_ts ON messages(session_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_messages_source ON messages(source);
+CREATE INDEX IF NOT EXISTS idx_messages_usage_day
+  ON messages(timestamp, COALESCE(source, 'claude'), input_tokens, output_tokens)
+  WHERE input_tokens IS NOT NULL OR output_tokens IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_messages_turn_duration
+  ON messages(turn_duration_ms DESC, COALESCE(source, 'claude'))
+  WHERE turn_duration_ms IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_tc_session_name ON tool_calls(session_id, name);
 CREATE INDEX IF NOT EXISTS idx_tc_message ON tool_calls(message_uuid);
 CREATE INDEX IF NOT EXISTS idx_tc_file ON tool_calls(file_path);

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -519,6 +519,12 @@ test('usage IPC aggregates normalized tokens across all indexed providers', asyn
       input_tokens, output_tokens, source
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run('codex-message', 'codex:session', 'assistant', '2026-07-10T11:00:00Z', 'assistant', 'ok', 100, 10, 'codex');
+  setup.prepare(`
+    INSERT INTO messages (
+      uuid, session_id, type, role, text,
+      input_tokens, output_tokens, source
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run('claude-undated-message', 'claude-session', 'assistant', 'assistant', 'ok', 7, 0, 'claude');
   setup.prepare('INSERT INTO sessions (id,source) VALUES (?,?)')
     .run('pi:session', 'pi');
   setup.prepare(`
@@ -598,11 +604,11 @@ test('usage IPC aggregates normalized tokens across all indexed providers', asyn
     assert.equal(ipcHandlers.get('db:getMessageFullText')(null, 'pi-hidden-main'), null);
 
     const claudeOnly = ipcHandlers.get('db:getUsageStats')(null, {});
-    assert.equal(claudeOnly.totalTokens, 65);
+    assert.equal(claudeOnly.totalTokens, 72);
     assert.equal(claudeOnly.daily[0].tokens, 65);
 
     const allSources = ipcHandlers.get('db:getUsageStats')(null, { source: 'all' });
-    assert.equal(allSources.totalTokens, 210);
+    assert.equal(allSources.totalTokens, 217);
     assert.equal(allSources.daily[0].tokens, 210);
     assert.equal(allSources.peakDay.tokens, 210);
 

--- a/tests/db-schema.test.mjs
+++ b/tests/db-schema.test.mjs
@@ -46,9 +46,29 @@ test('messages schema stores the raw content block type', async () => {
 
   assert.match(source, /content_type TEXT/);
   assert.match(source, /is_meta INTEGER DEFAULT 0/);
+  assert.match(source, /CREATE INDEX IF NOT EXISTS idx_messages_usage_day/);
+  assert.match(source, /CREATE INDEX IF NOT EXISTS idx_messages_turn_duration/);
   assert.match(source, /CREATE TRIGGER IF NOT EXISTS messages_fts_ai AFTER INSERT ON messages/);
   assert.match(source, /CREATE TRIGGER IF NOT EXISTS messages_fts_au AFTER UPDATE ON messages/);
   assert.match(source, /CREATE TRIGGER IF NOT EXISTS messages_fts_ad AFTER DELETE ON messages/);
+});
+
+test('usage indexes accept provider timestamps without normalizing them', async () => {
+  const db = new DatabaseSync(':memory:');
+  try {
+    db.exec(await readExecutableSchema());
+    db.prepare(`
+      INSERT INTO messages (uuid, timestamp, input_tokens, source)
+      VALUES (?, ?, ?, ?)
+    `).run('raw-timestamp', 'now', 1, 'claude');
+
+    assert.equal(
+      db.prepare("SELECT timestamp FROM messages WHERE uuid='raw-timestamp'").get().timestamp,
+      'now',
+    );
+  } finally {
+    db.close();
+  }
 });
 
 test('summaries preserve usage from provider-owned summary model calls', async () => {

--- a/tests/provider-schema-stability.test.mjs
+++ b/tests/provider-schema-stability.test.mjs
@@ -7,6 +7,6 @@ test('canonical transcript persistence schema changes only by explicit decision'
   const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url));
   assert.equal(
     createHash('sha256').update(schema).digest('hex'),
-    '0218f39cb41dabd055eed895cd08906d9f93a856fc2a30850d2d6cb8ee63e1cf',
+    '12c54c5a75f3feb6b3dcedca9377f45c7746ecbde3d210a2276c14fa7c875e6c',
   );
 });


### PR DESCRIPTION
## Summary

- Replace three repeated usage aggregates with one snapshot query, then derive lifetime and peak totals from the daily rows.
- Add partial covering indexes for token activity and longest-turn lookups.
- Preserve the existing treatment of undated token usage and accept raw provider timestamp strings.

## Scope

This PR only changes the `db:getUsageStats` query, its supporting indexes, and regression tests. It does not change the Activity renderer, provider indexing, background workers, caching, or other database queries.

## Schema decision

The schema change adds two non-destructive indexes. It does not change table layouts or rewrite indexed transcript rows. Existing databases build the indexes once through the current schema setup path; new and rebuilt databases create them with the rest of the schema.

On a local 2.4 GB database with 713,983 messages, the Activity query dropped from about 22.4 seconds to 0.14 seconds. The indexes use about 16.9 MB. Building them on that database took about 12 seconds once.

## Verification

- `npm test`: 409 passed
- `npm run typecheck`: passed
- `npm run lint`: 0 errors, 4 pre-existing warnings
- Production Electron build: passed
- `git diff --check`: passed
- New and old usage queries returned identical daily rows and lifetime totals on the benchmark database

`npm run test:electron:all` passed 4 of 5 local suites. `electron-session-virtualization.mjs` timed out while waiting for an existing SessionDetail timing assertion. The same timeout reproduces from a clean `origin/main` worktree, and this PR does not change renderer or SessionDetail code.
