### PR TITLE
perf(app): bound main session detail reads

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -514,19 +514,23 @@ function querySessionMessages(sessionId: string): SessionMessageRow[] {
 function querySessionToolCalls(sessionId: string): SessionToolCallRow[] {
   if (!db) return [];
   return db.prepare(`
-    SELECT tc.* FROM tool_calls tc
-    JOIN messages m ON m.uuid = tc.message_uuid
-    WHERE tc.session_id = ? AND COALESCE(m.visibility, 'visible') = 'visible'
-  `).all(sessionId) as SessionToolCallRow[];
+    SELECT tc.* FROM messages m
+    CROSS JOIN tool_calls tc ON tc.message_uuid = m.uuid
+    WHERE m.session_id = ? AND m.agent_id IS NULL
+      AND COALESCE(m.visibility, 'visible') = 'visible'
+      AND tc.session_id = ?
+  `).all(sessionId, sessionId) as SessionToolCallRow[];
 }
 
 function querySessionToolResults(sessionId: string): SessionToolResultRow[] {
   if (!db) return [];
   return db.prepare(`
-    SELECT tr.* FROM tool_results tr
-    JOIN messages m ON m.uuid = tr.message_uuid
-    WHERE tr.session_id = ? AND COALESCE(m.visibility, 'visible') = 'visible'
-  `).all(sessionId) as SessionToolResultRow[];
+    SELECT tr.* FROM messages m
+    CROSS JOIN tool_results tr ON tr.message_uuid = m.uuid
+    WHERE m.session_id = ? AND m.agent_id IS NULL
+      AND COALESCE(m.visibility, 'visible') = 'visible'
+      AND tr.session_id = ?
+  `).all(sessionId, sessionId) as SessionToolResultRow[];
 }
 
 function querySessionSubagents(sessionId: string): SessionSubagentRow[] {

--- a/packages/core/src/schema.sql
+++ b/packages/core/src/schema.sql
@@ -57,6 +57,9 @@ END;
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);
 CREATE INDEX IF NOT EXISTS idx_messages_agent ON messages(agent_id);
 CREATE INDEX IF NOT EXISTS idx_messages_ts ON messages(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_messages_main_timeline
+  ON messages(session_id, timestamp, uuid)
+  WHERE agent_id IS NULL AND COALESCE(visibility, 'visible') = 'visible';
 CREATE INDEX IF NOT EXISTS idx_messages_time ON messages(timestamp);
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_messages_source ON messages(source);

--- a/tests/app-main-settings.test.mjs
+++ b/tests/app-main-settings.test.mjs
@@ -589,6 +589,16 @@ test('usage IPC aggregates normalized tokens across all indexed providers', asyn
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run('pi-hidden-agent', 'pi:session', 'assistant', 'assistant', 'inactive agent', '2026-07-10T12:02:00Z', 'inactive', 'pi', 'pi:hidden-agent');
   setup.prepare(`
+    INSERT INTO messages (
+      uuid, session_id, type, role, text, timestamp, visibility, source
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run('pi-visible-main', 'pi:session', 'assistant', 'assistant', 'visible main', '2026-07-10T12:03:00Z', 'visible', 'pi');
+  setup.prepare(`
+    INSERT INTO messages (
+      uuid, session_id, type, role, text, timestamp, visibility, source, agent_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run('pi-visible-agent', 'pi:session', 'assistant', 'assistant', 'visible agent', '2026-07-10T12:04:00Z', 'visible', 'pi', 'pi:visible-agent');
+  setup.prepare(`
     INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json)
     VALUES (?, ?, ?, ?, ?)
   `).run('pi-hidden-main-call', 'pi-hidden-main', 'pi:session', 'read', '{"path":"secret"}');
@@ -597,6 +607,14 @@ test('usage IPC aggregates normalized tokens across all indexed providers', asyn
     VALUES (?, ?, ?, ?, ?)
   `).run('pi-hidden-agent-call', 'pi-hidden-agent', 'pi:session', 'read', '{"path":"secret"}');
   setup.prepare(`
+    INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json)
+    VALUES (?, ?, ?, ?, ?)
+  `).run('pi-visible-main-call', 'pi-visible-main', 'pi:session', 'read', '{"path":"main"}');
+  setup.prepare(`
+    INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json)
+    VALUES (?, ?, ?, ?, ?)
+  `).run('pi-visible-agent-call', 'pi-visible-agent', 'pi:session', 'read', '{"path":"agent"}');
+  setup.prepare(`
     INSERT INTO tool_results (tool_use_id, message_uuid, session_id, content)
     VALUES (?, ?, ?, ?)
   `).run('pi-hidden-main-call', 'pi-hidden-main', 'pi:session', 'hidden result');
@@ -604,6 +622,14 @@ test('usage IPC aggregates normalized tokens across all indexed providers', asyn
     INSERT INTO tool_results (tool_use_id, message_uuid, session_id, content)
     VALUES (?, ?, ?, ?)
   `).run('pi-hidden-agent-call', 'pi-hidden-agent', 'pi:session', 'hidden result');
+  setup.prepare(`
+    INSERT INTO tool_results (tool_use_id, message_uuid, session_id, content)
+    VALUES (?, ?, ?, ?)
+  `).run('pi-visible-main-call', 'pi-visible-main', 'pi:session', 'main result');
+  setup.prepare(`
+    INSERT INTO tool_results (tool_use_id, message_uuid, session_id, content)
+    VALUES (?, ?, ?, ?)
+  `).run('pi-visible-agent-call', 'pi-visible-agent', 'pi:session', 'agent result');
   setup.close();
 
   const ipcHandlers = new Map();
@@ -643,12 +669,36 @@ test('usage IPC aggregates normalized tokens across all indexed providers', asyn
     await importMain();
 
     assert.deepEqual(ipcHandlers.get('db:getSessionSummaries')(null, 'pi:session'), []);
-    assert.deepEqual(ipcHandlers.get('db:getSessionMessages')(null, 'pi:session'), []);
-    assert.deepEqual(ipcHandlers.get('db:getSessionToolCalls')(null, 'pi:session'), []);
-    assert.deepEqual(ipcHandlers.get('db:getSessionToolResults')(null, 'pi:session'), []);
+    assert.deepEqual(
+      ipcHandlers.get('db:getSessionMessages')(null, 'pi:session').map(row => row.uuid),
+      ['pi-visible-main'],
+    );
+    assert.deepEqual(
+      ipcHandlers.get('db:getSessionToolCalls')(null, 'pi:session').map(row => row.id),
+      ['pi-visible-main-call'],
+    );
+    assert.deepEqual(
+      ipcHandlers.get('db:getSessionToolResults')(null, 'pi:session').map(row => row.tool_use_id),
+      ['pi-visible-main-call'],
+    );
     assert.deepEqual(ipcHandlers.get('db:getSubagentMessages')(null, 'pi:hidden-agent'), []);
     assert.deepEqual(ipcHandlers.get('db:getSubagentToolCalls')(null, 'pi:hidden-agent'), []);
     assert.deepEqual(ipcHandlers.get('db:getSubagentToolResults')(null, 'pi:hidden-agent'), []);
+    assert.deepEqual(
+      ipcHandlers.get('db:getSubagentMessages')(null, 'pi:visible-agent').map(row => row.uuid),
+      ['pi-visible-agent'],
+    );
+    assert.deepEqual(
+      ipcHandlers.get('db:getSubagentToolCalls')(null, 'pi:visible-agent').map(row => row.id),
+      ['pi-visible-agent-call'],
+    );
+    assert.deepEqual(
+      ipcHandlers.get('db:getSubagentToolResults')(null, 'pi:visible-agent').map(row => row.tool_use_id),
+      ['pi-visible-agent-call'],
+    );
+    const patch = ipcHandlers.get('db:getSessionPatch')(null, 'pi:session', {});
+    assert.equal(patch.changes.messages[0].tool_calls[0].result.content, 'main result');
+    assert.equal(JSON.stringify(patch).includes('agent result'), false);
     assert.equal(ipcHandlers.get('db:getMessageFullText')(null, 'pi-hidden-main'), null);
 
     const claudeOnly = ipcHandlers.get('db:getUsageStats')(null, {});

--- a/tests/db-schema.test.mjs
+++ b/tests/db-schema.test.mjs
@@ -127,6 +127,54 @@ test('tool results schema indexes live session patch lookups', async () => {
   }
 });
 
+test('session detail queries use the visible main timeline index', async () => {
+  const db = new DatabaseSync(':memory:');
+  try {
+    db.exec(await readExecutableSchema());
+    const messagePlan = db.prepare(`
+      EXPLAIN QUERY PLAN
+      SELECT m.uuid FROM messages m
+      WHERE m.session_id = ? AND m.agent_id IS NULL
+        AND COALESCE(m.visibility, 'visible') = 'visible'
+      ORDER BY m.timestamp, m.uuid
+    `).all('session-1');
+    const toolCallPlan = db.prepare(`
+      EXPLAIN QUERY PLAN
+      SELECT tc.* FROM messages m
+      CROSS JOIN tool_calls tc ON tc.message_uuid = m.uuid
+      WHERE m.session_id = ? AND m.agent_id IS NULL
+        AND COALESCE(m.visibility, 'visible') = 'visible'
+        AND tc.session_id = ?
+    `).all('session-1', 'session-1');
+    const toolResultPlan = db.prepare(`
+      EXPLAIN QUERY PLAN
+      SELECT tr.* FROM messages m
+      CROSS JOIN tool_results tr ON tr.message_uuid = m.uuid
+      WHERE m.session_id = ? AND m.agent_id IS NULL
+        AND COALESCE(m.visibility, 'visible') = 'visible'
+        AND tr.session_id = ?
+    `).all('session-1', 'session-1');
+
+    const details = plan => plan.map(row => String(row.detail));
+    assert.ok(
+      details(messagePlan).some(detail => /USING INDEX idx_messages_main_timeline/.test(detail)),
+      `expected main timeline index, got: ${details(messagePlan).join('; ')}`,
+    );
+    assert.ok(
+      /USING INDEX idx_messages_main_timeline/.test(details(toolCallPlan)[0])
+        && details(toolCallPlan).some(detail => /USING INDEX idx_tc_message/.test(detail)),
+      `expected main-timeline-first tool call lookup, got: ${details(toolCallPlan).join('; ')}`,
+    );
+    assert.ok(
+      /USING INDEX idx_messages_main_timeline/.test(details(toolResultPlan)[0])
+        && details(toolResultPlan).some(detail => /USING INDEX idx_tr_message/.test(detail)),
+      `expected main-timeline-first tool result lookup, got: ${details(toolResultPlan).join('; ')}`,
+    );
+  } finally {
+    db.close();
+  }
+});
+
 test('tool payload schema indexes subagent joins and guardian retractions', async () => {
   const db = new DatabaseSync(':memory:');
   try {

--- a/tests/provider-schema-stability.test.mjs
+++ b/tests/provider-schema-stability.test.mjs
@@ -12,8 +12,8 @@ test('canonical transcript persistence schema changes only by explicit decision'
   const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url));
   assert.equal(
     createHash('sha256').update(schema).digest('hex'),
-    // 2026-08-24: indexed usage-day and longest-turn Activity queries.
-    'a3ddd5450fcf3e0bb481fcd75c3a988dea430647548c8736523769ce1046d2d3',
+    // 2026-08-24: indexed Activity queries and the visible main session timeline.
+    '0417d1a044a574a9adc8f347db5f46428a984e89900504bb082ce7366ebb1d4a',
   );
 });
 


### PR DESCRIPTION
## What and why

Large session-detail reads loaded tool calls and results for every agent in the parent session, even though assembly later discarded child-agent rows. On long sessions this inflated both cold-open IPC payloads and every live-patch snapshot, while the main message query also scanned child-agent history.

This PR keeps the change at the SQL boundary:

- scope parent timeline tools to visible main-session messages, without changing the dedicated subagent detail queries
- drive tool joins from the indexed visible main timeline so child-agent volume does not dominate parent reads
- add a partial index for the ordered visible main timeline

On the two heaviest local sessions, the estimated SQL text payload dropped from 62.3 MiB to 30.2 MiB and from 121.6 MiB to 43.9 MiB. The rendered timeline contract and patch format are unchanged.

## Verification

- [x] `npm test` — 506 pass / 0 fail
- [x] `npm run typecheck` — 0 errors, root and app
- [x] `npm run lint` — 0 errors; 9 warnings
- [x] Focused IPC, schema, and query-plan tests — 30 pass / 0 fail
- [x] Synthetic fresh-DB check with 10 main and 10,000 child tool rows confirms the tool queries use the main-timeline and message lookup indexes
- [ ] `npm run test:electron:all` — 4/5 suites pass. The unchanged `electron-session-virtualization.mjs` suite timed out at two different existing wait probes across retries. It registers its own IPC handlers and does not load the modified main-process query path; no renderer files changed.
- [x] New regression and query-plan tests run under the existing `tests/*.test.mjs` CI command
- [x] No existing assertion was loosened
- [x] Cold IPC and live-patch behavior are exercised through the registered main-process handlers against SQLite
- [x] Re-ran the checks on the current head after resolving the latest-main conflict and review findings

## Deliberately out of scope

- pagination or lazy loading of timeline/tool content
- renderer, preload, or patch-contract changes
- changes to subagent detail behavior
- moving the existing synchronous SQLite IPC layer to a worker

<details>
<summary><b>Schema / migration</b></summary>

- [x] Updated the schema hash with an explicit index justification
- [x] The migration is additive and idempotent through `CREATE INDEX IF NOT EXISTS`
- [x] No destructive DDL or external input is involved

</details>

<details>
<summary><b>Main process / untrusted input</b></summary>

- [x] No path, file-read, HTML, navigation, or interception behavior changed
- [x] No new main or preload source was added
- [ ] The existing `better-sqlite3` IPC remains synchronous; this PR narrows and indexes that existing work rather than introducing a second execution architecture

</details>