### PR TITLE
fix(core): Claude cursor must not count a torn unterminated tail line

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Verify adaptive watcher package
         run: |
           npm run build --workspace @obelisk-apps/adaptive-watcher
-          node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs tests/app-main-settings.test.mjs
+          node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/claude-parse.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs tests/app-main-settings.test.mjs
 
       - name: Verify POSIX bootstrap installer
         if: runner.os != 'Windows'

--- a/packages/core/src/parsing.ts
+++ b/packages/core/src/parsing.ts
@@ -113,7 +113,7 @@ function filePath(name: string, input: JsonRecord | null | undefined): string | 
 
 function isDir(p: string): boolean { try { return statSync(p).isDirectory(); } catch { return false; } }
 
-function readLines(filePath: string, callback: (line: string) => boolean | void): void {
+function readLines(filePath: string, callback: (line: string, terminated: boolean) => boolean | void): void {
   const fd = openSync(filePath, 'r');
   const bufSize = 64 * 1024;
   const buf = Buffer.alloc(bufSize);
@@ -125,10 +125,13 @@ function readLines(filePath: string, callback: (line: string) => boolean | void)
       lines[0] = remainder + lines[0];
       remainder = lines.pop() ?? '';
       for (const line of lines) {
-        if (line && callback(line) === false) return;
+        if (line && callback(line, true) === false) return;
       }
     }
-    if (remainder) callback(remainder);
+    // `terminated: false` — the final chunk had no trailing newline, so this
+    // tail may still be growing (or may simply be an unterminated last line;
+    // the caller cannot tell, and must decide what that means).
+    if (remainder) callback(remainder, false);
   } finally {
     closeSync(fd);
   }

--- a/packages/core/src/provider-indexing.ts
+++ b/packages/core/src/provider-indexing.ts
@@ -120,7 +120,7 @@ export function readRecentTranscriptHints(db: SqliteDb, limit = WATCH_HINT_LIMIT
   for (const row of rows) {
     if (hints.length >= limit) break;
     const key = String(row.jsonl_path);
-    let isDirectory = false;
+    let isDirectory: boolean;
     try {
       isDirectory = statSync(key).isDirectory();
     } catch {

--- a/packages/core/src/providers/claude.ts
+++ b/packages/core/src/providers/claude.ts
@@ -37,6 +37,21 @@ function cursorToSkip(cursor: Cursor): number {
   return Number.isFinite(n) ? n : 0;
 }
 
+// Cursor format: `${mtime}:${lines}:${size}:${ctimeMs}:${ino}`. The
+// mtime+ctime+size+inode signature (CONTRIBUTING: cursors must detect
+// same-millisecond rewrites) lets a same-mtime tail completion or a
+// same-mtime replacement back into discovery. Legacy `${mtime}:${lines}`
+// cursors keep the mtime-only gate and upgrade on the next parse.
+function cursorSignatureDiffers(cursor: string, filePath: string): boolean {
+  const stat = statSync(filePath);
+  const parts = cursor.split(':');
+  if (parts.length < 5) return Number(parts[0]) < stat.mtimeMs;
+  return Number(parts[0]) !== stat.mtimeMs
+    || Number(parts[2]) !== stat.size
+    || Number(parts[3]) !== stat.ctimeMs
+    || Number(parts[4]) !== stat.ino;
+}
+
 export const name = 'claude';
 export const CLAUDE_CANONICAL_TRANSCRIPT_MARKER = '__claude_canonical_transcript_v2__';
 
@@ -108,7 +123,7 @@ function discoverAt(rootDir: string, ctx: DiscoverContext): IndexUnit[] {
     return historyChanged
       || forcedPaths.has(normalizedPath)
       || cursor === null
-      || Number(cursor.split(':')[0]) < statSync(file.path).mtimeMs;
+      || cursorSignatureDiffers(cursor, file.path);
   }).map((f: any) => ({
     key: f.path,
     sessionId: f.sessionId,
@@ -262,7 +277,8 @@ export function* parse(unit: IndexUnit, cursor: Cursor): Generator<TranscriptRec
     return yield* parseWorkflow(unit);
   }
   const skip = cursorToSkip(cursor);
-  const mtime = statSync(unit.key).mtimeMs;
+  const stat = statSync(unit.key);
+  const mtime = stat.mtimeMs;
   const isSubagent = unit.isSubagent === true;
   const records: TranscriptRecord[] = [];
   const sm = {
@@ -400,7 +416,7 @@ export function* parse(unit: IndexUnit, cursor: Cursor): Generator<TranscriptRec
   }
 
   yield* records;
-  return `${mtime}:${cursorLines}`;
+  return `${mtime}:${cursorLines}:${stat.size}:${stat.ctimeMs}:${stat.ino}`;
 }
 
 function rawClaude(input: RawLookup): RawRecord | null {

--- a/packages/core/src/providers/claude.ts
+++ b/packages/core/src/providers/claude.ts
@@ -280,10 +280,18 @@ export function* parse(unit: IndexUnit, cursor: Cursor): Generator<TranscriptRec
   };
 
   let lineNum = 0;
-  readLines(unit.key, (line: string) => {
+  // Lines the cursor may safely skip on the next parse. A line only counts
+  // when it parsed, or when it is newline-terminated (mid-file garbage keeps
+  // the legacy count). An unterminated tail that fails to parse may still be
+  // growing — counting it would permanently skip the completed line.
+  let cursorLines = 0;
+  readLines(unit.key, (line: string, terminated: boolean) => {
     lineNum++;
     let obj: any;
-    try { obj = JSON.parse(line); } catch { return; }
+    let parsed = true;
+    try { obj = JSON.parse(line); } catch { parsed = false; }
+    if (parsed || terminated) cursorLines = lineNum;
+    if (!parsed) return;
     const sid = unit.sessionId;
     const ts = obj.timestamp || null;
     const msg = obj.message || {};
@@ -392,7 +400,7 @@ export function* parse(unit: IndexUnit, cursor: Cursor): Generator<TranscriptRec
   }
 
   yield* records;
-  return `${mtime}:${lineNum}`;
+  return `${mtime}:${cursorLines}`;
 }
 
 function rawClaude(input: RawLookup): RawRecord | null {

--- a/tests/claude-parse.test.mjs
+++ b/tests/claude-parse.test.mjs
@@ -7,7 +7,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, readFileSync, writeFileSync, statSync } from 'node:fs';
+import { mkdirSync, readFileSync, utimesSync, writeFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
@@ -81,8 +81,9 @@ test('claude parse() yields the expected record stream for a main session', () =
   assert.deepEqual(detail.messages.map((message) => message.text), ['hi', 'ok']);
   assert.equal(detail.messages[1].tool_calls[0].result.content, 'file body');
 
-  // Cursor encodes mtime:lines (6 lines consumed).
-  assert.equal(ret, `${statSync(path).mtimeMs}:6`);
+  // Cursor encodes mtime:lines:signature (6 lines consumed).
+  const stat = statSync(path);
+  assert.equal(ret, `${stat.mtimeMs}:6:${stat.size}:${stat.ctimeMs}:${stat.ino}`);
 });
 
 test('claude parse() emits no session record for a subagent transcript', () => {
@@ -265,4 +266,70 @@ test('a legal unterminated final JSON line advances the Claude cursor', () => {
   writeFileSync(path, `${head.join('\n')}\n${COMPLETED_TAIL}`);
   const { ret } = drain(parse({ key: path, sessionId: 'sid-torn' }, null));
   assert.equal(ret.split(':')[1], '3', 'a parseable unterminated final line is counted');
+});
+
+
+// ---- cursor signature: same-millisecond recovery through discover ----
+// The production self-heal path is discover → parse, not parse alone: after a
+// torn parse, the completed tail must be reselected even when the file's
+// mtime did not move (same-millisecond append, coarse or network filesystems).
+
+test('a same-mtime tail completion is rediscovered through the cursor signature', () => {
+  const root = makeTempDir('obelisk-claude-signature-');
+  const projectDir = join(root, 'projects', '-proj');
+  mkdirSync(projectDir, { recursive: true });
+  const path = join(projectDir, 'sid-torn.jsonl');
+  const head = [
+    JSON.stringify({ uuid: 'u1', type: 'user', timestamp: '2026-06-10T10:00:00Z', message: { role: 'user', content: 'hi' } }),
+    JSON.stringify({ uuid: 'a1', type: 'assistant', timestamp: '2026-06-10T10:00:05Z', message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }] } }),
+  ];
+  writeFileSync(path, `${head.join('\n')}\n{"uuid":"u2","type":"user","mes`);
+  const provider = createClaudeProvider({ rootDir: root });
+
+  // First production cycle: discover → parse the torn file.
+  let units = provider.discover({ lastCursor: () => null });
+  assert.equal(units.length, 1);
+  const tornCursor = drain(provider.parse(units[0], null)).ret;
+  assert.equal(tornCursor.split(':')[1], '2', 'the torn tail is not counted');
+
+  // The writer completes the line with the mtime pinned to the parse-time
+  // value — an mtime-only gate would never reselect this file.
+  writeFileSync(path, `${head.join('\n')}\n${COMPLETED_TAIL}\n`);
+  const pinnedMtime = new Date(Number(tornCursor.split(':')[0]));
+  utimesSync(path, pinnedMtime, pinnedMtime);
+
+  // The signature (size/ctime moved) reselects it anyway, and the completed
+  // line is indexed exactly once through the full discover → parse cycle.
+  units = provider.discover({ lastCursor: () => tornCursor });
+  assert.equal(units.length, 1, 'a same-mtime completion is rediscovered');
+  const healed = drain(provider.parse(units[0], tornCursor));
+  assert.equal(
+    healed.values.filter((r) => r.kind === 'message' && r.uuid === 'u2').length,
+    1,
+    'the completed line is indexed exactly once',
+  );
+});
+
+test('a legacy two-part cursor keeps the mtime-only gate until it upgrades', () => {
+  const root = makeTempDir('obelisk-claude-legacy-cursor-');
+  const projectDir = join(root, 'projects', '-proj');
+  mkdirSync(projectDir, { recursive: true });
+  const path = join(projectDir, 'sid-legacy.jsonl');
+  writeFileSync(path, [
+    JSON.stringify({ uuid: 'u1', type: 'user', timestamp: '2026-06-10T10:00:00Z', message: { role: 'user', content: 'hi' } }),
+    JSON.stringify({ uuid: 'a1', type: 'assistant', timestamp: '2026-06-10T10:00:05Z', message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }] } }),
+  ].join('\n') + '\n');
+  const provider = createClaudeProvider({ rootDir: root });
+  const mtime = statSync(path).mtimeMs;
+
+  assert.equal(
+    provider.discover({ lastCursor: () => `${mtime}:2` }).length,
+    0,
+    'a legacy cursor at the current mtime is not reselected',
+  );
+  assert.equal(
+    provider.discover({ lastCursor: () => `${mtime - 1000}:2` }).length,
+    1,
+    'a legacy cursor behind the current mtime is reselected',
+  );
 });

--- a/tests/claude-parse.test.mjs
+++ b/tests/claude-parse.test.mjs
@@ -211,3 +211,58 @@ test('claude links repeated workflow names by unique run id', () => {
   assert.equal(parentByRun.get('old-run'), 'old-call');
   assert.equal(parentByRun.get('new-run'), 'new-call');
 });
+
+
+// ---- torn-tail cursor safety (#102) ----
+// A build can land while the writer is mid-line. readLines reports the
+// unterminated EOF tail with terminated=false; the Claude cursor must not
+// count a tail that failed to parse, or the completed line is never re-read.
+
+function writeTornFixture() {
+  const dir = makeTempDir('obelisk-claude-torn-');
+  const path = join(dir, 'sid-torn.jsonl');
+  const head = [
+    JSON.stringify({ uuid: 'u1', type: 'user', timestamp: '2026-06-10T10:00:00Z', message: { role: 'user', content: 'hi' } }),
+    JSON.stringify({ uuid: 'a1', type: 'assistant', timestamp: '2026-06-10T10:00:05Z', message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }] } }),
+  ];
+  return { path, head };
+}
+
+const COMPLETED_TAIL = JSON.stringify({
+  uuid: 'u2', type: 'user', timestamp: '2026-06-10T10:00:10Z', message: { role: 'user', content: 'done' },
+});
+
+test('a torn unterminated tail line does not advance the Claude cursor', () => {
+  const { path, head } = writeTornFixture();
+  writeFileSync(path, `${head.join('\n')}\n{"uuid":"u2","type":"user","mes`);
+  const { ret } = drain(parse({ key: path, sessionId: 'sid-torn' }, null));
+  assert.equal(ret.split(':')[1], '2', 'the unparseable unterminated tail is not counted');
+});
+
+test('a completed tail line is indexed exactly once after a torn parse', () => {
+  const { path, head } = writeTornFixture();
+  writeFileSync(path, `${head.join('\n')}\n{"uuid":"u2","type":"user","mes`);
+  const torn = drain(parse({ key: path, sessionId: 'sid-torn' }, null));
+
+  // The writer finishes the line (a later build sees it complete).
+  writeFileSync(path, `${head.join('\n')}\n${COMPLETED_TAIL}\n`);
+  const healed = drain(parse({ key: path, sessionId: 'sid-torn' }, torn.ret));
+
+  const u2 = healed.values.filter((r) => r.kind === 'message' && r.uuid === 'u2');
+  assert.equal(u2.length, 1, 'the completed line is indexed exactly once');
+  assert.equal(healed.ret.split(':')[1], '3', 'the cursor now covers the completed line');
+});
+
+test('a newline-terminated malformed line advances the Claude cursor', () => {
+  const { path, head } = writeTornFixture();
+  writeFileSync(path, `${head.join('\n')}\nnot-json-at-all\n`);
+  const { ret } = drain(parse({ key: path, sessionId: 'sid-torn' }, null));
+  assert.equal(ret.split(':')[1], '3', 'terminated garbage keeps the legacy count');
+});
+
+test('a legal unterminated final JSON line advances the Claude cursor', () => {
+  const { path, head } = writeTornFixture();
+  writeFileSync(path, `${head.join('\n')}\n${COMPLETED_TAIL}`);
+  const { ret } = drain(parse({ key: path, sessionId: 'sid-torn' }, null));
+  assert.equal(ret.split(':')[1], '3', 'a parseable unterminated final line is counted');
+});


### PR DESCRIPTION
**Stacked on #90** (base `feat/adaptive-watcher-hot-overlay`; stack: #83 → #88 → #90 → this → the #86 scheduler PR). Bugfix PR — reproduction and root cause below.

## Root cause

`packages/core/src/providers/claude.ts` builds the incremental cursor as `${mtime}:${linesProcessed}`. Its parse loop increments the line counter **before** `JSON.parse`, and `readLines` (`packages/core/src/parsing.ts:131`) emits the unterminated EOF remainder as a line. So when a build happens while the writer has a partially-written tail line:

1. The torn tail fails `JSON.parse` — produces no records — but **is counted** in `linesProcessed`.
2. The cursor is persisted with that count.
3. The next build (after the line completes) resumes with `lineNum <= skip` and skips the now-complete line.

**The completed content of that line is never indexed.** Every later append only moves the cursor forward.

## Why now

Today the 2 s + 500 ms trailing stability wait makes a mid-line build rare. #86 (bounded scheduling) deliberately builds *during* continuous appends — torn-tail builds would become the common case, so this fix must land first. Scope is deliberately Claude-only, verified against the other providers' cursor models: Codex re-parses the whole file whenever its mtime-only cursor is stale (`codex.ts:100`); Pi and Kimi use snapshot cursors — none skip by line count.

## Change

- `readLines` passes a `terminated` flag to its callback (`false` only for the unterminated EOF remainder; backward-compatible extra argument).
- Claude's parse counts a line toward the cursor only when it **parsed successfully**, or is **newline-terminated**, or is **not the last line**. An unterminated unparseable tail is not counted, so the next build re-reads it once completed — self-healing, with no change for mid-file malformed lines or legal final lines without a trailing newline.
- **Cursor signature enrichment** (found in review): the self-heal only works if discovery reselects the file — and the gate compared mtime alone, so a completion landing in the same millisecond (or on a coarse/network filesystem) was never rediscovered, reproduced as `rediscovered: 0`. The cursor is now `${mtime}:${lines}:${size}:${ctimeMs}:${ino}`, per the CONTRIBUTING rule that cursors must detect same-millisecond rewrites (mtime + ctime + size + inode). Legacy `${mtime}:${lines}` cursors keep the mtime-only gate and upgrade on the next parse, so existing installations see no behavior change until their first new parse. Workflow cursors (`${mtime}:1`, complete-file JSON, no append model) are intentionally untouched.

## Tests (the four pinned cases)

1. A torn unterminated tail does **not** advance the cursor.
2. After the line completes, it is indexed **exactly once** (re-parse from the un-advanced cursor).
3. A newline-terminated malformed line **does** advance the cursor (unchanged legacy behavior).
4. A legal unterminated final line that parses **does** advance the cursor.

Plus two signature-level regressions walking the production `discover → parse` path: a same-mtime tail completion (mtime pinned with `utimesSync`) is rediscovered via the size/ctime signature and indexed exactly once, and a legacy two-part cursor keeps the mtime-only gate until it upgrades. `tests/claude-parse.test.mjs` is wired into the three-platform CI step.

## Verification

- `npm test`: 494/494 on the final head, including the pre-existing Claude parse/discovery suites (one golden cursor assertion updated to the enriched format).
- Full `npm run lint` on all tracked files: 0 errors. `npm run typecheck` clean.
