### PR TITLE
fix(app): truncate long project breadcrumbs

### DIFF
--- a/app/src/renderer/src/App.vue
+++ b/app/src/renderer/src/App.vue
@@ -468,7 +468,12 @@ provide('recapGenerateOpen', recapGenerateOpen);
                   {{ currentRouteType === 'sessions' ? 'Sessions' : 'Memory' }}
                 </button>
                 <span class="crumb-sep">/</span>
-                <span class="crumb terminal">{{ formatProjectLabel(state.projectFilter) }}</span>
+                <span
+                  class="crumb terminal project-crumb"
+                  :title="formatProjectLabel(state.projectFilter)"
+                >
+                  {{ formatProjectLabel(state.projectFilter) }}
+                </span>
               </template>
               <template v-else>
                 <span class="crumb terminal">

--- a/app/src/renderer/styles/toolbar.css
+++ b/app/src/renderer/styles/toolbar.css
@@ -24,6 +24,10 @@
   .crumb:hover { background: var(--surface-strong); color: var(--fg-2); }
   .crumb.terminal { color: var(--fg); font-weight: 600; cursor: default; }
   .crumb.terminal:hover { background: transparent; }
+  .crumb.project-crumb {
+    display: block; flex: 1 1 auto; min-width: 0;
+    overflow: hidden; text-overflow: ellipsis;
+  }
   .crumb svg { width: 13px; height: 13px; color: var(--muted); }
   .crumb.filename {
     font-family: var(--font-mono); font-weight: 500; color: var(--fg);
@@ -101,7 +105,7 @@
   .tab-group button.active { background: var(--accent-soft); color: var(--accent-2); }
 
   /* Source filter */
-  .source-filter-wrap { position: relative; }
+  .source-filter-wrap { position: relative; flex-shrink: 0; }
   .filter-btn {
     display: inline-flex; align-items: center; gap: 6px;
     height: 26px; padding: 0 10px;


### PR DESCRIPTION
## Reproduction

A long project name can consume the toolbar width and collide with the source filter and search controls.

## Root cause

The project breadcrumb had no shrink or truncation boundary, while the source-filter control was allowed to shrink.

## Fix

- Give only the project crumb a shrinking, trailing-ellipsis treatment and expose the full name through `title`.
- Keep the source-filter control at its intrinsic width.
- Leave the shared `.breadcrumb` container unchanged, so SessionDetail, MemoryDetail, and RecapDetail title crumbs are not clipped.

![Long project breadcrumb truncated before the source filter](https://raw.githubusercontent.com/cunninghamcard-bit/obelisk/pr-assets-116/obelisk-source-filter.png)

## Verification

- `npm test`: 546/546 passed.
- `npm run typecheck`: root and app tsconfigs passed (2/2).
- `npm run lint`: 0 errors, 9 existing warnings.
- `npm run test:electron:all`: 4/5 suites passed locally; `electron-session-virtualization.mjs` failed macOS hidden-window wheel/timing assertions. The unchanged `origin/main` baseline also produced 4/5 in the same environment (virtualization failed with `patchReads: 0`). No test assertion was changed or loosened.

## Scope

This PR only addresses project breadcrumb layout. The source-filter outside-click behavior remains in #116.