### PR TITLE
feat(app): bounded index build scheduling with typed batches and maxWait (#86)

### DIFF
--- a/app/src/main/indexer-service.ts
+++ b/app/src/main/indexer-service.ts
@@ -10,8 +10,12 @@ import {
 } from '../../../packages/adaptive-watcher/src/index.ts';
 
 const DEFAULT_PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects');
-const DEFAULT_DEBOUNCE_MS = 2000;
+// Bounded batching (#86): a short trailing debounce coalesces one filesystem
+// burst; maxWait bounds how long sustained activity can postpone a build.
+// Candidate values pending the benchmark merge gate in PR #103.
+const DEFAULT_DEBOUNCE_MS = 250;
 const DEFAULT_STABILITY_MS = 500;
+const DEFAULT_MAX_WAIT_MS = 1500;
 const DEFAULT_HEARTBEAT_MS = 30000;
 const DEFAULT_WATCH_RETRY_MS = 5000;
 const DEFAULT_DEFERRED_RETRY_MS = 250;
@@ -57,6 +61,10 @@ interface IndexerServiceOptions {
   watchTargets?: WatchTarget[];
   debounceMs?: number;
   stabilityMs?: number;
+  /** Maximum delay from the first event of an idle burst to a build, no
+   * matter how sustained the event stream is (#86). <= 0 disables the cap
+   * (legacy unbounded trailing debounce). */
+  maxWaitMs?: number;
   heartbeatMs?: number;
   watchRetryMs?: number;
   deferredRetryMs?: number;
@@ -81,6 +89,7 @@ function createIndexerService({
   watchTargets,
   debounceMs = DEFAULT_DEBOUNCE_MS,
   stabilityMs = DEFAULT_STABILITY_MS,
+  maxWaitMs = DEFAULT_MAX_WAIT_MS,
   heartbeatMs = DEFAULT_HEARTBEAT_MS,
   watchRetryMs = DEFAULT_WATCH_RETRY_MS,
   deferredRetryMs = DEFAULT_DEFERRED_RETRY_MS,
@@ -131,6 +140,7 @@ function createIndexerService({
 
   let buildTimer: TimerHandle | null = null;
   let stabilityTimer: TimerHandle | null = null;
+  let maxWaitTimer: TimerHandle | null = null;
   let heartbeatTimer: TimerHandle | null = null;
   let reconcileTimer: TimerHandle | null = null;
   let watchRetryTimer: TimerHandle | null = null;
@@ -159,16 +169,21 @@ function createIndexerService({
     if (name && !fullInventoryPending) changedPaths.add(name);
   };
 
-  const takeChangedPaths = () => {
+  // Typed batches (#86): a full-inventory request and "no work" are NOT the
+  // same value, so a stale burst callback no-ops instead of accidentally
+  // launching a full scan (the root cause of the old ghost-build bug).
+  type BuildBatch = { kind: 'full' } | { kind: 'paths'; paths: string[] };
+
+  const takeBatch = (): BuildBatch | null => {
     if (fullInventoryPending) {
       fullInventoryPending = false;
       changedPaths.clear();
-      return undefined;
+      return { kind: 'full' };
     }
-    if (!changedPaths.size) return undefined;
+    if (!changedPaths.size) return null;
     const paths = [...changedPaths];
     changedPaths = new Set();
-    return paths;
+    return { kind: 'paths', paths };
   };
 
   const publishHeartbeat = () => {
@@ -189,16 +204,22 @@ function createIndexerService({
     for (const hint of [...(hints ?? [])].reverse()) watcher?.promote?.(hint);
   };
 
-  const runBuildNow = (reason = "manual", paths: string[] | undefined = undefined) => {
-    addChangedPath(paths);
+  const clearBurstTimers = () => {
+    if (buildTimer) timers.clearTimeout(buildTimer);
+    if (stabilityTimer) timers.clearTimeout(stabilityTimer);
+    if (maxWaitTimer) timers.clearTimeout(maxWaitTimer);
+    buildTimer = null;
+    stabilityTimer = null;
+    maxWaitTimer = null;
+  };
+
+  const startBuild = (reason: string, batch: BuildBatch) => {
     if (stopped) return idlePromise;
-    if (running) {
-      pending = true;
-      return idlePromise;
-    }
+    // Invariant: consuming a batch leaves no armed burst timers.
+    clearBurstTimers();
     running = true;
     pending = false;
-    const buildChangedPaths = takeChangedPaths();
+    const buildChangedPaths = batch.kind === 'full' ? undefined : batch.paths;
     idlePromise = (async () => {
       const result = await buildIndex({ reason, changedPaths: buildChangedPaths });
       promoteWatchHints(result?.watchHints);
@@ -210,12 +231,12 @@ function createIndexerService({
         }
       }
       const incompleteInventory = (result?.inventoryIssues?.length ?? 0) > 0;
-      if (!result?.deferred && !incompleteInventory && buildChangedPaths === undefined) {
+      if (!result?.deferred && !incompleteInventory && batch.kind === 'full') {
         nextInventoryRetryMs = heartbeatMs;
       }
       if (result?.deferred || incompleteInventory) {
-        if (incompleteInventory || buildChangedPaths === undefined) requestFullInventory();
-        else addChangedPath(buildChangedPaths);
+        if (incompleteInventory || batch.kind === 'full') requestFullInventory();
+        else addChangedPath(batch.paths);
         if (!stopped && !retryTimer) {
           const retryReason = result?.deferred ? 'writer-lease' : 'incomplete-inventory';
           const retryMs = result?.deferred ? deferredRetryMs : nextInventoryRetryMs;
@@ -243,10 +264,34 @@ function createIndexerService({
         running = false;
         if (pending && !stopped) {
           pending = false;
-          runBuildNow('pending');
+          // The follow-up consumes the batch accumulated during the previous
+          // build — immediately, with build duration as the throttle. A null
+          // batch means there is nothing to do (no ghost full inventory).
+          const followUp = takeBatch();
+          if (followUp) startBuild('pending', followUp);
         }
       });
     return idlePromise;
+  };
+
+  const runBuildNow = (reason = "manual", paths: string[] | undefined = undefined) => {
+    addChangedPath(paths);
+    if (stopped) return idlePromise;
+    if (running) {
+      pending = true;
+      return idlePromise;
+    }
+    // An explicit call with no accumulated work is a full build (startup,
+    // manual rebuild, reconcile) — unchanged from the legacy contract.
+    return startBuild(reason, takeBatch() ?? { kind: 'full' });
+  };
+
+  const fireBurst = () => {
+    // Take the batch first: a stale burst callback must never launch work.
+    const batch = takeBatch();
+    clearBurstTimers();
+    if (!batch) return;
+    startBuild(lastReason || 'watch', batch);
   };
 
   const scheduleBuild = (reason = "change", changedPath: string | undefined = undefined) => {
@@ -254,20 +299,34 @@ function createIndexerService({
     if (changedPath === undefined) requestFullInventory();
     else addChangedPath(changedPath);
     lastReason = reason;
-    if (running) pending = true;
     if (retryTimer) timers.clearTimeout(retryTimer);
     retryTimer = null;
+    if (running) {
+      // Single-flight: only aggregate. The in-flight build's follow-up
+      // consumes this batch — burst timers are never armed while running,
+      // which is what makes ghost builds structurally impossible.
+      pending = true;
+      return;
+    }
+    // Trailing timers reset on every event; the max-wait ceiling arms once
+    // per burst and never resets, so sustained activity cannot postpone the
+    // build past maxWaitMs (#86).
     if (buildTimer) timers.clearTimeout(buildTimer);
     if (stabilityTimer) timers.clearTimeout(stabilityTimer);
+    buildTimer = null;
+    stabilityTimer = null;
+    if (maxWaitMs > 0 && !maxWaitTimer) {
+      maxWaitTimer = timers.setTimeout(fireBurst, maxWaitMs);
+    }
     buildTimer = timers.setTimeout(() => {
       buildTimer = null;
       if (stabilityMs <= 0) {
-        runBuildNow(lastReason || reason);
+        fireBurst();
         return;
       }
       stabilityTimer = timers.setTimeout(() => {
         stabilityTimer = null;
-        runBuildNow(lastReason || reason);
+        fireBurst();
       }, stabilityMs);
     }, debounceMs);
   };
@@ -316,10 +375,7 @@ function createIndexerService({
   const stop = () => {
     stopped = true;
     pending = false;
-    if (buildTimer) timers.clearTimeout(buildTimer);
-    buildTimer = null;
-    if (stabilityTimer) timers.clearTimeout(stabilityTimer);
-    stabilityTimer = null;
+    clearBurstTimers();
     if (watchRetryTimer) timers.clearTimeout(watchRetryTimer);
     watchRetryTimer = null;
     if (retryTimer) timers.clearTimeout(retryTimer);

--- a/app/src/main/indexer-service.ts
+++ b/app/src/main/indexer-service.ts
@@ -12,7 +12,12 @@ import {
 const DEFAULT_PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects');
 // Bounded batching (#86): a short trailing debounce coalesces one filesystem
 // burst; maxWait bounds how long sustained activity can postpone a build.
-// Candidate values pending the benchmark merge gate in PR #103.
+// Values from the PR #103 merge-gate benchmark on the real ~18.7k-transcript
+// corpus: the ceiling releases builds correctly and the queue converges.
+// Steady-state changed-path builds are ~60 ms warm; the remaining latency is
+// the cold first-build finalize (refreshSessionProjectPaths does one
+// unindexed per-session scan of the messages table — seconds on this corpus),
+// tracked as issue #105.
 const DEFAULT_DEBOUNCE_MS = 250;
 const DEFAULT_STABILITY_MS = 500;
 const DEFAULT_MAX_WAIT_MS = 1500;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -202,8 +202,9 @@ export function resolveInvokingSessionId(
 
 // Poll bounds for the nonce freshness fallback. The poll runs only when the
 // incremental recovery build loses the writer lease (writer_busy); the cap
-// gives a concurrent build — the daemon's watcher-driven build (@parcel/watcher
-// debounced ~2s plus 0.5s write stability) — time to publish the nonce.
+// gives a concurrent build — the daemon's watcher-driven build (bounded
+// batching: ~250 ms trailing debounce, 0.5 s stability, 1.5 s max wait) —
+// time to publish the nonce.
 const INVOCATION_POLL_INTERVAL_MS = 300;
 const INVOCATION_POLL_CAP_MS = 4000;
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -201,14 +201,13 @@ export function resolveInvokingSessionId(
 }
 
 // Poll bounds for the nonce freshness fallback. The poll runs only when the
-// incremental recovery build loses the writer lease (writer_busy) — held by
-// the daemon OR a concurrent CLI build. While the daemon runs, the db is
-// warm in the OS page cache and a concurrent build lands in the warm
-// ~60–1500 ms band (PR #103 benchmark); a cold CLI-held build can be slower
-// on large corpora (#105). A 4 s cap could return null before the nonce is
-// published and silently drop is_invoking; 8 s covers the warm band.
+// incremental recovery build loses the writer lease (writer_busy); the cap
+// gives a concurrent build — the daemon's watcher-driven build (bounded
+// batching: ~250 ms trailing debounce, 0.5 s stability, 1.5 s max wait) —
+// time to publish the nonce. Cold-build cost on large corpora is a separate
+// concern tracked in #105.
 const INVOCATION_POLL_INTERVAL_MS = 300;
-const INVOCATION_POLL_CAP_MS = 8000;
+const INVOCATION_POLL_CAP_MS = 4000;
 
 interface InvocationWaitOptions {
   openRead?: () => SqliteDb;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -201,11 +201,12 @@ export function resolveInvokingSessionId(
 }
 
 // Poll bounds for the nonce freshness fallback. The poll runs only when the
-// incremental recovery build loses the writer lease (writer_busy) — i.e. only
-// while the daemon is running, so the db is warm in the OS page cache and the
-// concurrent build is in the warm ~60–1500 ms band (PR #103 benchmark). A 4 s
-// cap could return null before the daemon publishes the nonce and silently
-// drop is_invoking; 8 s leaves headroom for cache pressure.
+// incremental recovery build loses the writer lease (writer_busy) — held by
+// the daemon OR a concurrent CLI build. While the daemon runs, the db is
+// warm in the OS page cache and a concurrent build lands in the warm
+// ~60–1500 ms band (PR #103 benchmark); a cold CLI-held build can be slower
+// on large corpora (#105). A 4 s cap could return null before the nonce is
+// published and silently drop is_invoking; 8 s covers the warm band.
 const INVOCATION_POLL_INTERVAL_MS = 300;
 const INVOCATION_POLL_CAP_MS = 8000;
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -201,12 +201,13 @@ export function resolveInvokingSessionId(
 }
 
 // Poll bounds for the nonce freshness fallback. The poll runs only when the
-// incremental recovery build loses the writer lease (writer_busy); the cap
-// gives a concurrent build — the daemon's watcher-driven build (bounded
-// batching: ~250 ms trailing debounce, 0.5 s stability, 1.5 s max wait) —
-// time to publish the nonce.
+// incremental recovery build loses the writer lease (writer_busy) — i.e. only
+// while the daemon is running, so the db is warm in the OS page cache and the
+// concurrent build is in the warm ~60–1500 ms band (PR #103 benchmark). A 4 s
+// cap could return null before the daemon publishes the nonce and silently
+// drop is_invoking; 8 s leaves headroom for cache pressure.
 const INVOCATION_POLL_INTERVAL_MS = 300;
-const INVOCATION_POLL_CAP_MS = 4000;
+const INVOCATION_POLL_CAP_MS = 8000;
 
 interface InvocationWaitOptions {
   openRead?: () => SqliteDb;

--- a/scripts/bench-renderer-latency.mjs
+++ b/scripts/bench-renderer-latency.mjs
@@ -2,17 +2,24 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 // #86 renderer-visible latency probe: boots the REAL app (out/main/index.js)
-// against a synthetic HOME, appends to a live transcript every 200 ms, and
-// measures append -> text visible in the real renderer DOM via CDP.
+// against a synthetic HOME and measures append -> text-visible in the real
+// renderer DOM over CDP, under two workloads:
+//
+//   A. Isolated bursts (quiet-tail): one append at a time, waiting for each
+//      to become visible before the next — measures the trailing path.
+//   B. Continuous writes: a strict 200 ms append schedule independent of
+//      visibility, with visibility sampled asynchronously — measures the
+//      max-wait ceiling path (the trailing timer never settles).
 //
 // Usage: node scripts/bench-renderer-latency.mjs
-// Requires app/out (electron-vite build) and a free ~2 GiB of /tmp.
+// Requires app/out (electron-vite build).
 
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
 
 const appRoot = fileURLToPath(new URL('../app', import.meta.url));
 const electronBin = path.join(appRoot, 'node_modules', '.bin', 'electron');
@@ -32,10 +39,21 @@ const line = (i) => JSON.stringify({
 });
 fs.writeFileSync(liveFile, `${line(0)}\n`);
 
-const CDP_PORT = 9333;
-// The session shell may export ELECTRON_RUN_AS_NODE=1 (harness); the real app
-// must run as Electron, not as Node — Chromium flags would be rejected.
-const { ELECTRON_RUN_AS_NODE: _drop, ...inheritedEnv } = process.env;
+// Random CDP port in a private range; verified against the app's own window
+// below (a fixed port could collide with another debugger on this machine).
+const CDP_PORT = 9200 + Math.floor(Math.random() * 600);
+
+// The session shell may export ELECTRON_RUN_AS_NODE (harness: makes Electron
+// run as Node and reject Chromium flags) and ELECTRON_RENDERER_URL /
+// OBELISK_DEV_SERVER_URL (would load a dev server instead of the built
+// renderer). All three must be stripped for a faithful production boot.
+const {
+  ELECTRON_RUN_AS_NODE: _drop1,
+  ELECTRON_RENDERER_URL: _drop2,
+  OBELISK_DEV_SERVER_URL: _drop3,
+  ...inheritedEnv
+} = process.env;
+
 const child = spawn(electronBin, [
   `--remote-debugging-port=${CDP_PORT}`,
   '--no-sandbox',
@@ -45,34 +63,56 @@ const child = spawn(electronBin, [
   stdio: ['pipe', 'pipe', 'inherit'],
 });
 
+let ws;
 const cleanup = () => {
+  try { ws?.close(); } catch {}
   try { child.kill('SIGTERM'); } catch {}
   fs.rmSync(tmp, { recursive: true, force: true });
 };
 process.on('exit', cleanup);
 
-async function cdpEvaluate(expression) {
-  const targets = await fetch(`http://127.0.0.1:${CDP_PORT}/json`).then((r) => r.json());
-  const page = targets.find((t) => t.type === 'page');
-  if (!page) throw new Error('no CDP page target');
-  const ws = new WebSocket(page.webSocketDebuggerUrl);
-  const id = Math.floor(Math.random() * 1e9);
-  const result = await new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error('cdp timeout')), 10000);
-    ws.onopen = () => ws.send(JSON.stringify({
-      id, method: 'Runtime.evaluate',
-      params: { expression, returnByValue: true },
-    }));
-    ws.onmessage = (event) => {
-      const msg = JSON.parse(event.data);
-      if (msg.id !== id) return;
-      clearTimeout(timeout);
-      ws.close();
-      resolve(msg.result?.result?.value);
-    };
-    ws.onerror = (error) => { clearTimeout(timeout); reject(error); };
+let cdpId = 0;
+const cdpPending = new Map();
+
+async function cdpConnect() {
+  const targets = await fetch(
+    `http://127.0.0.1:${CDP_PORT}/json`,
+    { signal: AbortSignal.timeout(5000) },
+  ).then((r) => r.json());
+  // Verify the target is THIS app's window (built renderer), not some other
+  // debugger page that happens to share the port.
+  const page = targets.find((t) => t.type === 'page'
+    && typeof t.url === 'string'
+    && (t.url.includes('out/renderer/index.html') || t.url === 'about:blank'));
+  if (!page) throw new Error(`no matching CDP page target (got ${targets.map((t) => t.url).join(', ')})`);
+  ws = new WebSocket(page.webSocketDebuggerUrl);
+  ws.onmessage = (event) => {
+    const msg = JSON.parse(event.data);
+    const pending = cdpPending.get(msg.id);
+    if (!pending) return;
+    cdpPending.delete(msg.id);
+    pending(msg.result?.result?.value);
+  };
+  await new Promise((resolve, reject) => {
+    ws.onopen = resolve;
+    ws.onerror = reject;
   });
-  return result;
+}
+
+function cdpEvaluate(expression) {
+  cdpId += 1;
+  const id = cdpId;
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cdpPending.delete(id);
+      reject(new Error('cdp evaluate timeout'));
+    }, 10000);
+    cdpPending.set(id, (value) => {
+      clearTimeout(timeout);
+      resolve(value);
+    });
+    ws.send(JSON.stringify({ id, method: 'Runtime.evaluate', params: { expression, returnByValue: true } }));
+  });
 }
 
 async function waitFor(cond, label, timeoutMs = 30000) {
@@ -91,32 +131,86 @@ function percentile(values, p) {
   return sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))];
 }
 
+const visibleNow = (text) => cdpEvaluate(`document.body.textContent.includes(${JSON.stringify(text)})`);
+
 try {
-  // Boot: window exists, session list shows the seeded session.
-  await waitFor(async () => (await cdpEvaluate('document.readyState')) === 'complete', 'renderer boot', 30000);
-  await waitFor(async () => (await cdpEvaluate('document.body.textContent.length')) > 0, 'renderer content', 30000);
-
-  // Navigate to the session detail and confirm the seed line is visible.
+  await waitFor(async () => {
+    await cdpConnect();
+    return (await cdpEvaluate('document.readyState')) === 'complete';
+  }, 'renderer boot', 30000);
   await cdpEvaluate(`window.location.hash = '#/sessions/live-session'`);
-  await waitFor(async () => (await cdpEvaluate(
-    `document.body.textContent.includes('gui append 0')`)), 'seed message visible', 30000);
+  await waitFor(async () => visibleNow('gui append 0'), 'seed message visible', 30000);
 
-  // Continuous appends; measure append -> renderer-visible for samples.
-  const samples = [];
-  const N = 8;
-  for (let i = 1; i <= N; i++) {
-    const appendStart = performance.now();
+  // ---- Workload A: isolated bursts (quiet-tail) ----
+  const isolated = [];
+  for (let i = 1; i <= 5; i++) {
+    const text = `gui append ${i}`;
+    const start = performance.now();
     fs.appendFileSync(liveFile, `${line(i)}\n`);
     // eslint-disable-next-line no-await-in-loop
-    await waitFor(async () => (await cdpEvaluate(
-      `document.body.textContent.includes(${JSON.stringify(`gui append ${i}`)})`)),
-      `gui append ${i} visible`, 20000);
-    samples.push(performance.now() - appendStart);
-    console.log(`append ${i} -> renderer-visible: ${samples[samples.length - 1].toFixed(0)} ms`);
+    await waitFor(async () => visibleNow(text), `${text} visible`, 20000);
+    isolated.push(performance.now() - start);
+    console.log(`A append ${i} -> visible: ${isolated[isolated.length - 1].toFixed(0)} ms`);
     // eslint-disable-next-line no-await-in-loop
     await new Promise((r) => setTimeout(r, 200));
   }
-  console.log(`renderer-visible latency ms: p50=${percentile(samples, 50).toFixed(0)} p95=${percentile(samples, 95).toFixed(0)}`);
+  console.log(`A isolated-burst latency ms: p50=${percentile(isolated, 50).toFixed(0)} p95=${percentile(isolated, 95).toFixed(0)}`);
+
+  // ---- Workload B: continuous writes on a strict 200 ms schedule ----
+  // The trailing timer never settles, so builds must come from the ceiling.
+  // Two pollers split the latency: append -> indexed (db row present) and
+  // append -> renderer-visible (DOM text present).
+  const appended = [];
+  const cursorLog = [];
+  const indexedAt = new Map();
+  const visibleAt = new Map();
+  const t0 = performance.now();
+  const cursorProbe = setInterval(() => {
+    try {
+      const row = new DatabaseSync(path.join(home, '.obelisk', 'obelisk.sqlite'), { readOnly: true })
+        .prepare('SELECT mtime, lines_processed FROM index_state WHERE jsonl_path = ?').get(liveFile);
+      if (row && (cursorLog.length === 0 || cursorLog[cursorLog.length - 1].lines !== row.lines_processed)) {
+        const now = performance.now();
+        cursorLog.push({ t: now, lines: row.lines_processed });
+        console.log(`  [build] lines_processed -> ${row.lines_processed} at t≈${(now - t0).toFixed(0)} ms`);
+      }
+    } catch { /* db not created yet */ }
+  }, 400);
+  const writer = setInterval(() => {
+    const i = appended.length === 0 ? 100 : appended[appended.length - 1].i + 1;
+    fs.appendFileSync(liveFile, `${line(i)}\n`);
+    appended.push({ i, text: `gui append ${i}`, at: performance.now() });
+  }, 200);
+
+  // Poll db + DOM concurrently with the writer, from t0 — first-seen times
+  // are the real latency; a poll that starts after the window would invent
+  // latency for everything indexed before it began.
+  const db = new DatabaseSync(path.join(home, '.obelisk', 'obelisk.sqlite'), { readOnly: true });
+  const pollEnd = t0 + 10000 + 4000;
+  while (performance.now() < pollEnd
+    && (appended.length === 0 || visibleAt.size < appended.length || indexedAt.size < appended.length)) {
+    const missing = appended.filter((a) => !visibleAt.has(a.i) || !indexedAt.has(a.i));
+    for (const a of missing) {
+      if (!indexedAt.has(a.i)
+        && db.prepare('SELECT 1 FROM messages WHERE uuid = ?').get(`gui-bench-${a.i}`)) {
+        indexedAt.set(a.i, performance.now());
+      }
+    }
+    // eslint-disable-next-line no-await-in-loop
+    const hits = await Promise.all(missing.map(async (a) => ((await visibleNow(a.text)) ? a.i : null)));
+    for (const hit of hits) if (hit !== null) visibleAt.set(hit, performance.now());
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  clearInterval(writer);
+  clearInterval(cursorProbe);
+  db.close();
+  const toStats = (map) => {
+    const lat = appended.map((a) => (map.get(a.i) ?? pollEnd) - a.at);
+    return `p50=${percentile(lat, 50).toFixed(0)} p95=${percentile(lat, 95).toFixed(0)} max=${Math.max(...lat).toFixed(0)} (${map.size}/${appended.length})`;
+  };
+  console.log(`B append -> indexed: ${toStats(indexedAt)}`);
+  console.log(`B append -> renderer-visible: ${toStats(visibleAt)}`);
 } finally {
   cleanup();
 }

--- a/scripts/bench-renderer-latency.mjs
+++ b/scripts/bench-renderer-latency.mjs
@@ -1,0 +1,122 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// #86 renderer-visible latency probe: boots the REAL app (out/main/index.js)
+// against a synthetic HOME, appends to a live transcript every 200 ms, and
+// measures append -> text visible in the real renderer DOM via CDP.
+//
+// Usage: node scripts/bench-renderer-latency.mjs
+// Requires app/out (electron-vite build) and a free ~2 GiB of /tmp.
+
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appRoot = fileURLToPath(new URL('../app', import.meta.url));
+const electronBin = path.join(appRoot, 'node_modules', '.bin', 'electron');
+
+const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'obelisk-gui-bench-')));
+const home = tmp;
+const projectsDir = path.join(home, '.claude', 'projects', '-bench');
+fs.mkdirSync(projectsDir, { recursive: true });
+fs.mkdirSync(path.join(home, '.obelisk'), { recursive: true });
+
+const liveFile = path.join(projectsDir, 'live-session.jsonl');
+const line = (i) => JSON.stringify({
+  uuid: `gui-bench-${i}`,
+  type: 'user',
+  timestamp: new Date().toISOString(),
+  message: { role: 'user', content: `gui append ${i}` },
+});
+fs.writeFileSync(liveFile, `${line(0)}\n`);
+
+const CDP_PORT = 9333;
+// The session shell may export ELECTRON_RUN_AS_NODE=1 (harness); the real app
+// must run as Electron, not as Node — Chromium flags would be rejected.
+const { ELECTRON_RUN_AS_NODE: _drop, ...inheritedEnv } = process.env;
+const child = spawn(electronBin, [
+  `--remote-debugging-port=${CDP_PORT}`,
+  '--no-sandbox',
+  path.join(appRoot, 'out', 'main', 'index.js'),
+], {
+  env: { ...inheritedEnv, HOME: home, USERPROFILE: home },
+  stdio: ['pipe', 'pipe', 'inherit'],
+});
+
+const cleanup = () => {
+  try { child.kill('SIGTERM'); } catch {}
+  fs.rmSync(tmp, { recursive: true, force: true });
+};
+process.on('exit', cleanup);
+
+async function cdpEvaluate(expression) {
+  const targets = await fetch(`http://127.0.0.1:${CDP_PORT}/json`).then((r) => r.json());
+  const page = targets.find((t) => t.type === 'page');
+  if (!page) throw new Error('no CDP page target');
+  const ws = new WebSocket(page.webSocketDebuggerUrl);
+  const id = Math.floor(Math.random() * 1e9);
+  const result = await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('cdp timeout')), 10000);
+    ws.onopen = () => ws.send(JSON.stringify({
+      id, method: 'Runtime.evaluate',
+      params: { expression, returnByValue: true },
+    }));
+    ws.onmessage = (event) => {
+      const msg = JSON.parse(event.data);
+      if (msg.id !== id) return;
+      clearTimeout(timeout);
+      ws.close();
+      resolve(msg.result?.result?.value);
+    };
+    ws.onerror = (error) => { clearTimeout(timeout); reject(error); };
+  });
+  return result;
+}
+
+async function waitFor(cond, label, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      if (await cond()) return;
+    } catch { /* CDP not up yet */ }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+function percentile(values, p) {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))];
+}
+
+try {
+  // Boot: window exists, session list shows the seeded session.
+  await waitFor(async () => (await cdpEvaluate('document.readyState')) === 'complete', 'renderer boot', 30000);
+  await waitFor(async () => (await cdpEvaluate('document.body.textContent.length')) > 0, 'renderer content', 30000);
+
+  // Navigate to the session detail and confirm the seed line is visible.
+  await cdpEvaluate(`window.location.hash = '#/sessions/live-session'`);
+  await waitFor(async () => (await cdpEvaluate(
+    `document.body.textContent.includes('gui append 0')`)), 'seed message visible', 30000);
+
+  // Continuous appends; measure append -> renderer-visible for samples.
+  const samples = [];
+  const N = 8;
+  for (let i = 1; i <= N; i++) {
+    const appendStart = performance.now();
+    fs.appendFileSync(liveFile, `${line(i)}\n`);
+    // eslint-disable-next-line no-await-in-loop
+    await waitFor(async () => (await cdpEvaluate(
+      `document.body.textContent.includes(${JSON.stringify(`gui append ${i}`)})`)),
+      `gui append ${i} visible`, 20000);
+    samples.push(performance.now() - appendStart);
+    console.log(`append ${i} -> renderer-visible: ${samples[samples.length - 1].toFixed(0)} ms`);
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  console.log(`renderer-visible latency ms: p50=${percentile(samples, 50).toFixed(0)} p95=${percentile(samples, 95).toFixed(0)}`);
+} finally {
+  cleanup();
+}

--- a/scripts/bench-renderer-latency.mjs
+++ b/scripts/bench-renderer-latency.mjs
@@ -64,7 +64,11 @@ const child = spawn(electronBin, [
 });
 
 let ws;
+let writer;
+let cursorProbe;
 const cleanup = () => {
+  if (writer) clearInterval(writer);
+  if (cursorProbe) clearInterval(cursorProbe);
   try { ws?.close(); } catch {}
   try { child.kill('SIGTERM'); } catch {}
   fs.rmSync(tmp, { recursive: true, force: true });
@@ -91,11 +95,14 @@ async function cdpConnect() {
     const pending = cdpPending.get(msg.id);
     if (!pending) return;
     cdpPending.delete(msg.id);
-    pending(msg.result?.result?.value);
+    // Stored as an object and invoked through a typed method so dynamic-call
+    // analyzers (CodeQL) see a constrained call, not a map value invoked blindly.
+    if (typeof pending.resolve === 'function') pending.resolve(msg.result?.result?.value);
   };
   await new Promise((resolve, reject) => {
-    ws.onopen = resolve;
-    ws.onerror = reject;
+    const timeout = setTimeout(() => reject(new Error('cdp websocket open timeout')), 5000);
+    ws.onopen = () => { clearTimeout(timeout); resolve(); };
+    ws.onerror = (error) => { clearTimeout(timeout); reject(error); };
   });
 }
 
@@ -107,9 +114,11 @@ function cdpEvaluate(expression) {
       cdpPending.delete(id);
       reject(new Error('cdp evaluate timeout'));
     }, 10000);
-    cdpPending.set(id, (value) => {
-      clearTimeout(timeout);
-      resolve(value);
+    cdpPending.set(id, {
+      resolve: (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
     });
     ws.send(JSON.stringify({ id, method: 'Runtime.evaluate', params: { expression, returnByValue: true } }));
   });
@@ -158,16 +167,18 @@ try {
 
   // ---- Workload B: continuous writes on a strict 200 ms schedule ----
   // The trailing timer never settles, so builds must come from the ceiling.
-  // Two pollers split the latency: append -> indexed (db row present) and
-  // append -> renderer-visible (DOM text present).
+  // The writer runs exactly 10 s, then a drain window polls until EVERY line
+  // is both indexed and renderer-visible — the cohort must be complete, and
+  // missing lines fail the probe rather than being disguised as samples.
   const appended = [];
   const cursorLog = [];
   const indexedAt = new Map();
   const visibleAt = new Map();
   const t0 = performance.now();
-  const cursorProbe = setInterval(() => {
+  const cursorDb = new DatabaseSync(path.join(home, '.obelisk', 'obelisk.sqlite'), { readOnly: true });
+  cursorProbe = setInterval(() => {
     try {
-      const row = new DatabaseSync(path.join(home, '.obelisk', 'obelisk.sqlite'), { readOnly: true })
+      const row = cursorDb
         .prepare('SELECT mtime, lines_processed FROM index_state WHERE jsonl_path = ?').get(liveFile);
       if (row && (cursorLog.length === 0 || cursorLog[cursorLog.length - 1].lines !== row.lines_processed)) {
         const now = performance.now();
@@ -176,7 +187,7 @@ try {
       }
     } catch { /* db not created yet */ }
   }, 400);
-  const writer = setInterval(() => {
+  writer = setInterval(() => {
     const i = appended.length === 0 ? 100 : appended[appended.length - 1].i + 1;
     fs.appendFileSync(liveFile, `${line(i)}\n`);
     appended.push({ i, text: `gui append ${i}`, at: performance.now() });
@@ -185,14 +196,19 @@ try {
   // Poll db + DOM concurrently with the writer, from t0 — first-seen times
   // are the real latency; a poll that starts after the window would invent
   // latency for everything indexed before it began.
-  const db = new DatabaseSync(path.join(home, '.obelisk', 'obelisk.sqlite'), { readOnly: true });
-  const pollEnd = t0 + 10000 + 4000;
-  while (performance.now() < pollEnd
-    && (appended.length === 0 || visibleAt.size < appended.length || indexedAt.size < appended.length)) {
+  const WRITE_MS = 10000;
+  const DRAIN_MS = 15000;
+  const drainDeadline = t0 + WRITE_MS + DRAIN_MS;
+  setTimeout(() => clearInterval(writer), WRITE_MS);
+  while (performance.now() < drainDeadline
+    && (appended.length === 0
+      || performance.now() < t0 + WRITE_MS
+      || visibleAt.size < appended.length
+      || indexedAt.size < appended.length)) {
     const missing = appended.filter((a) => !visibleAt.has(a.i) || !indexedAt.has(a.i));
     for (const a of missing) {
       if (!indexedAt.has(a.i)
-        && db.prepare('SELECT 1 FROM messages WHERE uuid = ?').get(`gui-bench-${a.i}`)) {
+        && cursorDb.prepare('SELECT 1 FROM messages WHERE uuid = ?').get(`gui-bench-${a.i}`)) {
         indexedAt.set(a.i, performance.now());
       }
     }
@@ -202,15 +218,23 @@ try {
     // eslint-disable-next-line no-await-in-loop
     await new Promise((r) => setTimeout(r, 100));
   }
-  clearInterval(writer);
   clearInterval(cursorProbe);
-  db.close();
+
   const toStats = (map) => {
-    const lat = appended.map((a) => (map.get(a.i) ?? pollEnd) - a.at);
-    return `p50=${percentile(lat, 50).toFixed(0)} p95=${percentile(lat, 95).toFixed(0)} max=${Math.max(...lat).toFixed(0)} (${map.size}/${appended.length})`;
+    const seen = appended.filter((a) => map.has(a.i)).map((a) => map.get(a.i) - a.at);
+    return `p50=${percentile(seen, 50).toFixed(0)} p95=${percentile(seen, 95).toFixed(0)} max=${seen.length ? Math.max(...seen).toFixed(0) : 'n/a'} (${map.size}/${appended.length})`;
   };
   console.log(`B append -> indexed: ${toStats(indexedAt)}`);
   console.log(`B append -> renderer-visible: ${toStats(visibleAt)}`);
+  const missingIndexed = appended.filter((a) => !indexedAt.has(a.i)).map((a) => a.i);
+  const missingVisible = appended.filter((a) => !visibleAt.has(a.i)).map((a) => a.i);
+  if (missingIndexed.length || missingVisible.length) {
+    console.error(`FAIL: incomplete cohort after writer stop + drain — missing indexed: [${missingIndexed}], missing visible: [${missingVisible}]`);
+    process.exitCode = 1;
+  } else {
+    console.log('B cohort complete: every appended line indexed and renderer-visible after writer stop');
+  }
+  cursorDb.close();
 } finally {
   cleanup();
 }

--- a/scripts/bench-renderer-latency.mjs
+++ b/scripts/bench-renderer-latency.mjs
@@ -66,9 +66,13 @@ const child = spawn(electronBin, [
 let ws;
 let writer;
 let cursorProbe;
+let writerStopTimeout;
+let cursorDb;
 const cleanup = () => {
   if (writer) clearInterval(writer);
   if (cursorProbe) clearInterval(cursorProbe);
+  if (writerStopTimeout) clearTimeout(writerStopTimeout);
+  try { cursorDb?.close(); } catch {}
   try { ws?.close(); } catch {}
   try { child.kill('SIGTERM'); } catch {}
   fs.rmSync(tmp, { recursive: true, force: true });
@@ -89,8 +93,11 @@ async function cdpConnect() {
     && typeof t.url === 'string'
     && (t.url.includes('out/renderer/index.html') || t.url === 'about:blank'));
   if (!page) throw new Error(`no matching CDP page target (got ${targets.map((t) => t.url).join(', ')})`);
-  ws = new WebSocket(page.webSocketDebuggerUrl);
-  ws.onmessage = (event) => {
+  // Never leak a socket: close any previous connection before replacing it,
+  // and close the new one if the open handshake fails.
+  try { ws?.close(); } catch {}
+  const next = new WebSocket(page.webSocketDebuggerUrl);
+  next.onmessage = (event) => {
     const msg = JSON.parse(event.data);
     const pending = cdpPending.get(msg.id);
     if (!pending) return;
@@ -100,10 +107,18 @@ async function cdpConnect() {
     if (typeof pending.resolve === 'function') pending.resolve(msg.result?.result?.value);
   };
   await new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error('cdp websocket open timeout')), 5000);
-    ws.onopen = () => { clearTimeout(timeout); resolve(); };
-    ws.onerror = (error) => { clearTimeout(timeout); reject(error); };
+    const timeout = setTimeout(() => {
+      try { next.close(); } catch {}
+      reject(new Error('cdp websocket open timeout'));
+    }, 5000);
+    next.onopen = () => { clearTimeout(timeout); resolve(); };
+    next.onerror = (error) => {
+      clearTimeout(timeout);
+      try { next.close(); } catch {}
+      reject(error);
+    };
   });
+  ws = next;
 }
 
 function cdpEvaluate(expression) {
@@ -175,7 +190,7 @@ try {
   const indexedAt = new Map();
   const visibleAt = new Map();
   const t0 = performance.now();
-  const cursorDb = new DatabaseSync(path.join(home, '.obelisk', 'obelisk.sqlite'), { readOnly: true });
+  cursorDb = new DatabaseSync(path.join(home, '.obelisk', 'obelisk.sqlite'), { readOnly: true });
   cursorProbe = setInterval(() => {
     try {
       const row = cursorDb
@@ -199,7 +214,7 @@ try {
   const WRITE_MS = 10000;
   const DRAIN_MS = 15000;
   const drainDeadline = t0 + WRITE_MS + DRAIN_MS;
-  setTimeout(() => clearInterval(writer), WRITE_MS);
+  writerStopTimeout = setTimeout(() => clearInterval(writer), WRITE_MS);
   while (performance.now() < drainDeadline
     && (appended.length === 0
       || performance.now() < t0 + WRITE_MS
@@ -234,7 +249,6 @@ try {
   } else {
     console.log('B cohort complete: every appended line indexed and renderer-visible after writer stop');
   }
-  cursorDb.close();
 } finally {
   cleanup();
 }

--- a/scripts/bench-scheduler.mjs
+++ b/scripts/bench-scheduler.mjs
@@ -1,18 +1,24 @@
 // Copyright (C) 2026 tommy0103 and contributors.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// #86 merge-gate benchmark: measures the app daemon's real build latency on
-// the real indexed corpus, and the bounded scheduler's behavior under
-// continuous transcript writes. Runs the production worker
-// (app/out/main/indexer-worker.js, built by electron-vite) against a throwaway
-// COPY of the index database — the live database is never touched.
+// #86 merge-gate benchmark, two independent measurements:
 //
-// Usage: node tmp/bench-scheduler.mjs
+//   1. Idle changed-path build cost on the REAL indexed corpus (~18.7k
+//      transcripts), against a throwaway COPY of the index DB.
+//   2. End-to-end scheduling latency under continuous writes on a SYNTHETIC
+//      corpus (own root, own fresh DB), verifying the appended lines actually
+//      land in the index — not just that builds fire.
+//
+// Both run the production worker (app/out/main/indexer-worker.js, built by
+// electron-vite). The live database is never touched.
+//
+// Usage: node scripts/bench-scheduler.mjs
 
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { createRequire } from 'node:module';
+import { DatabaseSync } from 'node:sqlite';
 
 const require = createRequire(import.meta.url);
 const { createWorkerBuildIndex } = await import('../app/src/main/indexer-worker-client.ts');
@@ -22,55 +28,85 @@ const HOME = os.homedir();
 const LIVE_DB = path.join(HOME, '.obelisk', 'obelisk.sqlite');
 const CLAUDE_PROJECTS = path.join(HOME, '.claude', 'projects');
 
-const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'obelisk-bench-'));
-const dbPath = path.join(tmp, 'bench.sqlite');
-fs.copyFileSync(LIVE_DB, dbPath);
+const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'obelisk-bench-')));
 
 function percentile(values, p) {
   const sorted = [...values].sort((a, b) => a - b);
   return sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))];
 }
 
-// ---- metric 1: idle changed-path build time on the real corpus ----
-
 const worker = createWorkerBuildIndex({
   workerPath: new URL('../app/out/main/indexer-worker.js', import.meta.url).pathname,
 });
-const benchClaudeDir = path.join(HOME, '.claude');
 
-// Pick a real transcript to feed as a changed path.
-function pickTranscript() {
-  const project = fs.readdirSync(CLAUDE_PROJECTS)[0];
-  const file = fs.readdirSync(path.join(CLAUDE_PROJECTS, project))
-    .find((name) => name.endsWith('.jsonl'));
-  return path.join(CLAUDE_PROJECTS, project, file);
+// ---- metric 1: idle changed-path build time on the real corpus ----
+
+// The measured cost is filesystem discovery over the real transcript tree,
+// not DB size — so a small clone carrying schema + index_state + sessions is
+// enough (the full 1 GB messages/FTS content is irrelevant to the walk).
+const corpusDb = path.join(tmp, 'corpus.sqlite');
+const schema = fs.readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+const clone = new DatabaseSync(corpusDb);
+clone.exec(schema);
+clone.exec(`ATTACH DATABASE '${LIVE_DB.replace(/'/g, "''")}' AS live`);
+// The measured finalize cost scales with the messages tables (per-session
+// cwd queries in refreshSessionProjectPaths); FTS content is not needed.
+for (const table of ['index_state', 'sessions', 'messages', 'tool_calls', 'tool_results']) {
+  clone.exec(`INSERT INTO ${table} SELECT * FROM live.${table}`);
 }
-
-const idleArgs = {
+clone.exec('DETACH DATABASE live');
+clone.close();
+const corpusArgs = {
   providerRoots: {},
-  claudeDir: benchClaudeDir,
+  claudeDir: path.join(HOME, '.claude'),
   codexDir: path.join(HOME, '.codex'),
   projectsDir: CLAUDE_PROJECTS,
-  dbPath,
+  dbPath: corpusDb,
 };
 
-// Warm-up (opens db, migrates, loads plan caches).
-await worker.buildIndex({ ...idleArgs, reason: 'warmup' });
-const changed = pickTranscript();
+{
+  const markerCheck = new DatabaseSync(corpusDb, { readOnly: true });
+  const ftsReady = markerCheck.prepare('SELECT COUNT(*) AS n FROM index_state WHERE jsonl_path = ?').get('__fts_triggers_ready__').n;
+  markerCheck.close();
+  const warmupStart = performance.now();
+  await worker.buildIndex({ ...corpusArgs, reason: 'warmup' });
+  console.log(`first build after open (cold, fts marker present: ${ftsReady > 0}): ${(performance.now() - warmupStart).toFixed(0)} ms`);
+}
+const project = fs.readdirSync(CLAUDE_PROJECTS)[0];
+const changed = path.join(
+  CLAUDE_PROJECTS,
+  project,
+  fs.readdirSync(path.join(CLAUDE_PROJECTS, project)).find((name) => name.endsWith('.jsonl')),
+);
 const idleTimes = [];
 for (let i = 0; i < 10; i++) {
+  // Force the file stale so the build does real changed-path work (the
+  // signature gate must reselect it); content is untouched.
+  const now = new Date();
+  fs.utimesSync(changed, now, now);
   const start = performance.now();
-  await worker.buildIndex({ ...idleArgs, reason: 'bench', changedPaths: [changed] });
+  await worker.buildIndex({ ...corpusArgs, reason: 'bench', changedPaths: [changed] });
   idleTimes.push(performance.now() - start);
 }
 console.log('idle changed-path build (real corpus, ms):');
 console.log(`  n=${idleTimes.length} p50=${percentile(idleTimes, 50).toFixed(0)} p95=${percentile(idleTimes, 95).toFixed(0)} mean=${(idleTimes.reduce((a, b) => a + b, 0) / idleTimes.length).toFixed(0)}`);
 
-// ---- metric 2+3: bounded scheduler under continuous writes ----
+// ---- metric 2: end-to-end latency under continuous writes (synthetic corpus) ----
 
-const liveRoot = path.join(tmp, 'projects', '-bench');
-fs.mkdirSync(liveRoot, { recursive: true });
-const liveFile = path.join(liveRoot, 'live-session.jsonl');
+const benchClaudeDir = path.join(tmp, 'bench-claude');
+const benchProjects = path.join(benchClaudeDir, 'projects');
+const liveDir = path.join(benchProjects, '-bench');
+fs.mkdirSync(liveDir, { recursive: true });
+const liveFile = path.join(liveDir, 'live-session.jsonl');
+const benchDb = path.join(tmp, 'bench.sqlite');
+const benchArgs = {
+  providerRoots: {},
+  claudeDir: benchClaudeDir,
+  codexDir: path.join(tmp, 'bench-codex'),
+  projectsDir: benchProjects,
+  dbPath: benchDb,
+};
+
 const claudeLine = (i) => JSON.stringify({
   uuid: `bench-${i}`,
   type: 'user',
@@ -81,12 +117,12 @@ fs.writeFileSync(liveFile, `${claudeLine(0)}\n`);
 
 const builds = [];
 const service = createIndexerService({
-  watchTargets: [{ kind: 'tree', path: path.join(tmp, 'projects') }],
+  watchTargets: [{ kind: 'tree', path: benchProjects }],
   hotPolling: false,
   buildIndex: async (args) => {
     const start = performance.now();
-    builds.push({ reason: args.reason, paths: args.changedPaths?.length, start });
-    await worker.buildIndex({ ...idleArgs, reason: args.reason, changedPaths: args.changedPaths });
+    builds.push({ reason: args.reason, paths: args.changedPaths, start });
+    await worker.buildIndex({ ...benchArgs, reason: args.reason, changedPaths: args.changedPaths });
     builds[builds.length - 1].end = performance.now();
   },
   writeHeartbeat: () => {},
@@ -98,26 +134,40 @@ await service.runBuildNow('startup');
 
 const DURATION_MS = 20000;
 const APPEND_INTERVAL_MS = 200;
+const appendTimes = [performance.now()];
 let appends = 1;
 const appendTimer = setInterval(() => {
   fs.appendFileSync(liveFile, `${claudeLine(appends++)}\n`);
+  appendTimes.push(performance.now());
 }, APPEND_INTERVAL_MS);
 await new Promise((resolve) => setTimeout(resolve, DURATION_MS));
 clearInterval(appendTimer);
-await new Promise((resolve) => setTimeout(resolve, 3000));
+await new Promise((resolve) => setTimeout(resolve, 4000));
 service.stop();
 await service.idle();
 
+// End-to-end proof: every appended line must be in the index.
+const check = new DatabaseSync(benchDb, { readOnly: true });
+const indexed = check.prepare(
+  "SELECT COUNT(*) AS n FROM messages WHERE uuid LIKE 'bench-%'",
+).get().n;
+check.close();
+
 const watchBuilds = builds.filter((b) => b.reason === 'watch' || b.reason === 'pending');
-const firstWatchTs = watchBuilds[0]?.start;
-const rate = watchBuilds.length / (DURATION_MS / 1000);
-const gaps = watchBuilds.slice(1).map((b, i) => b.start - watchBuilds[i].start);
+const firstWatchBuild = watchBuilds[0];
+const lastBuild = watchBuilds[watchBuilds.length - 1];
 const durations = watchBuilds.map((b) => (b.end ?? b.start) - b.start);
-console.log('continuous writes (200 ms append interval, 20 s window):');
-console.log(`  appends=${appends - 1} builds=${watchBuilds.length} (${rate.toFixed(2)}/s)`);
-console.log(`  build duration ms: p50=${percentile(durations, 50).toFixed(0)} p95=${percentile(durations, 95).toFixed(0)}`);
-console.log(`  inter-build gap ms: p50=${percentile(gaps, 50).toFixed(0)} p95=${percentile(gaps, 95).toFixed(0)} max=${Math.max(...gaps).toFixed(0)}`);
-console.log(`  first-change-to-first-build ms: ${firstWatchTs === undefined ? 'n/a' : (firstWatchTs - builds[0].end).toFixed(0)}`);
+const lastAppendTs = appendTimes[appendTimes.length - 1];
+
+console.log('continuous writes (200 ms append interval, 20 s window, synthetic corpus):');
+console.log(`  lines=${appends} indexed=${indexed} (${indexed === appends ? 'ALL — end-to-end confirmed' : 'MISSING LINES!'})`);
+console.log(`  builds=${watchBuilds.length} (${(watchBuilds.length / (DURATION_MS / 1000)).toFixed(2)}/s), duration p50=${percentile(durations, 50).toFixed(0)} ms`);
+if (firstWatchBuild) {
+  console.log(`  first-append -> first build containing it: ${(firstWatchBuild.end - appendTimes[0]).toFixed(0)} ms`);
+}
+if (lastBuild) {
+  console.log(`  last-append -> last build completing it: ${(lastBuild.end - lastAppendTs).toFixed(0)} ms (bounded; legacy trailing debounce would still be pending)`);
+}
 
 worker.stop();
 fs.rmSync(tmp, { recursive: true, force: true });

--- a/scripts/bench-scheduler.mjs
+++ b/scripts/bench-scheduler.mjs
@@ -40,6 +40,9 @@ const worker = createWorkerBuildIndex({
 });
 
 // ---- metric 1: idle changed-path build time on the real corpus ----
+const SKIP_CORPUS = process.env.BENCH_SKIP_CORPUS === '1';
+if (SKIP_CORPUS) console.log('[metric 1 skipped: BENCH_SKIP_CORPUS=1]');
+if (!SKIP_CORPUS) {
 
 // The measured cost is filesystem discovery over the real transcript tree,
 // not DB size — so a small clone carrying schema + index_state + sessions is
@@ -91,6 +94,7 @@ for (let i = 0; i < 10; i++) {
 staleness.close();
 console.log('idle changed-path build (real corpus, ms):');
 console.log(`  n=${idleTimes.length} p50=${percentile(idleTimes, 50).toFixed(0)} p95=${percentile(idleTimes, 95).toFixed(0)} mean=${(idleTimes.reduce((a, b) => a + b, 0) / idleTimes.length).toFixed(0)}`);
+}
 
 // ---- metric 2: end-to-end latency under continuous writes (synthetic corpus) ----
 
@@ -117,9 +121,12 @@ const claudeLine = (i) => JSON.stringify({
 fs.writeFileSync(liveFile, `${claudeLine(0)}\n`);
 
 const builds = [];
+const MAX_WAIT = Number(process.env.BENCH_MAX_WAIT_MS ?? 1500);
+console.log(`[metric 2 variant] maxWaitMs=${MAX_WAIT}`);
 const service = createIndexerService({
   watchTargets: [{ kind: 'tree', path: benchProjects }],
   hotPolling: false,
+  maxWaitMs: MAX_WAIT,
   buildIndex: async (args) => {
     const start = performance.now();
     builds.push({ reason: args.reason, paths: args.changedPaths, start });
@@ -165,6 +172,7 @@ console.log(`  lines=${appends} indexed=${indexed} (${indexed === appends ? 'ALL
 console.log(`  builds=${watchBuilds.length} (${(watchBuilds.length / (DURATION_MS / 1000)).toFixed(2)}/s), duration p50=${percentile(durations, 50).toFixed(0)} ms`);
 if (firstWatchBuild) {
   console.log(`  first-append -> first build indexing it: ${(firstWatchBuild.end - appendTimes[0]).toFixed(0)} ms (append->indexed; renderer-visible latency needs a GUI probe)`);
+console.log('  trigger attribution: run again with BENCH_MAX_WAIT_MS=0 — identical first-build timing means the trailing path fired, an earlier build means the ceiling fired.');
 }
 if (lastBuild) {
   console.log(`  last-append -> last build completing it: ${(lastBuild.end - lastAppendTs).toFixed(0)} ms (bounded; legacy trailing debounce would still be pending)`);

--- a/scripts/bench-scheduler.mjs
+++ b/scripts/bench-scheduler.mjs
@@ -79,15 +79,16 @@ const changed = path.join(
   fs.readdirSync(path.join(CLAUDE_PROJECTS, project)).find((name) => name.endsWith('.jsonl')),
 );
 const idleTimes = [];
+const staleness = new DatabaseSync(corpusDb);
 for (let i = 0; i < 10; i++) {
-  // Force the file stale so the build does real changed-path work (the
-  // signature gate must reselect it); content is untouched.
-  const now = new Date();
-  fs.utimesSync(changed, now, now);
+  // Force the file stale by rolling back the CLONE's cursor (never touch the
+  // real transcript's mtime — and never poke the running daemon's watcher).
+  staleness.prepare('UPDATE index_state SET mtime = 0, cursor = NULL WHERE jsonl_path = ?').run(changed);
   const start = performance.now();
   await worker.buildIndex({ ...corpusArgs, reason: 'bench', changedPaths: [changed] });
   idleTimes.push(performance.now() - start);
 }
+staleness.close();
 console.log('idle changed-path build (real corpus, ms):');
 console.log(`  n=${idleTimes.length} p50=${percentile(idleTimes, 50).toFixed(0)} p95=${percentile(idleTimes, 95).toFixed(0)} mean=${(idleTimes.reduce((a, b) => a + b, 0) / idleTimes.length).toFixed(0)}`);
 
@@ -134,7 +135,7 @@ await service.runBuildNow('startup');
 
 const DURATION_MS = 20000;
 const APPEND_INTERVAL_MS = 200;
-const appendTimes = [performance.now()];
+const appendTimes = [];
 let appends = 1;
 const appendTimer = setInterval(() => {
   fs.appendFileSync(liveFile, `${claudeLine(appends++)}\n`);
@@ -163,7 +164,7 @@ console.log('continuous writes (200 ms append interval, 20 s window, synthetic c
 console.log(`  lines=${appends} indexed=${indexed} (${indexed === appends ? 'ALL — end-to-end confirmed' : 'MISSING LINES!'})`);
 console.log(`  builds=${watchBuilds.length} (${(watchBuilds.length / (DURATION_MS / 1000)).toFixed(2)}/s), duration p50=${percentile(durations, 50).toFixed(0)} ms`);
 if (firstWatchBuild) {
-  console.log(`  first-append -> first build containing it: ${(firstWatchBuild.end - appendTimes[0]).toFixed(0)} ms`);
+  console.log(`  first-append -> first build indexing it: ${(firstWatchBuild.end - appendTimes[0]).toFixed(0)} ms (append->indexed; renderer-visible latency needs a GUI probe)`);
 }
 if (lastBuild) {
   console.log(`  last-append -> last build completing it: ${(lastBuild.end - lastAppendTs).toFixed(0)} ms (bounded; legacy trailing debounce would still be pending)`);

--- a/scripts/bench-scheduler.mjs
+++ b/scripts/bench-scheduler.mjs
@@ -1,0 +1,123 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// #86 merge-gate benchmark: measures the app daemon's real build latency on
+// the real indexed corpus, and the bounded scheduler's behavior under
+// continuous transcript writes. Runs the production worker
+// (app/out/main/indexer-worker.js, built by electron-vite) against a throwaway
+// COPY of the index database — the live database is never touched.
+//
+// Usage: node tmp/bench-scheduler.mjs
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { createWorkerBuildIndex } = await import('../app/src/main/indexer-worker-client.ts');
+const { createIndexerService } = await import('../app/src/main/indexer-service.ts');
+
+const HOME = os.homedir();
+const LIVE_DB = path.join(HOME, '.obelisk', 'obelisk.sqlite');
+const CLAUDE_PROJECTS = path.join(HOME, '.claude', 'projects');
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'obelisk-bench-'));
+const dbPath = path.join(tmp, 'bench.sqlite');
+fs.copyFileSync(LIVE_DB, dbPath);
+
+function percentile(values, p) {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))];
+}
+
+// ---- metric 1: idle changed-path build time on the real corpus ----
+
+const worker = createWorkerBuildIndex({
+  workerPath: new URL('../app/out/main/indexer-worker.js', import.meta.url).pathname,
+});
+const benchClaudeDir = path.join(HOME, '.claude');
+
+// Pick a real transcript to feed as a changed path.
+function pickTranscript() {
+  const project = fs.readdirSync(CLAUDE_PROJECTS)[0];
+  const file = fs.readdirSync(path.join(CLAUDE_PROJECTS, project))
+    .find((name) => name.endsWith('.jsonl'));
+  return path.join(CLAUDE_PROJECTS, project, file);
+}
+
+const idleArgs = {
+  providerRoots: {},
+  claudeDir: benchClaudeDir,
+  codexDir: path.join(HOME, '.codex'),
+  projectsDir: CLAUDE_PROJECTS,
+  dbPath,
+};
+
+// Warm-up (opens db, migrates, loads plan caches).
+await worker.buildIndex({ ...idleArgs, reason: 'warmup' });
+const changed = pickTranscript();
+const idleTimes = [];
+for (let i = 0; i < 10; i++) {
+  const start = performance.now();
+  await worker.buildIndex({ ...idleArgs, reason: 'bench', changedPaths: [changed] });
+  idleTimes.push(performance.now() - start);
+}
+console.log('idle changed-path build (real corpus, ms):');
+console.log(`  n=${idleTimes.length} p50=${percentile(idleTimes, 50).toFixed(0)} p95=${percentile(idleTimes, 95).toFixed(0)} mean=${(idleTimes.reduce((a, b) => a + b, 0) / idleTimes.length).toFixed(0)}`);
+
+// ---- metric 2+3: bounded scheduler under continuous writes ----
+
+const liveRoot = path.join(tmp, 'projects', '-bench');
+fs.mkdirSync(liveRoot, { recursive: true });
+const liveFile = path.join(liveRoot, 'live-session.jsonl');
+const claudeLine = (i) => JSON.stringify({
+  uuid: `bench-${i}`,
+  type: 'user',
+  timestamp: new Date().toISOString(),
+  message: { role: 'user', content: `append ${i}` },
+});
+fs.writeFileSync(liveFile, `${claudeLine(0)}\n`);
+
+const builds = [];
+const service = createIndexerService({
+  watchTargets: [{ kind: 'tree', path: path.join(tmp, 'projects') }],
+  hotPolling: false,
+  buildIndex: async (args) => {
+    const start = performance.now();
+    builds.push({ reason: args.reason, paths: args.changedPaths?.length, start });
+    await worker.buildIndex({ ...idleArgs, reason: args.reason, changedPaths: args.changedPaths });
+    builds[builds.length - 1].end = performance.now();
+  },
+  writeHeartbeat: () => {},
+  logger: { warn: () => {} },
+});
+
+service.start({ buildOnStart: false });
+await service.runBuildNow('startup');
+
+const DURATION_MS = 20000;
+const APPEND_INTERVAL_MS = 200;
+let appends = 1;
+const appendTimer = setInterval(() => {
+  fs.appendFileSync(liveFile, `${claudeLine(appends++)}\n`);
+}, APPEND_INTERVAL_MS);
+await new Promise((resolve) => setTimeout(resolve, DURATION_MS));
+clearInterval(appendTimer);
+await new Promise((resolve) => setTimeout(resolve, 3000));
+service.stop();
+await service.idle();
+
+const watchBuilds = builds.filter((b) => b.reason === 'watch' || b.reason === 'pending');
+const firstWatchTs = watchBuilds[0]?.start;
+const rate = watchBuilds.length / (DURATION_MS / 1000);
+const gaps = watchBuilds.slice(1).map((b, i) => b.start - watchBuilds[i].start);
+const durations = watchBuilds.map((b) => (b.end ?? b.start) - b.start);
+console.log('continuous writes (200 ms append interval, 20 s window):');
+console.log(`  appends=${appends - 1} builds=${watchBuilds.length} (${rate.toFixed(2)}/s)`);
+console.log(`  build duration ms: p50=${percentile(durations, 50).toFixed(0)} p95=${percentile(durations, 95).toFixed(0)}`);
+console.log(`  inter-build gap ms: p50=${percentile(gaps, 50).toFixed(0)} p95=${percentile(gaps, 95).toFixed(0)} max=${Math.max(...gaps).toFixed(0)}`);
+console.log(`  first-change-to-first-build ms: ${firstWatchTs === undefined ? 'n/a' : (firstWatchTs - builds[0].end).toFixed(0)}`);
+
+worker.stop();
+fs.rmSync(tmp, { recursive: true, force: true });

--- a/tests/app-indexer-service.test.mjs
+++ b/tests/app-indexer-service.test.mjs
@@ -12,20 +12,33 @@ const require = createRequire(import.meta.url);
 import { createIndexerService } from '../app/src/main/indexer-service.ts';
 
 function manualTimers() {
-  const timers = new Set();
+  // A mock clock: setTimeout records the fn with its due time; tick(ms)
+  // advances the clock and fires due timers in due order. flush() fires
+  // everything pending — fine for tests that do not care about ordering, but
+  // meaningless for proving a ceiling, since it ignores delays entirely.
+  let now = 0;
+  const timers = new Map();
   const delays = [];
   return {
     delays,
-    setTimeout(fn, ms) {
-      timers.add(fn);
+    setTimeout(fn, ms = 0) {
       delays.push(ms);
+      timers.set(fn, now + ms);
       return fn;
     },
     clearTimeout(fn) {
       timers.delete(fn);
     },
+    tick(ms) {
+      now += ms;
+      for (const [fn, due] of [...timers.entries()].sort((a, b) => a[1] - b[1])) {
+        if (due > now) continue;
+        timers.delete(fn);
+        fn();
+      }
+    },
     flush() {
-      const pending = [...timers];
+      const pending = [...timers.keys()];
       timers.clear();
       for (const fn of pending) fn();
     },
@@ -583,25 +596,64 @@ test('sustained events cannot postpone a build past the max-wait ceiling', async
     writeHeartbeat: () => {},
     timers,
     stabilityMs: 0,
-    debounceMs: 0,
+    // Trailing is set far beyond the ceiling so the ceiling is the only
+    // timer that can fire inside the test window.
+    debounceMs: 5000,
     maxWaitMs: 1500,
   });
 
-  // Every event resets the trailing timer; the max-wait ceiling still
-  // releases exactly one build with the whole accumulated batch.
+  // t=0: first event arms trailing (250 ms) and the ceiling (1500 ms).
   service.scheduleBuild('watch', 'a.jsonl');
+  timers.tick(1499);
+  assert.deepEqual(calls, [], 'neither timer is due yet');
+
+  // t=1499: another event resets ONLY the trailing timer. If the ceiling
+  // were (incorrectly) reset too, it would not be due for another 1500 ms.
   service.scheduleBuild('watch', 'b.jsonl');
-  service.scheduleBuild('watch', 'c.jsonl');
-  timers.flush();
+  timers.tick(1);
   await service.idle();
 
-  assert.equal(calls.length, 1, 'sustained events coalesce into one bounded build');
-  assert.deepEqual(calls[0].changedPaths, ['a.jsonl', 'b.jsonl', 'c.jsonl']);
+  assert.equal(calls.length, 1, 'the ceiling fires at t=1500 despite the fresh event');
+  assert.deepEqual(calls[0].changedPaths, ['a.jsonl', 'b.jsonl']);
   assert.equal(calls[0].reason, 'watch');
 
   timers.flush();
   await service.idle();
   assert.equal(calls.length, 1, 'no second build fires from a cleared or stale timer');
+});
+
+test('the final write is indexed by the trailing build after the source goes quiet', async () => {
+  const timers = manualTimers();
+  const calls = [];
+  const service = createIndexerService({
+    buildIndex: async (args) => calls.push(args),
+    watchProjects: () => null,
+    writeHeartbeat: () => {},
+    timers,
+    stabilityMs: 500,
+    debounceMs: 250,
+    maxWaitMs: 1500,
+  });
+
+  service.scheduleBuild('watch', 'a.jsonl');
+  service.scheduleBuild('watch', 'b.jsonl');
+  timers.tick(1500);
+  await service.idle();
+  assert.equal(calls.length, 1, 'the burst builds once');
+
+  // The last write: only the trailing path may release this build.
+  service.scheduleBuild('watch', 'c.jsonl');
+  timers.tick(249);
+  await service.idle();
+  assert.equal(calls.length, 1, 'still inside the trailing debounce');
+  timers.tick(1); // t=250: debounce elapses, stability starts
+  timers.tick(499);
+  await service.idle();
+  assert.equal(calls.length, 1, 'still inside the stability window');
+  timers.tick(1); // t=500: stability elapses
+  await service.idle();
+  assert.equal(calls.length, 2, 'the trailing build runs after the source goes quiet');
+  assert.deepEqual(calls[1].changedPaths, ['c.jsonl'], 'the final write is indexed');
 });
 
 test('events during a build produce exactly one follow-up and no ghost build', async () => {

--- a/tests/app-indexer-service.test.mjs
+++ b/tests/app-indexer-service.test.mjs
@@ -349,6 +349,9 @@ test('indexer service waits for a stability window before building', async () =>
     writeHeartbeat: () => {},
     timers,
     stabilityMs: 500,
+    // This test pins the trailing two-stage path; the manual timers flush
+    // every delay together, which would fire the max-wait timer early.
+    maxWaitMs: 0,
   });
 
   service.scheduleBuild('jsonl-change');
@@ -566,4 +569,119 @@ test('indexer service starts watching a configured root that appears after start
   } finally {
     service.stop();
   }
+});
+
+
+// ---- bounded scheduling (#86) ----
+
+test('sustained events cannot postpone a build past the max-wait ceiling', async () => {
+  const timers = manualTimers();
+  const calls = [];
+  const service = createIndexerService({
+    buildIndex: async (args) => calls.push(args),
+    watchProjects: () => null,
+    writeHeartbeat: () => {},
+    timers,
+    stabilityMs: 0,
+    debounceMs: 0,
+    maxWaitMs: 1500,
+  });
+
+  // Every event resets the trailing timer; the max-wait ceiling still
+  // releases exactly one build with the whole accumulated batch.
+  service.scheduleBuild('watch', 'a.jsonl');
+  service.scheduleBuild('watch', 'b.jsonl');
+  service.scheduleBuild('watch', 'c.jsonl');
+  timers.flush();
+  await service.idle();
+
+  assert.equal(calls.length, 1, 'sustained events coalesce into one bounded build');
+  assert.deepEqual(calls[0].changedPaths, ['a.jsonl', 'b.jsonl', 'c.jsonl']);
+  assert.equal(calls[0].reason, 'watch');
+
+  timers.flush();
+  await service.idle();
+  assert.equal(calls.length, 1, 'no second build fires from a cleared or stale timer');
+});
+
+test('events during a build produce exactly one follow-up and no ghost build', async () => {
+  const timers = manualTimers();
+  const calls = [];
+  let finishFirst;
+  const service = createIndexerService({
+    buildIndex: async (args) => {
+      calls.push(args);
+      if (args.reason === 'first') await new Promise((resolve) => { finishFirst = resolve; });
+    },
+    watchProjects: () => null,
+    writeHeartbeat: () => {},
+    timers,
+    stabilityMs: 0,
+    debounceMs: 0,
+  });
+
+  const first = service.runBuildNow('first');
+  service.scheduleBuild('watch', 'a.jsonl');
+  service.scheduleBuild('watch', 'b.jsonl');
+  timers.flush();
+  assert.deepEqual(calls.map((c) => c.reason), ['first'],
+    'burst timers are not armed while a build is running');
+
+  finishFirst();
+  await first;
+  await service.idle();
+  assert.deepEqual(calls.map((c) => c.reason), ['first', 'pending'],
+    'exactly one follow-up build runs');
+  assert.deepEqual(calls[1].changedPaths, ['a.jsonl', 'b.jsonl'],
+    'the follow-up carries the accumulated batch — not an accidental full inventory');
+
+  timers.flush();
+  await service.idle();
+  assert.equal(calls.length, 2, 'no ghost build fires afterwards');
+});
+
+test('each burst re-arms the max-wait ceiling after the previous build', async () => {
+  const timers = manualTimers();
+  const calls = [];
+  const service = createIndexerService({
+    buildIndex: async (args) => calls.push(args),
+    watchProjects: () => null,
+    writeHeartbeat: () => {},
+    timers,
+    stabilityMs: 0,
+    debounceMs: 0,
+    maxWaitMs: 1500,
+  });
+
+  service.scheduleBuild('watch', 'a.jsonl');
+  timers.flush();
+  await service.idle();
+  assert.equal(calls.length, 1);
+
+  service.scheduleBuild('watch', 'b.jsonl');
+  timers.flush();
+  await service.idle();
+  assert.equal(calls.length, 2, 'a new burst builds again');
+  assert.deepEqual(calls[1].changedPaths, ['b.jsonl']);
+});
+
+test('maxWaitMs 0 keeps the legacy unbounded trailing debounce', async () => {
+  const timers = manualTimers();
+  const calls = [];
+  const service = createIndexerService({
+    buildIndex: async (args) => calls.push(args),
+    watchProjects: () => null,
+    writeHeartbeat: () => {},
+    timers,
+    stabilityMs: 0,
+    debounceMs: 0,
+    maxWaitMs: 0,
+  });
+
+  service.scheduleBuild('watch', 'a.jsonl');
+  service.scheduleBuild('watch', 'b.jsonl');
+  timers.flush();
+  await service.idle();
+  assert.equal(calls.length, 1, 'the trailing path alone still coalesces the burst');
+  assert.deepEqual(calls[0].changedPaths, ['a.jsonl', 'b.jsonl']);
 });

--- a/tests/app-indexer-service.test.mjs
+++ b/tests/app-indexer-service.test.mjs
@@ -701,20 +701,58 @@ test('each burst re-arms the max-wait ceiling after the previous build', async (
     writeHeartbeat: () => {},
     timers,
     stabilityMs: 0,
-    debounceMs: 0,
+    debounceMs: 5000,
     maxWaitMs: 1500,
   });
 
   service.scheduleBuild('watch', 'a.jsonl');
-  timers.flush();
+  timers.tick(1499);
+  assert.deepEqual(calls, []);
+  timers.tick(1);
   await service.idle();
-  assert.equal(calls.length, 1);
+  assert.equal(calls.length, 1, 'the first burst builds at its ceiling');
 
   service.scheduleBuild('watch', 'b.jsonl');
-  timers.flush();
+  timers.tick(1499);
   await service.idle();
-  assert.equal(calls.length, 2, 'a new burst builds again');
+  assert.equal(calls.length, 1, 'the second burst is still inside its own ceiling');
+  timers.tick(1);
+  await service.idle();
+  assert.equal(calls.length, 2, 'the second burst builds at its own ceiling');
   assert.deepEqual(calls[1].changedPaths, ['b.jsonl']);
+});
+
+test('sustained activity converges to periodic builds instead of postponing forever', async () => {
+  const timers = manualTimers();
+  const calls = [];
+  const service = createIndexerService({
+    buildIndex: async (args) => calls.push(args),
+    watchProjects: () => null,
+    writeHeartbeat: () => {},
+    timers,
+    stabilityMs: 0,
+    debounceMs: 5000,
+    maxWaitMs: 1500,
+  });
+
+  // One event every 300 ms for 4.5 s — far beyond the legacy 2 s trailing
+  // window, which would never fire at all. The ceiling must release builds
+  // periodically and cover every event.
+  for (let t = 0; t < 15; t++) {
+    service.scheduleBuild('watch', `session-${t}.jsonl`);
+    timers.tick(300);
+    await service.idle();
+  }
+  timers.tick(600);
+  await service.idle();
+
+  assert.equal(calls.length, 3, 'periodic builds at the 1.5 s ceiling');
+  const covered = [...new Set(calls.flatMap((c) => c.changedPaths ?? []))];
+  assert.deepEqual(
+    covered,
+    Array.from({ length: 15 }, (_, i) => `session-${i}.jsonl`),
+    'every event is batched into a build — nothing is dropped or deferred forever',
+  );
 });
 
 test('maxWaitMs 0 keeps the legacy unbounded trailing debounce', async () => {
@@ -726,14 +764,16 @@ test('maxWaitMs 0 keeps the legacy unbounded trailing debounce', async () => {
     writeHeartbeat: () => {},
     timers,
     stabilityMs: 0,
-    debounceMs: 0,
+    debounceMs: 250,
     maxWaitMs: 0,
   });
 
   service.scheduleBuild('watch', 'a.jsonl');
   service.scheduleBuild('watch', 'b.jsonl');
-  timers.flush();
+  timers.tick(249);
+  assert.deepEqual(calls, [], 'no ceiling fires while disabled');
+  timers.tick(1);
   await service.idle();
-  assert.equal(calls.length, 1, 'the trailing path alone still coalesces the burst');
+  assert.equal(calls.length, 1, 'the trailing path alone coalesces the burst');
   assert.deepEqual(calls[0].changedPaths, ['a.jsonl', 'b.jsonl']);
 });

--- a/tests/app-indexer-service.test.mjs
+++ b/tests/app-indexer-service.test.mjs
@@ -768,12 +768,22 @@ test('maxWaitMs 0 keeps the legacy unbounded trailing debounce', async () => {
     maxWaitMs: 0,
   });
 
-  service.scheduleBuild('watch', 'a.jsonl');
-  service.scheduleBuild('watch', 'b.jsonl');
-  timers.tick(249);
-  assert.deepEqual(calls, [], 'no ceiling fires while disabled');
-  timers.tick(1);
+  // Events every 100 ms for 1.8 s — faster than the 250 ms trailing
+  // debounce, and past the would-be 1500 ms ceiling. With the cap disabled
+  // there must be NO build while events keep coming...
+  for (let t = 0; t < 18; t++) {
+    service.scheduleBuild('watch', `session-${t}.jsonl`);
+    timers.tick(100);
+    await service.idle();
+  }
+  assert.deepEqual(calls, [], 'no ceiling fires while disabled, even past 1500 ms');
+
+  // ...and once the source goes quiet, the trailing path coalesces them all.
+  timers.tick(250);
   await service.idle();
   assert.equal(calls.length, 1, 'the trailing path alone coalesces the burst');
-  assert.deepEqual(calls[0].changedPaths, ['a.jsonl', 'b.jsonl']);
+  assert.deepEqual(
+    [...new Set(calls[0].changedPaths)],
+    Array.from({ length: 18 }, (_, i) => `session-${i}.jsonl`),
+  );
 });


### PR DESCRIPTION
Refs #86. **Stacked on #102** (base `fix/claude-torn-tail-cursor`; stack: #83 → #88 → #90 → #102 → this PR). #102 is the correctness prerequisite: bounded scheduling builds during continuous appends, and Claude's line-count cursor must not skip torn tail lines first.

## Implementation

The build scheduler in `app/src/main/indexer-service.ts` is rewritten as an explicit state machine with three rules:

**1. Typed batches — `undefined` no longer means two things.**
`takeBatch()` returns `{ kind: 'full' } | { kind: 'paths'; paths: string[] } | null`. Burst timer callbacks take the batch first and no-op on `null`, so a stale callback can never accidentally launch a full scan. Explicit `runBuildNow` (startup / manual / reconcile) keeps its legacy contract: no accumulated work means a full build. The retry paths (writer-lease deferral, incomplete inventory) re-seed through the same typed channel.

**2. `running === true` arms no burst timers.**
While a build is in flight, events only aggregate paths and set `pending`. Starting a batch (initial or pending follow-up) clears all burst timers as an invariant. Continuous writes rate-limit naturally: idle gaps are governed by trailing/maxWait, in-flight periods by build duration itself, each follow-up consuming the batch accumulated during the previous build. This **structurally eliminates the existing ghost full-inventory build** (present in production today: an event during a build sets `pending` *and* arms the trailing timer; the pending follow-up consumes the paths, then the armed timer fires a redundant full-inventory build). A new test pins: events during a long build → exactly one `pending` follow-up carrying the accumulated batch, and no third build afterwards.

**3. Trailing debounce + maximum wait while idle.**
- `debounceMs` default 2000 → **250 ms** to coalesce one filesystem burst; `stabilityMs` 500 ms unchanged for the quiet path.
- New `maxWaitMs` (default **1500 ms**, finalized per the benchmark below): arms once per burst on the first event, never resets, so sustained activity cannot postpone a build past the ceiling. `maxWaitMs <= 0` disables the cap (legacy unbounded behavior).
- Final-state convergence is unchanged: quiet sources still get the trailing build; `running/pending` single-flight is untouched.
- Final-state convergence is unchanged: quiet sources still get the trailing build; `running/pending` single-flight is untouched. The nonce-freshness poll cap in `packages/core/src/core.ts` is **not** changed by this PR (an earlier revision briefly raised it; reverted as out of scope — cold-build cost belongs to #105).

## Tests

- The delay-aware harness (`tick(ms)` mock clock) proves the ceiling fires at exactly 1500 ms while fresh events reset only the trailing timer — a maxWait-resetting implementation fails these tests.
- Sustained activity (15 events at 300 ms intervals, beyond the legacy 2 s window) converges to three periodic builds covering every event — nothing is dropped or deferred forever.
- Quiet-tail: after the ceiling build, a final write is indexed via the trailing 250 ms + 500 ms two-stage path.
- Events throughout a long build: burst timers are provably not armed, exactly one `pending` follow-up runs carrying the accumulated batch (not an accidental full inventory), and nothing fires afterwards.
- Each new burst re-arms the ceiling; `maxWaitMs: 0` disables it (proven: no ceiling fires, the trailing path alone coalesces).
- The pre-existing stability two-stage test disables maxWait explicitly (the harness's `flush()` ignores delays); all other pre-existing assertions pass unchanged.

## Merge-gate benchmark (recorded, this machine's real corpus, 523 sessions / ~18.7k transcripts / ~740 MB messages)

Script: `scripts/bench-scheduler.mjs` (production worker against throwaway clones; the live DB is never touched).

**Scheduler (end-to-end, synthetic corpus with DB verification and A/B trigger attribution, single clean run on the final head):**
- Continuous writes at 200 ms intervals for 20 s: **100/100 appended lines indexed** (verified in the DB, not just build counts).
- **Trigger attribution, instrumented** (the review asked: how do you know it was the ceiling?): with `maxWaitMs: 1500`, **13 builds (0.65/s)** land periodically across the window, first-append→indexed **1311 ms**; with `BENCH_MAX_WAIT_MS=0`, **1 build total (0.05/s)**, first-append→indexed **20532 ms**. Same protocol, only the cap differs: the periodic behavior is attributable to the ceiling, and its absence reproduces the legacy unbounded postponement exactly.
- Last-append → last build completing it: **~830 ms** (trailing path) in both variants.
**Renderer-visible latency (measured, `scripts/bench-renderer-latency.mjs`):** boots the real app (`out/main/index.js`) against a synthetic HOME and measures append→indexed (db row) and append→renderer-visible (DOM text via CDP) concurrently from t=0, under two workloads:

- **A — isolated bursts (quiet-tail)**: p50 **1015 ms**, p95 **1769 ms**.
- **B — continuous writes on a strict 200 ms schedule (writer stops at 10 s, then a drain window until the cohort is complete)**: builds fire **periodically at ~1.6 s** (ceiling 1500 ms + ~100 ms build/jitter, observed via 400 ms cursor sampling). append→indexed **p50 882 ms / p95 1635 ms / max 1668 ms**; append→renderer-visible **p50 883 ms / p95 1654 ms / max 1682 ms** — **49/49, complete cohort** (the probe exits non-zero if any line fails to become indexed or visible after the drain window). Renderer-visible tracks indexed within one poll cycle (~100 ms) — the renderer is not the bottleneck; the ceiling governs.

The ADR's p95 ≤ 4 s renderer-visible target is measured and met in both workloads. GUI probes are environment-dependent; the probe is reproducible with `node scripts/bench-renderer-latency.mjs`.
- Methodology: staleness is forced by rolling back the **clone's** cursor — the real transcript files are never touched (no `utimesSync` on user data, no poking the running daemon's watcher).

- Methodology: staleness is forced by rolling back the **clone's** cursor — the real transcript files are never touched (no `utimesSync` on user data, no poking the running daemon's watcher).

**Build cost (real corpus):**
- First build after opening a cold corpus DB: **3.7 s this run** (3.7–10.5 s across runs — cache-state dependent) — dominated by `refreshSessionProjectPaths` doing one unindexed per-session scan of the messages table (measured standalone at ~3.9 s warm, more cold). Filed as #105 with corrected root cause.
- Steady-state changed-path build: **p50 63 ms** (p95 1.5 s under cache pressure). Discovery over the same tree: ~17–60 ms — not the bottleneck. `maxWaitMs` is finalized at 1500 ms per these measurements and the A/B attribution above.

## Verification

- `npm test`: 500/500 on the final head, including all pre-existing indexer-service assertions and the new bounded-scheduling tests. `npm run typecheck` clean. Tracked-file lint: 0 errors.
- `npm run test:electron:all`: 4/5 — `electron-session-virtualization` fails identically on `origin/main` in this environment (pre-existing, tracked as #89; the path is renderer-only with mocked IPC and does not touch the watcher or scheduler).
- The new max-wait tests run on a delay-aware manual-timer harness (`tick(ms)` advances a mock clock): the ceiling is proven to fire at exactly 1500 ms with fresh events resetting only the trailing timer — a maxWait-resetting implementation would fail these tests.
