### PR TITLE
docs(adr): mark ADR-0009 as accepted

### DIFF
--- a/docs/adr/0009-standalone-adaptive-watcher-package.md
+++ b/docs/adr/0009-standalone-adaptive-watcher-package.md
@@ -1,6 +1,6 @@
 # Package the hybrid watcher as a standalone adaptive watcher
 
-**Status: proposed.**
+**Status: accepted.**
 
 **Context.** Obelisk needs low-latency indexing of agent transcripts without
 making filesystem notifications the source of truth. No single native watcher


### PR DESCRIPTION
ADR-0009's status was still `proposed`, but the entire adaptive-watcher stack implementing it has merged (#83, #88, #90, #102, #103, #106). One-line status update to `accepted`.