### PR TITLE
fix(cli): resolve --query invocations by script content when the path is transcript-invisible

### DIFF
--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { copyFileSync, mkdirSync, rmSync } from 'node:fs';
+import { chmodSync, copyFileSync, mkdirSync, rmSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -17,3 +17,6 @@ execFileSync(process.execPath, [tsc, '-p', resolve(cliRoot, 'tsconfig.build.json
 const schemaTarget = resolve(outDir, 'core/src/schema.sql');
 mkdirSync(dirname(schemaTarget), { recursive: true });
 copyFileSync(resolve(repoRoot, 'packages/core/src/schema.sql'), schemaTarget);
+
+// tsc emits 0644; restore the bin shebang's executable bit so npm-linked installs keep working.
+chmodSync(resolve(outDir, 'cli/src/obelisk.js'), 0o755);

--- a/packages/cli/src/obelisk.ts
+++ b/packages/cli/src/obelisk.ts
@@ -76,9 +76,17 @@ async function main() {
   }
   if (args[0] === '--query' && args[1]) {
     try {
-      // The nonce is the query file path as typed (not resolved): the
-      // transcript records what the agent typed.
-      emit(await executeQuery(readFileSync(resolve(args[1]), 'utf8'), { invocationNonce: args[1] }));
+      const script = readFileSync(resolve(args[1]), 'utf8');
+      // Nonce candidates, tried in order: the file path as typed (not
+      // resolved), then the script content itself. The transcript records the
+      // content verbatim (Write input, heredoc command text) even when the
+      // path sits behind a shell variable — the documented mktemp flow — and
+      // never reaches the transcript. Short scripts are not distinctive enough
+      // to safely identify a session, so the path stands alone there.
+      const CONTENT_NONCE_MIN_CHARS = 40;
+      const trimmed = script.trim();
+      const nonceCandidates = trimmed.length >= CONTENT_NONCE_MIN_CHARS ? [args[1], trimmed] : [args[1]];
+      emit(await executeQuery(script, { invocationNonce: nonceCandidates }));
     } catch (error) { fail(error); }
     return;
   }

--- a/packages/cli/src/obelisk.ts
+++ b/packages/cli/src/obelisk.ts
@@ -82,10 +82,14 @@ async function main() {
       // content verbatim (Write input, heredoc command text) even when the
       // path sits behind a shell variable — the documented mktemp flow — and
       // never reaches the transcript. Short scripts are not distinctive enough
-      // to safely identify a session, so the path stands alone there.
+      // to safely identify a session, so the path stands alone there. Content
+      // is not unique by construction, so it resolves in strict mode: exactly
+      // one recent matching session that itself invoked the CLI, else null.
       const CONTENT_NONCE_MIN_CHARS = 40;
       const trimmed = script.trim();
-      const nonceCandidates = trimmed.length >= CONTENT_NONCE_MIN_CHARS ? [args[1], trimmed] : [args[1]];
+      const nonceCandidates = trimmed.length >= CONTENT_NONCE_MIN_CHARS
+        ? [args[1], { value: trimmed, strict: true }]
+        : [args[1]];
       emit(await executeQuery(script, { invocationNonce: nonceCandidates }));
     } catch (error) { fail(error); }
     return;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -35,7 +35,11 @@ interface InvocationOptions {
   // the as-typed --query path first and the script content second: transcripts
   // record the content verbatim (Write input, heredoc command text) even when
   // the path sits behind a shell variable and never reaches the transcript.
-  invocationNonce?: string | readonly string[];
+  // A strict candidate (used for script content, which is not unique by
+  // construction — boilerplate queries recur across sessions) resolves only
+  // when exactly one recent session matches and that session itself holds a
+  // recent CLI invocation record; anything else is honest null.
+  invocationNonce?: string | readonly (string | { value: string; strict?: boolean })[];
 }
 
 interface InventoryIssue {
@@ -139,13 +143,14 @@ interface InvocationResolveOptions {
 // resolveInvokingSessionIdWithWait below.
 export function resolveInvokingSessionId(
   db: SqliteDb,
-  nonce: string | readonly string[] | null | undefined,
+  nonce: string | readonly (string | { value: string; strict?: boolean })[] | null | undefined,
   opts: InvocationResolveOptions = {},
 ): string | null {
-  const candidates = Array.isArray(nonce) ? nonce : [nonce];
-  for (const candidate of candidates) {
-    if (!candidate) continue;
-    const hit = resolveSingleInvocationNonce(db, candidate, opts);
+  const raw = Array.isArray(nonce) ? nonce : [nonce];
+  for (const entry of raw) {
+    const candidate = typeof entry === 'string' ? { value: entry } : entry;
+    if (!candidate?.value) continue;
+    const hit = resolveSingleInvocationNonce(db, candidate.value, opts, candidate.strict === true);
     if (hit) return hit;
   }
   return null;
@@ -155,6 +160,7 @@ function resolveSingleInvocationNonce(
   db: SqliteDb,
   nonce: string,
   { nowMs = Date.now(), recencyMs = INVOCATION_RECENCY_MS, collisionMs = INVOCATION_COLLISION_MS }: InvocationResolveOptions,
+  strict = false,
 ): string | null {
   // The query path is read-only and may face a partially built index (for
   // example only index_state exists while a writer lease is held). A missing
@@ -211,6 +217,18 @@ function resolveSingleInvocationNonce(
     }
   }
   if (newestBySession.size === 0) return null;
+  if (strict) {
+    // Content-derived candidates are not unique by construction (boilerplate
+    // queries recur across sessions), so newest-wins is not enough. Resolve
+    // only when exactly one recent session matches AND that session itself
+    // holds a recent CLI invocation record — the invoker's transcript always
+    // contains both the file write and the `obelisk --query` call, while a
+    // stranger who merely wrote or quoted the same content does not invoke.
+    // Zero or multiple eligible sessions are honest null, never a guess.
+    const invokers = recentCliInvokerSessions(db, cutoff, indexedTables);
+    const eligible = [...newestBySession.keys()].filter(id => invokers.has(id));
+    return eligible.length === 1 ? eligible[0] : null;
+  }
   const ranked = [...newestBySession.entries()]
     .map(([sessionId, timestamp]) => ({ sessionId, ms: Date.parse(timestamp) }))
     .sort((a, b) => b.ms - a.ms);
@@ -218,6 +236,38 @@ function resolveSingleInvocationNonce(
   if (ranked.some(r => Number.isNaN(r.ms))) return null;
   if (ranked.length > 1 && ranked[0].ms - ranked[1].ms <= collisionMs) return null;
   return ranked[0].sessionId;
+}
+
+// Sessions holding a recent record of an actual CLI invocation (`obelisk
+// --query ...` / `obelisk --search ...` in a tool-call command line or message
+// text). Bounded to the same recency window as the nonce legs.
+function recentCliInvokerSessions(
+  db: SqliteDb,
+  cutoff: string,
+  indexedTables: Set<string>,
+): Set<string> {
+  const invokers = new Set<string>();
+  const patterns = ['%obelisk --%', '%obelisk.js --%'];
+  if (indexedTables.has('tool_calls') && indexedTables.has('messages')) {
+    const rows = db.prepare(`
+      SELECT DISTINCT tc.session_id AS session_id
+      FROM messages m CROSS JOIN tool_calls tc ON tc.message_uuid = m.uuid
+      WHERE m.timestamp >= ? AND (tc.input_json LIKE ? OR tc.input_json LIKE ?)
+    `).all(cutoff, ...patterns);
+    for (const row of rows) {
+      if (typeof row.session_id === 'string') invokers.add(row.session_id);
+    }
+  }
+  if (indexedTables.has('messages')) {
+    const rows = db.prepare(`
+      SELECT DISTINCT session_id FROM messages
+      WHERE timestamp >= ? AND (text LIKE ? OR text LIKE ?)
+    `).all(cutoff, ...patterns);
+    for (const row of rows) {
+      if (typeof row.session_id === 'string') invokers.add(row.session_id);
+    }
+  }
+  return invokers;
 }
 
 // Poll bounds for the nonce freshness fallback. The poll runs only when the
@@ -261,7 +311,7 @@ function sleepSync(ms: number): void {
 // honest null. Queries without a nonce or with an immediate hit pay zero
 // added latency.
 export function resolveInvokingSessionIdWithWait(
-  nonce: string | readonly string[] | null | undefined,
+  nonce: string | readonly (string | { value: string; strict?: boolean })[] | null | undefined,
   providerRegistry: ProviderRegistry,
   {
     openRead = openReadDb,
@@ -271,7 +321,8 @@ export function resolveInvokingSessionIdWithWait(
     resolveOpts,
   }: InvocationWaitOptions = {},
 ): string | null {
-  const candidates = (Array.isArray(nonce) ? nonce : [nonce]).filter((c): c is string => Boolean(c));
+  const candidates = (Array.isArray(nonce) ? nonce : [nonce])
+    .filter(c => Boolean(typeof c === 'string' ? c : c?.value));
   if (candidates.length === 0) return null;
   // Open a fresh read snapshot per attempt: another writer (the daemon or a
   // concurrent agent's build) may publish a newer index between ticks.

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -31,7 +31,11 @@ export { buildIndex, DB_PATH };
 type SandboxApi = Record<string, unknown>;
 
 interface InvocationOptions {
-  invocationNonce?: string;
+  // One nonce, or candidates tried in order (first match wins). The CLI passes
+  // the as-typed --query path first and the script content second: transcripts
+  // record the content verbatim (Write input, heredoc command text) even when
+  // the path sits behind a shell variable and never reaches the transcript.
+  invocationNonce?: string | readonly string[];
 }
 
 interface InventoryIssue {
@@ -112,13 +116,16 @@ interface InvocationResolveOptions {
   collisionMs?: number;
 }
 
-// Resolve the session that invoked this query via a unique nonce embedded in
-// the CLI's argv (a uuidgen token for --search, the as-typed query file path
-// for --query). Every provider writes the tool-call record before the tool
+// Resolve the session that invoked this query via a unique nonce observed in
+// the transcript (the --nonce token for --search; for --query the as-typed
+// file path, falling back to the script content, which heredoc/Write tool-call
+// records carry verbatim even when the path hides behind a shell variable).
+// Every provider writes the tool-call record before the tool
 // finishes, so once the nonce reaches the index it identifies the invoking
 // session. Both legs are bounded to the last INVOCATION_RECENCY_MS (see
 // above), which keeps weeks-old fixed-path reuse out of the candidate set and
-// makes cross-leg timestamps comparable.
+// makes cross-leg timestamps comparable. Candidates are tried in order and the
+// first one with any match resolves.
 //
 // The invoking record is always written "now", so matches far apart in time
 // are unrelated history, not ambiguity: each session tracks its newest
@@ -132,10 +139,23 @@ interface InvocationResolveOptions {
 // resolveInvokingSessionIdWithWait below.
 export function resolveInvokingSessionId(
   db: SqliteDb,
-  nonce: string | null | undefined,
-  { nowMs = Date.now(), recencyMs = INVOCATION_RECENCY_MS, collisionMs = INVOCATION_COLLISION_MS }: InvocationResolveOptions = {},
+  nonce: string | readonly string[] | null | undefined,
+  opts: InvocationResolveOptions = {},
 ): string | null {
-  if (!nonce) return null;
+  const candidates = Array.isArray(nonce) ? nonce : [nonce];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const hit = resolveSingleInvocationNonce(db, candidate, opts);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+function resolveSingleInvocationNonce(
+  db: SqliteDb,
+  nonce: string,
+  { nowMs = Date.now(), recencyMs = INVOCATION_RECENCY_MS, collisionMs = INVOCATION_COLLISION_MS }: InvocationResolveOptions,
+): string | null {
   // The query path is read-only and may face a partially built index (for
   // example only index_state exists while a writer lease is held). A missing
   // schema simply means the nonce cannot resolve: honest unknown.
@@ -241,7 +261,7 @@ function sleepSync(ms: number): void {
 // honest null. Queries without a nonce or with an immediate hit pay zero
 // added latency.
 export function resolveInvokingSessionIdWithWait(
-  nonce: string | null | undefined,
+  nonce: string | readonly string[] | null | undefined,
   providerRegistry: ProviderRegistry,
   {
     openRead = openReadDb,
@@ -251,13 +271,14 @@ export function resolveInvokingSessionIdWithWait(
     resolveOpts,
   }: InvocationWaitOptions = {},
 ): string | null {
-  if (!nonce) return null;
+  const candidates = (Array.isArray(nonce) ? nonce : [nonce]).filter((c): c is string => Boolean(c));
+  if (candidates.length === 0) return null;
   // Open a fresh read snapshot per attempt: another writer (the daemon or a
   // concurrent agent's build) may publish a newer index between ticks.
   const tryResolve = (): string | null => {
     const db = openRead();
     try {
-      return resolveInvokingSessionId(db, nonce, resolveOpts);
+      return resolveInvokingSessionId(db, candidates, resolveOpts);
     } finally {
       db.close();
     }

--- a/skill-doc/SKILL.md
+++ b/skill-doc/SKILL.md
@@ -51,16 +51,18 @@ exits successfully and returns its query result.
 ## Quick Start
 
 Fast keyword search (pass a unique nonce so Obelisk can recognize your own
-session in results):
+session in results). Invent the nonce yourself and type it as a literal token:
+the transcript records the command as typed, so a shell substitution like
+`$(uuidgen)` never expands there and can never resolve:
 
 ```bash
-obelisk --search "keyword" --nonce "$(uuidgen 2>/dev/null || echo "$$.$RANDOM.$RANDOM")"
+obelisk --search "keyword" --nonce "obq-<unique-token-you-invent>"
 ```
 
 Custom query:
 
-1. Write a bounded JS query to a unique temp file — the as-typed file path is
-   your invocation nonce:
+1. Write a bounded JS query to a unique temp file (a Write tool call or a
+   heredoc both work):
 
    ```bash
    qdir=$(mktemp -d /tmp/obq.XXXXXX 2>/dev/null || { d="/tmp/obq.$$.$RANDOM"; mkdir "$d"; echo "$d"; })
@@ -76,6 +78,10 @@ Custom query:
    obelisk --query "$qfile"
    ```
 
+   Self-identification matches the file path when the transcript contains it,
+   and falls back to the script content — heredoc/Write tool-call records
+   carry it verbatim, so a path hidden behind `$qfile` still resolves.
+
 3. Parse JSON stdout and answer with concise evidence.
 
 The query file runs inside `(async () => { ... })()`. Use `return` to emit JSON.
@@ -85,10 +91,11 @@ Query scripts are read-only: `remember()` and `forget()` are not available, and
 ## Your Own Session In Results
 
 Obelisk refreshes the index before each query, so your own live session shows
-up in results. The invocation nonce (`--search --nonce`, or the unique
-`--query` file path) lets Obelisk mark it: session projections in `search()`
-hits and `sessions()` rows carry `is_invoking: true`, and
-`overview().current.session_id` holds the invoking session id when known. Treat
+up in results. The invocation nonce (a literal `--search --nonce` token, or the
+`--query` file path with script content as fallback) lets Obelisk mark it:
+session projections in `search()` hits and `sessions()` rows carry
+`is_invoking: true`, and `overview().current.session_id` holds the invoking
+session id when known. Treat
 a session flagged `is_invoking` as your own current context, NOT as independent
 historical evidence. Resolution is newest-wins over recent matches; only a
 near-simultaneous same-nonce collision (or no match at all) leaves nothing

--- a/tests/invoking-session.test.mjs
+++ b/tests/invoking-session.test.mjs
@@ -207,6 +207,65 @@ test('resolver matches a JSON-escaped multi-line content candidate in tool_calls
   db.close();
 });
 
+test('strict candidate resolves when the matching session invoked the CLI', () => {
+  // The heredoc body and the `obelisk --query` call land in the same command
+  // record, so the invoker always satisfies the invocation requirement.
+  const db = invokingDb();
+  const script = "const hits = search('strict needle', { limit: 3 });\nreturn hits.length;\n";
+  db.prepare('INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json) VALUES (?,?,?,?,?)')
+    .run('call-strict', 'msg-self-call', 'sid-self', 'Bash', JSON.stringify({
+      command: `cat > "$qfile" <<'QUERY_EOF'\n${script}QUERY_EOF\nobelisk --query "$qfile"`,
+    }));
+
+  assert.equal(
+    resolveInvokingSessionId(db, [{ value: script.trim(), strict: true }], { nowMs: FIXTURE_NOW_MS }),
+    'sid-self',
+  );
+  db.close();
+});
+
+test('strict candidate rejects a matching session that never invoked the CLI', () => {
+  // A stranger who merely wrote or quoted the same content has no CLI
+  // invocation record: honest null instead of mis-marking their session.
+  const db = invokingDb();
+  const script = "const hits = search('strict needle', { limit: 3 });\nreturn hits.length;\n";
+  db.prepare('INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json) VALUES (?,?,?,?,?)')
+    .run('call-quote', 'msg-history', 'sid-history', 'Write', JSON.stringify({ file_path: '/tmp/obq.quote/query.mjs', content: script }));
+  // msg-history sits at 2026-08-01, outside the window; give the quote a fresh message.
+  db.prepare('INSERT INTO messages (uuid, session_id, type, role, text, timestamp) VALUES (?,?,?,?,?,?)')
+    .run('msg-quote', 'sid-history', 'assistant', 'assistant', null, '2026-08-11T10:00:05Z');
+  db.prepare('UPDATE tool_calls SET message_uuid = ? WHERE id = ?').run('msg-quote', 'call-quote');
+
+  assert.equal(
+    resolveInvokingSessionId(db, [{ value: script.trim(), strict: true }], { nowMs: FIXTURE_NOW_MS }),
+    null,
+  );
+  db.close();
+});
+
+test('strict candidate rejects content matched by multiple sessions', () => {
+  // Shared boilerplate: two sessions hold the same script within the window.
+  // Newest-wins would guess; strict mode refuses.
+  const db = invokingDb();
+  const script = "const map = overview({ limit: 6 });\nreturn map.current_project;\n";
+  db.prepare('INSERT INTO messages (uuid, session_id, type, role, text, timestamp) VALUES (?,?,?,?,?,?)')
+    .run('msg-history-call', 'sid-history', 'assistant', 'assistant', null, '2026-08-11T09:59:00Z');
+  db.prepare('INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json) VALUES (?,?,?,?,?)')
+    .run('call-history', 'msg-history-call', 'sid-history', 'Bash', JSON.stringify({
+      command: `cat > "$qfile" <<'QUERY_EOF'\n${script}QUERY_EOF\nobelisk --query "$qfile"`,
+    }));
+  db.prepare('INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json) VALUES (?,?,?,?,?)')
+    .run('call-self-strict', 'msg-self-call', 'sid-self', 'Bash', JSON.stringify({
+      command: `cat > "$qfile" <<'QUERY_EOF'\n${script}QUERY_EOF\nobelisk --query "$qfile"`,
+    }));
+
+  assert.equal(
+    resolveInvokingSessionId(db, [{ value: script.trim(), strict: true }], { nowMs: FIXTURE_NOW_MS }),
+    null,
+  );
+  db.close();
+});
+
 test('resolver tolerates a partially built index', () => {
   // A read-only query can face a DB with only index_state (writer lease held,
   // schema never published). The nonce cannot resolve: honest null, no throw.

--- a/tests/invoking-session.test.mjs
+++ b/tests/invoking-session.test.mjs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 // Nonce self-search: the CLI embeds a unique invocation nonce in its argv
-// (--search --nonce <token>, or the as-typed --query file path). Providers
+// (--search --nonce <token>, or the as-typed --query file path). For --query
+// the script content is a second candidate, because heredoc/Write tool-call
+// records carry the content verbatim even when the path hides behind a shell
+// variable. Providers
 // write the tool-call record before the tool finishes, so after the pre-query
 // index refresh the nonce is in the fresh index. The session with the newest
 // matching record is the invoking session; matches far apart in time are
@@ -177,6 +180,33 @@ test('resolver bounds the tool_calls scan to the recency window', () => {
   db.close();
 });
 
+test('resolver falls back to the script-content candidate when the path misses', () => {
+  // The documented mktemp flow hides the query path behind a shell variable;
+  // the transcript then carries the heredoc body verbatim, never the path.
+  const db = invokingDb();
+  const script = "const hits = search('content nonce needle', { limit: 3 });\nreturn hits.length;\n";
+  db.prepare('INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json) VALUES (?,?,?,?,?)')
+    .run('call-heredoc', 'msg-self-call', 'sid-self', 'Bash', JSON.stringify({
+      command: `cat > "$qfile" <<'QUERY_EOF'\n${script}QUERY_EOF\nobelisk --query "$qfile"`,
+    }));
+
+  assert.equal(resolveInvokingSessionId(db, ['/tmp/obq.hidden/query.mjs', script.trim()], { nowMs: FIXTURE_NOW_MS }), 'sid-self');
+  assert.equal(resolveInvokingSessionId(db, ['/tmp/obq.hidden/query.mjs'], { nowMs: FIXTURE_NOW_MS }), null);
+  db.close();
+});
+
+test('resolver matches a JSON-escaped multi-line content candidate in tool_calls', () => {
+  // Write-style tool input JSON-escapes newlines, so the stored input_json
+  // holds the escaped spelling; the resolver already matches both spellings.
+  const db = invokingDb();
+  const script = "const map = overview({ limit: 6 });\nreturn map.current_project;\n";
+  db.prepare('INSERT INTO tool_calls (id, message_uuid, session_id, name, input_json) VALUES (?,?,?,?,?)')
+    .run('call-write', 'msg-self-call', 'sid-self', 'Write', JSON.stringify({ file_path: '/tmp/obq.write/query.mjs', content: script }));
+
+  assert.equal(resolveInvokingSessionId(db, ['/tmp/obq.absent/query.mjs', script.trim()], { nowMs: FIXTURE_NOW_MS }), 'sid-self');
+  db.close();
+});
+
 test('resolver tolerates a partially built index', () => {
   // A read-only query can face a DB with only index_state (writer lease held,
   // schema never published). The nonce cannot resolve: honest null, no throw.
@@ -257,6 +287,64 @@ test('cli --search --nonce marks the invoking session end to end', () => {
   const plainHits = JSON.parse(withoutNonce.stdout);
   assert.equal(plainHits.length, 1);
   assert.equal(plainHits[0].session.is_invoking, undefined);
+});
+
+test('cli --query marks the invoking session via script content when the path is hidden', () => {
+  // The documented mktemp flow: the path sits behind a shell variable, so only
+  // the heredoc body reaches the transcript. The content candidate must still
+  // identify the invoking session.
+  const home = tempHome('obelisk-invoking-content-');
+  const projectDir = join(home, '.claude', 'projects', '-tmp-content');
+  mkdirSync(projectDir, { recursive: true });
+  const script = [
+    "const hits = search('content nonce needle', { limit: 5 });",
+    'return hits.map(h => ({ id: h.session.id, invoking: h.session.is_invoking === true }));',
+  ].join('\n') + '\n';
+  const now = new Date().toISOString();
+  const lines = [
+    {
+      uuid: 'content-user', type: 'user', timestamp: now, cwd: '/tmp/content',
+      message: { role: 'user', content: 'find the content nonce needle evidence' },
+    },
+    {
+      uuid: 'content-call', type: 'assistant', timestamp: now, cwd: '/tmp/content',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_content', name: 'Bash', input: { command: `qfile=$(mktemp /tmp/obq.XXXXXX)\ncat > "$qfile" <<'QUERY_EOF'\n${script}QUERY_EOF\nobelisk --query "$qfile"` } }] },
+    },
+  ];
+  writeFileSync(join(projectDir, 'content-invoking-session.jsonl'), lines.map(l => JSON.stringify(l)).join('\n') + '\n');
+
+  const queryFile = join(makeTempDir('obelisk-content-query-'), 'query.mjs');
+  writeFileSync(queryFile, script);
+  const result = runCli(['--query', queryFile], { home });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const hits = JSON.parse(result.stdout);
+  assert.ok(hits.length > 0);
+  assert.ok(hits.every(h => h.id === 'content-invoking-session' && h.invoking === true));
+});
+
+test('cli --query does not treat short script content as a nonce candidate', () => {
+  // `return overview().current.session_id;` is under the distinctiveness
+  // floor: only the path remains, a hidden path resolves nothing, and the
+  // decoy transcript quoting the same script must NOT be marked as invoking.
+  const home = tempHome('obelisk-invoking-short-');
+  const projectDir = join(home, '.claude', 'projects', '-tmp-short');
+  mkdirSync(projectDir, { recursive: true });
+  const script = 'return overview().current.session_id;\n';
+  assert.ok(script.trim().length < 40, 'fixture stays under the content-nonce floor');
+  const now = new Date().toISOString();
+  const lines = [
+    {
+      uuid: 'short-call', type: 'assistant', timestamp: now, cwd: '/tmp/short',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_short', name: 'Bash', input: { command: `cat > "$qfile" <<'QUERY_EOF'\n${script}QUERY_EOF\nobelisk --query "$qfile"` } }] },
+    },
+  ];
+  writeFileSync(join(projectDir, 'short-decoy-session.jsonl'), lines.map(l => JSON.stringify(l)).join('\n') + '\n');
+
+  const queryFile = join(makeTempDir('obelisk-short-query-'), 'query.mjs');
+  writeFileSync(queryFile, script);
+  const result = runCli(['--query', queryFile], { home });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(JSON.parse(result.stdout), null);
 });
 
 test('wait helper skips the recovery build and poll on an immediate hit', () => {


### PR DESCRIPTION
## Problem

The `--query` invocation nonce was the as-typed file path only. The documented flow is:

```bash
qdir=$(mktemp -d /tmp/obq.XXXXXX); qfile="$qdir/query.mjs"
obelisk --query "$qfile"
```

Transcripts record the command as typed (`$qfile` unexpanded), so the expanded path never appears in any transcript and the nonce **always misses**. The same applies to `--search --nonce "$(uuidgen)"` — a subshell-expanded value never reaches the transcript either.

A nonce miss is harmless for correctness, but the recovery path is expensive: every miss runs an index-freshness recovery build plus a bounded poll. Measured on a 1.1GB index with the app daemon live:

| Scenario | Walltime |
|---|---|
| Nonce resolves | 0.07–1.1s |
| Miss + writer lease unavailable | ~4.1s (poll cap) |
| Miss + lease acquired (full messages_fts rebuild in finalize + busy waits) | 11–28s |

## Fix

The CLI passes **ordered nonce candidates**: the as-typed path first (behavior unchanged when it resolves), then the script content when it is distinctive enough (>= 40 chars). Heredoc and Write tool-call records carry the content verbatim, and the resolver's existing raw + JSON-escaped matching already covers multi-line scripts.

Script content is not unique by construction (boilerplate queries recur across sessions), so the content candidate resolves in **strict mode**: exactly one recent matching session, and that session must itself hold a recent CLI invocation record. The invariant is that an invoker's transcript always contains both the file write and the `obelisk --query` call, while a stranger who merely wrote or quoted the same content does not invoke. Zero or multiple eligible sessions resolve to honest null instead of mis-marking.

`resolveInvokingSessionId` / `resolveInvokingSessionIdWithWait` accept a candidate list, tried in order, first match wins. Path-nonce semantics (newest-wins, 10s collision window, 15min recency window) are unchanged, and the content candidate is never consulted when the path resolves.

Also fixes the `--search` quick start: agents now invent a literal token instead of `$(uuidgen)`, which could never resolve.

A separate small commit restores the bin's executable bit after `build.mjs` rebuilds (tsc emits 0644, breaking npm-linked installs on every rebuild). Overlaps fd93d91 on the unmerged `codex/cli-0.2.5` branch — whichever lands second can drop its copy.

## Tests

Seven new tests in `tests/invoking-session.test.mjs`: heredoc content hit when the path misses, JSON-escaped multi-line content (Write flow), CLI end-to-end with the path fully hidden behind a shell variable, the short-script guard, and strict-mode accept/reject cases (no invocation record, multiple matching sessions).

- `invoking-session`: 29/29; full suite: 561/561
- Verified on the live index with the documented mktemp+heredoc flow: `overview().current.session_id` resolves correctly under strict mode, warm-path walltime ~1.4s (previously 4–28s)

## Follow-up

The recovery-build cost itself (every incremental build's finalize rebuilds `messages_fts` from scratch is orthogonal and tracked in #105. This PR makes misses rare in real flows, but stale/replayed nonces still hit the slow path.
EOF
)