### PR TITLE
test(app): fix Codex result virtualization fixture

### DIFF
--- a/app/tests/electron-session-virtualization.mjs
+++ b/app/tests/electron-session-virtualization.mjs
@@ -103,6 +103,7 @@ const toolResults = [{
   is_error: 0,
 }, {
   tool_use_id: 'call-codex-exec',
+  message_uuid: focusMessageUuid,
   content: codexExecOutput,
   is_error: 0,
 }];


### PR DESCRIPTION
**Stacked on #103** (base `feat/bounded-index-scheduling`; full stack: #83 → #88 → #90 → #102 → #103 → this PR).

## Summary

- Restore the fifth Electron suite by making its Codex tool-result fixture conform to the canonical session-detail schema.
- Confirm that the timed-out result update now reaches the incremental patch, rerenders the mounted row, and preserves disclosure/Raw state.

## Scope

- In scope: the `call-codex-exec` fixture row used by `electron-session-virtualization.mjs`.
- Out of scope: renderer, patch, watcher, scheduler, and production indexing behavior.

## Root Cause

The fixture's Codex tool result omitted `message_uuid`. The canonical assembler filters tool results through visible message identity before attaching them to tool calls, so the result was absent from both the original and updated assembled snapshots. Replacing its content therefore produced no changed message, and the DOM assertion waited forever.

## Validation

- `env -u ELECTRON_RUN_AS_NODE npm run test:electron:all` from `app/`: 5/5 Electron suites passed.
- `npm run typecheck`: passed for root and app TypeScript configs.
- The previously failing `updated Codex exec result` assertion passes, and the following disclosure/Raw-state preservation assertion also passes.

## Risks and Rollback

- Risk is limited to test-fixture fidelity; no production source changes.
- Rollback is the single fixture-field insertion.

## Related Issues

- Related to #103

Closes #89
