### PR TITLE
fix(core): skip cursor-clean Codex guardian transcripts in incremental discovery

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Verify adaptive watcher package
         run: |
           npm run build --workspace @obelisk-apps/adaptive-watcher
-          node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/claude-parse.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs tests/app-main-settings.test.mjs tests/app-indexer-watcher-filter.test.mjs tests/deepseek-tree.test.mjs
+          node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/claude-parse.test.mjs tests/codex-discover.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs tests/app-main-settings.test.mjs tests/app-indexer-watcher-filter.test.mjs tests/deepseek-tree.test.mjs
 
       - name: Verify query sandbox read-only contract
         run: node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/query.test.mjs

--- a/packages/core/src/providers/codex.ts
+++ b/packages/core/src/providers/codex.ts
@@ -38,7 +38,7 @@ import type {
 } from './types.ts';
 
 export const name = 'codex';
-const CODEX_CANONICAL_TRANSCRIPT_MARKER = '__codex_canonical_transcript_v2__';
+const CODEX_CANONICAL_TRANSCRIPT_MARKER = '__codex_canonical_transcript_v3__';
 const CODEX_SESSIONS_DIR = 'sessions';
 const CODEX_ARCHIVED_SESSIONS_DIR = 'archived_sessions';
 
@@ -98,10 +98,14 @@ function discoverAt(rootDir: string, ctx: DiscoverContext): IndexUnit[] {
       const fileChanged = changedFiles.has(normalize(file.path));
       if (ctx.changedPaths !== undefined && !sessionIndexChanged && !fileChanged) return [];
       const cursor = ctx.lastCursor(file.path);
-      const guardian = readCodexGuardianThreadInfo(file.path);
-      if (!sessionIndexChanged && !fileChanged && cursor !== null && Number(cursor.split(':')[0]) >= statSync(file.path).mtimeMs && guardian === null) {
+      // Skip unchanged files before paying for guardian detection: guardian
+      // status is content-derived, so a cursor-clean file's status cannot
+      // have changed. Pre-v3 databases may still hold guardian session rows;
+      // the v3 marker bump forces one full replay that retracts them.
+      if (!sessionIndexChanged && !fileChanged && cursor !== null && Number(cursor.split(':')[0]) >= statSync(file.path).mtimeMs) {
         return [];
       }
+      const guardian = readCodexGuardianThreadInfo(file.path);
       let meta: any = null;
       readLines(file.path, (line: string) => {
         try {

--- a/tests/app-indexer.test.mjs
+++ b/tests/app-indexer.test.mjs
@@ -660,7 +660,7 @@ test('app indexer skips Codex guardian review threads', () => {
   db.close();
 });
 
-test('app indexer removes stale Codex guardian rows when the JSONL was already indexed', () => {
+test('app indexer retracts stale Codex guardian rows via the marker-driven replay', () => {
   const home = makeTempDir('obelisk-app-indexer-codex-guardian-stale-');
   const claudeDir = join(home, '.claude');
   const codexDir = join(home, '.codex');
@@ -706,6 +706,10 @@ test('app indexer removes stale Codex guardian rows when the JSONL was already i
   db.prepare('INSERT INTO subagents (agent_id,session_id) VALUES (?,?)').run(guardianSessionId, guardianSessionId);
   db.prepare('INSERT OR REPLACE INTO index_state (jsonl_path,mtime,lines_processed) VALUES (?,?,?)')
     .run(jsonlPath, statSync(jsonlPath).mtimeMs, 2);
+  // Simulate a pre-fix database: the old marker is present and the current
+  // one is absent, so the next build runs one marker-driven full replay.
+  db.prepare("DELETE FROM index_state WHERE jsonl_path LIKE '\\_\\_codex\\_canonical\\_transcript%' ESCAPE '\\'").run();
+  db.prepare("INSERT INTO index_state (jsonl_path, mtime, lines_processed) VALUES ('__codex_canonical_transcript_v2__', 0, 0)").run();
   db.close();
 
   buildIndex({ claudeDir, codexDir, dbPath, DatabaseImpl: TestDatabase });

--- a/tests/codex-discover.test.mjs
+++ b/tests/codex-discover.test.mjs
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Codex discovery skip logic (#114): a cursor-clean transcript — guardian or
+// not — is skipped without reading its contents. Guardian detection only runs
+// for files that actually need re-parsing; stale guardian rows from pre-fix
+// databases are retracted by the marker-driven full replay instead.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { createCodexProvider } from '../packages/core/src/providers/codex.ts';
+import { makeTempDir } from './temp-dirs.mjs';
+
+const GUARDIAN_ID = '019ed5c4-8d52-7bc0-91f3-447a15e987d1';
+const PLAIN_ID = '019e8951-3e7d-7343-a3e3-05bff48a317d';
+
+function writeRollout(rootDir, id, metaExtra) {
+  const dir = join(rootDir, 'sessions', '2026', '06', '15');
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `rollout-2026-06-15T10-00-00-${id}.jsonl`);
+  writeFileSync(path, [
+    JSON.stringify({
+      type: 'session_meta',
+      timestamp: '2026-06-15T10:00:00Z',
+      payload: { id, timestamp: '2026-06-15T10:00:00Z', cwd: '/tmp/cdx', cli_version: '1.0', ...metaExtra },
+    }),
+    JSON.stringify({ type: 'event_msg', timestamp: '2026-06-15T10:00:01Z', payload: { type: 'user_message', message: 'hello' } }),
+    '',
+  ].join('\n'));
+  return path;
+}
+
+function cursorAt(path, offsetMs) {
+  return `${String(statSync(path).mtimeMs + offsetMs)}:2`;
+}
+
+test('codex discovery skips guardian and plain transcripts with clean cursors', () => {
+  const rootDir = makeTempDir('obelisk-codex-discover-');
+  const guardianPath = writeRollout(rootDir, GUARDIAN_ID, {
+    thread_source: 'subagent',
+    source: { subagent: { other: 'guardian' } },
+  });
+  const plainPath = writeRollout(rootDir, PLAIN_ID, {});
+  const cursors = new Map([
+    [guardianPath, cursorAt(guardianPath, 1000)],
+    [plainPath, cursorAt(plainPath, 1000)],
+  ]);
+
+  const units = createCodexProvider({ rootDir }).discover({
+    lastCursor: (key) => cursors.get(key) ?? null,
+  });
+  assert.deepEqual(units, [], 'both cursor-clean files are skipped');
+});
+
+test('codex discovery still flags a guardian transcript whose cursor is stale', () => {
+  const rootDir = makeTempDir('obelisk-codex-discover-');
+  const guardianPath = writeRollout(rootDir, GUARDIAN_ID, {
+    thread_source: 'subagent',
+    source: { subagent: { other: 'guardian' } },
+  });
+
+  const units = createCodexProvider({ rootDir }).discover({
+    lastCursor: () => cursorAt(guardianPath, -10000),
+  });
+  assert.equal(units.length, 1, 'stale cursor forces re-planning');
+  assert.equal(units[0].sessionId, '', 'guardian units carry no session id');
+  assert.equal(units[0].meta.guardian, true, 'guardian detection runs for re-planned files');
+});

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -556,7 +556,7 @@ test('runtime skips Codex guardian review threads', () => {
   });
 });
 
-test('runtime removes stale Codex guardian rows when the JSONL was already indexed', () => {
+test('runtime retracts stale Codex guardian rows via the marker-driven replay', () => {
   const home = tempHome();
   const codexSessionDir = join(home, '.codex', 'sessions', '2026', '06', '15');
   mkdirSync(codexSessionDir, { recursive: true });
@@ -600,6 +600,10 @@ test('runtime removes stale Codex guardian rows when the JSONL was already index
   db.prepare('INSERT INTO subagents (agent_id,session_id) VALUES (?,?)').run(guardianSessionId, guardianSessionId);
   db.prepare('INSERT OR REPLACE INTO index_state (jsonl_path,mtime,lines_processed) VALUES (?,?,?)')
     .run(jsonlPath, statSync(jsonlPath).mtimeMs, 2);
+  // Simulate a pre-fix database: the old marker is present and the current
+  // one is absent, so the next build runs one marker-driven full replay.
+  db.prepare("DELETE FROM index_state WHERE jsonl_path LIKE '\\_\\_codex\\_canonical\\_transcript%' ESCAPE '\\'").run();
+  db.prepare("INSERT INTO index_state (jsonl_path, mtime, lines_processed) VALUES ('__codex_canonical_transcript_v2__', 0, 0)").run();
   db.prepare("UPDATE index_state SET mtime=? WHERE jsonl_path='__last_build__'").run(Date.now() - 31000);
   db.close();
 


### PR DESCRIPTION
## Background

#114: the incremental-discovery skip condition carried a permanent `guardian === null` clause, so every guardian transcript was fully re-read and re-parsed on every build. On a guardian-heavy corpus (405 of 1,430 codex rollouts) this accounted for ~28s of a ~33s otherwise-no-op build.

## Changes

**`packages/core/src/providers/codex.ts`**
- Drop `guardian === null` from the skip condition and move `readCodexGuardianThreadInfo` *after* the skip check. Guardian status is content-derived, so a cursor-clean file's status cannot have changed, and nothing consumes `meta.guardian` for a skipped file. On a no-change build, a guardian file now costs one `statSync` instead of a full read + parse.
- Bump the canonical transcript marker `__codex_canonical_transcript_v2__` → `v3`: pre-fix databases run one marker-driven full replay on upgrade, and guardian files retract their stale session rows via `delete-session`. If the inventory is incomplete during that replay, `writeProviderIndexMarkers` clears the cursors of uncommitted replay keys so the next build retries them. The v3 bump is also the migration carrier for the stacked cursor work in #123.

**`.github/workflows/cli.yml`**
- The CI test step enumerates files explicitly and did not cover the new `codex-discover.test.mjs`; added.

Cursor strengthening (mtime+ctime+size+inode for codex) lives in the stacked #123.

## Tests

- New `tests/codex-discover.test.mjs`: guardian and plain transcripts with clean cursors are both skipped; a stale cursor still triggers guardian detection and re-planning.
- The existing stale-row tests in `tests/app-indexer.test.mjs` and `tests/runtime.test.mjs` now simulate a pre-fix database (v2 marker present, v3 absent) and verify the marker-driven replay performs the retraction — test (b) from the issue. Both previously relied on the very "guardians are never skipped" behavior this PR removes.

## Verification

- Full local suite: **563/563 pass** on this branch (`npm test`, incl. CLI rebuild via pretest); 567/567 with stacked #123 applied.
- `npm run typecheck` (root + app): clean.
- `eslint` on all changed files: clean (the repo has pre-existing lint errors in unrelated paths).

## Known residual risks (pre-existing, not introduced here)

- The same-millisecond append hole (#104) now applies to guardian files as well; #123 closes the cursor half of #104 on top of this PR.
- Downgrading to a pre-guardian build and upgrading again can leave stale guardian rows that no longer self-heal (exotic; previously masked by the permanent re-scan).

Closes #114