### PR TITLE
fix(app): scope incremental project path refresh

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -280,10 +280,11 @@ function startIndexerService({ buildOnStart = false } = {}) {
   const service = createIndexerService({
     projectsDir: paths.projectsDir,
     watchDirs: paths.providerRegistry.watchRoots(paths.providerRoots),
-    buildIndex: async ({ reason, changedPaths }) => {
+    buildIndex: async ({ reason, changedPaths, retrySessionIds }) => {
       const result = await indexerWorker.buildIndex({
         reason,
         changedPaths,
+        retrySessionIds,
         providerRoots: paths.providerRoots,
         providerSettings: paths.providerSettings,
         claudeDir: paths.claudeDir,

--- a/app/src/main/indexer-service.ts
+++ b/app/src/main/indexer-service.ts
@@ -31,6 +31,7 @@ interface Watcher {
 interface IndexerBuildResult {
   deferred?: boolean;
   complete?: boolean;
+  affectedSessionIds?: string[];
   inventoryIssues?: Array<{
     provider: string;
     path: string;
@@ -41,6 +42,7 @@ interface IndexerBuildResult {
 type IndexerBuild = (args: {
   reason?: string;
   changedPaths?: string[];
+  retrySessionIds?: string[];
 }) => IndexerBuildResult | void | Promise<IndexerBuildResult | void>;
 
 interface IndexerServiceOptions {
@@ -147,6 +149,7 @@ function createIndexerService({
   let pending = false;
   let lastReason: string | null = null;
   let changedPaths = new Set<string>();
+  const deferredSessionIds = new Set<string>();
   let fullInventoryPending = false;
   let nextInventoryRetryMs = heartbeatMs;
   let idlePromise = Promise.resolve();
@@ -197,7 +200,19 @@ function createIndexerService({
     pending = false;
     const buildChangedPaths = takeChangedPaths();
     idlePromise = (async () => {
-      const result = await buildIndex({ reason, changedPaths: buildChangedPaths });
+      const retrySessionIds = [...deferredSessionIds];
+      const result = await buildIndex({
+        reason,
+        changedPaths: buildChangedPaths,
+        ...(retrySessionIds.length ? { retrySessionIds } : {}),
+      });
+      if (result?.deferred) {
+        for (const sessionId of result.affectedSessionIds ?? []) {
+          deferredSessionIds.add(sessionId);
+        }
+      } else {
+        deferredSessionIds.clear();
+      }
       if (result?.complete === false) {
         for (const issue of result.inventoryIssues ?? []) {
           logger.warn?.(

--- a/app/src/main/indexer.ts
+++ b/app/src/main/indexer.ts
@@ -146,8 +146,13 @@ function sessionIdFromChangedPath(projectsDir, changedPath) {
   return null;
 }
 
-function refreshSessionProjectPaths(db) {
-  const sessions = db.prepare('SELECT id, project FROM sessions').all();
+function refreshSessionProjectPaths(db, sessionIds: ReadonlySet<string> | null = null) {
+  const sessionById = db.prepare('SELECT id, project FROM sessions WHERE id = ?');
+  const sessions = sessionIds === null
+    ? db.prepare('SELECT id, project FROM sessions').all()
+    : [...sessionIds]
+      .map(sessionId => sessionById.get(sessionId))
+      .filter(Boolean);
   const cwdStmt = db.prepare(`
     SELECT cwd FROM messages
     WHERE session_id = ? AND cwd IS NOT NULL AND cwd != ''
@@ -241,6 +246,7 @@ interface BuildIndexOptions {
   LockDatabaseImpl?: new (dbPath: string) => any;
   force?: boolean;
   changedPaths?: string[];
+  retrySessionIds?: string[];
   preserveDbPath?: string | null;
   writerLeasePath?: string;
   writerLeaseWaitMs?: number;
@@ -301,6 +307,7 @@ function buildIndex({
   LockDatabaseImpl = DatabaseImpl,
   force = false,
   changedPaths = undefined,
+  retrySessionIds = [],
   preserveDbPath = null,
   writerLeasePath = writerLockPathFor(dbPath),
   writerLeaseWaitMs = 2000,
@@ -418,7 +425,10 @@ function buildIndex({
         for (const sessionId of unit.retractSessionIds ?? []) affectedSessionIds.add(sessionId);
       };
       const finalize = (providerResult) => {
-        refreshSessionProjectPaths(db);
+        const projectPathSessionIds = !force && Array.isArray(changedPaths)
+          ? new Set([...retrySessionIds, ...affectedSessionIds, ...finalizeAffectedSessionIds])
+          : null;
+        refreshSessionProjectPaths(db, projectPathSessionIds);
         healWorkflowParentLinks(db);
         if (messageFtsTriggersDropped) installSchema(db, schemaPath);
         ftsRebuilt = ensureFtsReady(db, { force });

--- a/tests/app-indexer-service.test.mjs
+++ b/tests/app-indexer-service.test.mjs
@@ -79,14 +79,16 @@ test('indexer service runs one pending build after an in-flight build finishes',
   assert.deepEqual(calls, ['first', 'pending']);
 });
 
-test('indexer service reschedules a writer-lease deferral without publishing a heartbeat', async () => {
+test('indexer service carries committed sessions across a deferred retry', async () => {
   const timers = manualTimers();
   const calls = [];
   let heartbeats = 0;
   const service = createIndexerService({
-    buildIndex: async ({ reason, changedPaths }) => {
-      calls.push({ reason, changedPaths });
-      return calls.length === 1 ? { deferred: true, reason: 'writer_busy' } : { deferred: false };
+    buildIndex: async (args) => {
+      calls.push(args);
+      return calls.length === 1
+        ? { deferred: true, reason: 'database_busy', affectedSessionIds: ['session-a'] }
+        : { deferred: false };
     },
     watchProjects: () => null,
     writeHeartbeat: () => { heartbeats += 1; },
@@ -102,9 +104,19 @@ test('indexer service reschedules a writer-lease deferral without publishing a h
   await service.idle();
   assert.deepEqual(calls, [
     { reason: 'watch', changedPaths: ['project/session.jsonl'] },
-    { reason: 'writer-lease', changedPaths: ['project/session.jsonl'] },
+    {
+      reason: 'writer-lease',
+      changedPaths: ['project/session.jsonl'],
+      retrySessionIds: ['session-a'],
+    },
   ]);
   assert.equal(heartbeats, 1);
+
+  await service.runBuildNow('manual', ['project/next.jsonl']);
+  assert.deepEqual(calls.at(-1), {
+    reason: 'manual',
+    changedPaths: ['project/next.jsonl'],
+  });
 });
 
 test('a deferred full-inventory build stays full when retried', async () => {

--- a/tests/app-indexer.test.mjs
+++ b/tests/app-indexer.test.mjs
@@ -64,6 +64,16 @@ test('app indexer records build success without claiming daemon ownership', () =
   assert.equal(db.prepare("SELECT jsonl_path FROM index_state WHERE jsonl_path='__app_heartbeat__'").get(), undefined);
   assert.equal(db.prepare("SELECT jsonl_path FROM index_state WHERE jsonl_path='__app_last_successful_build__'").get().jsonl_path, '__app_last_successful_build__');
   assert.equal(db.prepare('SELECT project_path FROM sessions WHERE id=?').get(sessionId).project_path, '/tmp/obelisk-app');
+  db.prepare('UPDATE sessions SET project_path=? WHERE id=?').run('/tmp/stale-affected', sessionId);
+  db.prepare('INSERT INTO sessions (id,project,project_path,source) VALUES (?,?,?,?)')
+    .run('session-app-unaffected', '-tmp-unaffected', '/tmp/stale-unaffected', 'claude');
+  db.prepare(`
+    INSERT INTO messages (uuid,session_id,type,timestamp,role,text,content_type,cwd,source)
+    VALUES (?,?,?,?,?,?,?,?,?)
+  `).run(
+    'msg-app-unaffected', 'session-app-unaffected', 'user', '2026-06-13T09:00:00Z',
+    'user', 'unrelated session', 'text', '/tmp/unaffected', 'claude',
+  );
   db.close();
 
   appendFileSync(jsonlPath, [
@@ -90,7 +100,36 @@ test('app indexer records build success without claiming daemon ownership', () =
   const db2 = new TestDatabase(dbPath);
   assert.equal(db2.prepare("SELECT uuid FROM messages_fts WHERE messages_fts MATCH 'companion'").get().uuid, 'msg-app-2');
   assert.equal(db2.prepare('SELECT message_count FROM sessions WHERE id=?').get(sessionId).message_count, 2);
+  assert.equal(db2.prepare('SELECT project_path FROM sessions WHERE id=?').get(sessionId).project_path, '/tmp/obelisk-app');
+  assert.equal(
+    db2.prepare('SELECT project_path FROM sessions WHERE id=?').get('session-app-unaffected').project_path,
+    '/tmp/stale-unaffected',
+  );
   db2.close();
+
+  buildIndex({
+    claudeDir,
+    dbPath,
+    DatabaseImpl: TestDatabase,
+    changedPaths: [],
+    retrySessionIds: ['session-app-unaffected'],
+  });
+  const retryDb = new TestDatabase(dbPath);
+  assert.equal(
+    retryDb.prepare('SELECT project_path FROM sessions WHERE id=?').get('session-app-unaffected').project_path,
+    '/tmp/unaffected',
+  );
+  retryDb.prepare('UPDATE sessions SET project_path=? WHERE id=?')
+    .run('/tmp/stale-unaffected', 'session-app-unaffected');
+  retryDb.close();
+
+  buildIndex({ claudeDir, dbPath, DatabaseImpl: TestDatabase });
+  const repairedDb = new TestDatabase(dbPath);
+  assert.equal(
+    repairedDb.prepare('SELECT project_path FROM sessions WHERE id=?').get('session-app-unaffected').project_path,
+    '/tmp/unaffected',
+  );
+  repairedDb.close();
 });
 
 test('app indexer refreshes unchanged Claude usage when input token semantics change', () => {


### PR DESCRIPTION
## Summary

- refresh project paths only for sessions affected by an incremental app-indexer build
- carry committed session IDs across a deferred finalize retry so lock contention cannot leave stale paths behind
- preserve database-wide repair for startup, full-inventory, and force builds

## Scope

This only changes app-side project-path refresh scoping and the retry state required to keep it correct. UI behavior, FTS, provider parsing, session patches, and CLI indexing are unchanged.

## Validation

- 384 tests passed
- TypeScript checks passed
- ESLint passed with no errors; four existing warnings remain
- two independent blind-review rounds completed; the second round had no actionable findings