### PR TITLE
docs(skill): require writable fresh index in sandboxes

### DIFF
--- a/skill-doc/SKILL.md
+++ b/skill-doc/SKILL.md
@@ -29,6 +29,25 @@ Obelisk is a CodeAct memory layer: write a small JS query, run it locally, read
 the JSON, then answer. Do not turn history into a flat document or browse entire
 sessions by default.
 
+## Fresh Index and Sandbox Permissions
+
+Treat a successful Obelisk invocation as a precondition for using its results.
+Obelisk refreshes `~/.obelisk/obelisk.sqlite` before retrieval so the answer
+includes the latest sessions and can identify the invoking session. Never
+degrade to a stale, read-only index when that refresh cannot write.
+
+In Codex `workspace-write` or managed sandboxes, `~/.obelisk` may be outside the
+writable roots. If an Obelisk command fails with `SQLITE_READONLY`, `EACCES`,
+`EPERM`, `attempt to write a readonly database`, or another permission error for
+`~/.obelisk`, rerun the same command with
+`sandbox_permissions: "require_escalated"`. On another agent host, use its
+equivalent mechanism to grant write access to `~/.obelisk`. Do not replace the
+failed command with direct SQLite, JSONL, or stale-index reads.
+
+If write access is unavailable or the user denies escalation, stop and report
+the permission blocker. Retrieval is complete only when the Obelisk command
+exits successfully and returns its query result.
+
 ## Quick Start
 
 Fast keyword search (pass a unique nonce so Obelisk can recognize your own

--- a/tests/skill-doc-artifact.test.mjs
+++ b/tests/skill-doc-artifact.test.mjs
@@ -30,6 +30,8 @@ test('build:skill produces a docs-only skill that delegates execution to the CLI
   assert.match(skill, /Bash\(obelisk:\*\)/);
   assert.match(skill, /obelisk --query "\$qfile"/);
   assert.match(skill, /obelisk --attune \/tmp\/register-memory\.mjs/);
+  assert.match(skill, /sandbox_permissions: "require_escalated"/);
+  assert.match(skill, /Never\s+degrade to a stale, read-only index/);
   assert.doesNotMatch(skill, /\$SKILL_DIR\/scripts\/runtime\.js/);
   assert.doesNotMatch(`${skill}\n${schema}`, /scripts\//);
 });


### PR DESCRIPTION
## Summary

- make fresh index publication a prerequisite for Obelisk retrieval
- require Codex sandbox escalation when `~/.obelisk` is outside writable roots
- forbid stale-index, direct SQLite, or raw JSONL fallbacks
- lock the contract into the built skill artifact test

## Verification

- `node --test tests/skill-doc-artifact.test.mjs`
- `npm run build:skill`