### PR TITLE
fix(core): strengthen Codex cursors to the mtime+ctime+size+inode signature

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Verify adaptive watcher package
         run: |
           npm run build --workspace @obelisk-apps/adaptive-watcher
-          node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/claude-parse.test.mjs tests/codex-discover.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs tests/app-main-settings.test.mjs tests/app-indexer-watcher-filter.test.mjs tests/deepseek-tree.test.mjs
+          node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/claude-parse.test.mjs tests/codex-parse.test.mjs tests/codex-discover.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs tests/app-main-settings.test.mjs tests/app-indexer-watcher-filter.test.mjs tests/deepseek-tree.test.mjs
 
       - name: Verify query sandbox read-only contract
         run: node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/query.test.mjs

--- a/packages/core/src/parsing.ts
+++ b/packages/core/src/parsing.ts
@@ -137,6 +137,21 @@ function readLines(filePath: string, callback: (line: string, terminated: boolea
   }
 }
 
+// Cursor format: `${mtime}:${lines}:${size}:${ctimeMs}:${ino}`. The
+// mtime+ctime+size+inode signature (CONTRIBUTING: cursors must detect
+// same-millisecond rewrites) lets a same-mtime tail completion or a
+// same-mtime replacement back into discovery. Legacy `${mtime}:${lines}`
+// cursors keep the mtime-only gate and upgrade on the next parse.
+function cursorSignatureDiffers(cursor: string, filePath: string): boolean {
+  const stat = statSync(filePath);
+  const parts = cursor.split(':');
+  if (parts.length < 5) return Number(parts[0]) < stat.mtimeMs;
+  return Number(parts[0]) !== stat.mtimeMs
+    || Number(parts[2]) !== stat.size
+    || Number(parts[3]) !== stat.ctimeMs
+    || Number(parts[4]) !== stat.ino;
+}
+
 // ---- project-path + discovery helpers ----
 function legacyProjectPathFromSlug(project: string | null | undefined): string | null {
   if (!project) return null;
@@ -388,6 +403,7 @@ function codexToolOutput(payload: JsonRecord): string | null {
 export {
   CLAUDE_DIR, CODEX_DIR, PROJECTS_DIR, CODEX_SESSIONS_DIR, TEXT_LIMIT,
   trunc, truncJson, extractText, extractContentType, extractMessageIsMeta, isSkillInstructions, filePath, isDir, readLines,
+  cursorSignatureDiffers,
   legacyProjectPathFromSlug, normalizeObservedCwd, projectSlugFromPath, inferProjectPath,
   discoverJsonlFiles, discoverCodexJsonlFiles, sourceInventoryIssue,
   codexDbId, codexRawId, codexLineUuid, codexCallId, codexParentThreadId, codexIsGuardianThread,

--- a/packages/core/src/providers/claude.ts
+++ b/packages/core/src/providers/claude.ts
@@ -16,6 +16,7 @@ import { dirname, isAbsolute, join, normalize, relative } from 'node:path';
 import {
   extractText, extractContentType, extractMessageIsMeta, isSkillInstructions,
   filePath, trunc, truncJson, readLines, discoverJsonlFiles, isDir, sourceInventoryIssue,
+  cursorSignatureDiffers,
 } from '../parsing.ts';
 
 import type {
@@ -28,28 +29,13 @@ import type {
   RawRecord,
 } from './types.ts';
 
-// Claude cursor encodes the file mtime and the number of lines already indexed:
-// "<mtimeMs>:<linesProcessed>". mtime lets discovery detect change; lines lets
-// parse resume without reprocessing.
+// Claude cursor starts with "<mtimeMs>:<linesProcessed>" (the full signature
+// format lives in cursorSignatureDiffers). mtime lets discovery detect change;
+// lines lets parse resume without reprocessing.
 function cursorToSkip(cursor: Cursor): number {
   if (!cursor) return 0;
   const n = Number(cursor.split(':')[1]);
   return Number.isFinite(n) ? n : 0;
-}
-
-// Cursor format: `${mtime}:${lines}:${size}:${ctimeMs}:${ino}`. The
-// mtime+ctime+size+inode signature (CONTRIBUTING: cursors must detect
-// same-millisecond rewrites) lets a same-mtime tail completion or a
-// same-mtime replacement back into discovery. Legacy `${mtime}:${lines}`
-// cursors keep the mtime-only gate and upgrade on the next parse.
-function cursorSignatureDiffers(cursor: string, filePath: string): boolean {
-  const stat = statSync(filePath);
-  const parts = cursor.split(':');
-  if (parts.length < 5) return Number(parts[0]) < stat.mtimeMs;
-  return Number(parts[0]) !== stat.mtimeMs
-    || Number(parts[2]) !== stat.size
-    || Number(parts[3]) !== stat.ctimeMs
-    || Number(parts[4]) !== stat.ino;
 }
 
 export const name = 'claude';

--- a/packages/core/src/providers/codex.ts
+++ b/packages/core/src/providers/codex.ts
@@ -23,7 +23,7 @@ import {
   codexEventText, codexMessagePayloadText, codexVisibleMessageKey,
   codexToolInput, codexToolOutput,
   extractMessageIsMeta, isSkillInstructions,
-  readCodexGuardianThreadInfo,
+  readCodexGuardianThreadInfo, cursorSignatureDiffers,
 } from '../parsing.ts';
 
 import type {
@@ -99,10 +99,11 @@ function discoverAt(rootDir: string, ctx: DiscoverContext): IndexUnit[] {
       if (ctx.changedPaths !== undefined && !sessionIndexChanged && !fileChanged) return [];
       const cursor = ctx.lastCursor(file.path);
       // Skip unchanged files before paying for guardian detection: guardian
-      // status is content-derived, so a cursor-clean file's status cannot
-      // have changed. Pre-v3 databases may still hold guardian session rows;
-      // the v3 marker bump forces one full replay that retracts them.
-      if (!sessionIndexChanged && !fileChanged && cursor !== null && Number(cursor.split(':')[0]) >= statSync(file.path).mtimeMs) {
+      // status is content-derived, so a file whose cursor signature still
+      // matches cannot have changed status. Pre-v3 databases may still hold
+      // guardian session rows; the v3 marker bump forces one full replay that
+      // retracts them.
+      if (!sessionIndexChanged && !fileChanged && cursor !== null && !cursorSignatureDiffers(cursor, file.path)) {
         return [];
       }
       const guardian = readCodexGuardianThreadInfo(file.path);
@@ -138,14 +139,14 @@ export function discover(ctx: DiscoverContext): IndexUnit[] {
 }
 
 export function* parse(unit: IndexUnit, _cursor: Cursor): Generator<TranscriptRecord, Cursor> {
-  const mtime = statSync(unit.key).mtimeMs;
+  const stat = statSync(unit.key);
   const records: { lineNum: number; obj: any }[] = [];
   let lineNum = 0;
   readLines(unit.key, (line: string) => {
     lineNum++;
     try { records.push({ lineNum, obj: JSON.parse(line) }); } catch { /* skip malformed */ }
   });
-  const outCursor = `${mtime}:${lineNum}`;
+  const outCursor = `${stat.mtimeMs}:${lineNum}:${stat.size}:${stat.ctimeMs}:${stat.ino}`;
 
   const metaRecord = records.find(r => r.obj?.type === 'session_meta' && r.obj.payload?.id);
   if (!metaRecord) return outCursor;

--- a/tests/codex-discover.test.mjs
+++ b/tests/codex-discover.test.mjs
@@ -1,10 +1,12 @@
 // Copyright (C) 2026 tommy0103 and contributors.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Codex discovery skip logic (#114): a cursor-clean transcript — guardian or
-// not — is skipped without reading its contents. Guardian detection only runs
-// for files that actually need re-parsing; stale guardian rows from pre-fix
-// databases are retracted by the marker-driven full replay instead.
+// Codex discovery skip logic (#114): a transcript whose cursor signature still
+// matches — guardian or not — is skipped without reading its contents. Guardian
+// detection only runs for files that actually need re-parsing; stale guardian
+// rows from pre-fix databases are retracted by the marker-driven full replay
+// instead. Codex cursors use the shared mtime+ctime+size+inode signature
+// (CONTRIBUTING), so a same-mtime rewrite is re-planned even for guardians.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -16,6 +18,11 @@ import { makeTempDir } from './temp-dirs.mjs';
 
 const GUARDIAN_ID = '019ed5c4-8d52-7bc0-91f3-447a15e987d1';
 const PLAIN_ID = '019e8951-3e7d-7343-a3e3-05bff48a317d';
+
+const GUARDIAN_META = {
+  thread_source: 'subagent',
+  source: { subagent: { other: 'guardian' } },
+};
 
 function writeRollout(rootDir, id, metaExtra) {
   const dir = join(rootDir, 'sessions', '2026', '06', '15');
@@ -33,39 +40,49 @@ function writeRollout(rootDir, id, metaExtra) {
   return path;
 }
 
-function cursorAt(path, offsetMs) {
-  return `${String(statSync(path).mtimeMs + offsetMs)}:2`;
+// `${mtime}:${lines}:${size}:${ctimeMs}:${ino}` — see cursorSignatureDiffers.
+function cursorFor(path, overrides = {}) {
+  const s = statSync(path);
+  return [overrides.mtimeMs ?? s.mtimeMs, 2, overrides.size ?? s.size, s.ctimeMs, s.ino].join(':');
 }
 
-test('codex discovery skips guardian and plain transcripts with clean cursors', () => {
-  const rootDir = makeTempDir('obelisk-codex-discover-');
-  const guardianPath = writeRollout(rootDir, GUARDIAN_ID, {
-    thread_source: 'subagent',
-    source: { subagent: { other: 'guardian' } },
-  });
-  const plainPath = writeRollout(rootDir, PLAIN_ID, {});
-  const cursors = new Map([
-    [guardianPath, cursorAt(guardianPath, 1000)],
-    [plainPath, cursorAt(plainPath, 1000)],
-  ]);
-
-  const units = createCodexProvider({ rootDir }).discover({
+function discoverWith(rootDir, cursors) {
+  return createCodexProvider({ rootDir }).discover({
     lastCursor: (key) => cursors.get(key) ?? null,
   });
-  assert.deepEqual(units, [], 'both cursor-clean files are skipped');
+}
+
+test('codex discovery skips guardian and plain transcripts with matching cursor signatures', () => {
+  const rootDir = makeTempDir('obelisk-codex-discover-');
+  const guardianPath = writeRollout(rootDir, GUARDIAN_ID, GUARDIAN_META);
+  const plainPath = writeRollout(rootDir, PLAIN_ID, {});
+  const cursors = new Map([
+    [guardianPath, cursorFor(guardianPath)],
+    [plainPath, cursorFor(plainPath)],
+  ]);
+
+  assert.deepEqual(discoverWith(rootDir, cursors), [], 'both cursor-clean files are skipped');
 });
 
-test('codex discovery still flags a guardian transcript whose cursor is stale', () => {
+test('codex discovery re-plans a guardian transcript rewritten at the same mtime', () => {
   const rootDir = makeTempDir('obelisk-codex-discover-');
-  const guardianPath = writeRollout(rootDir, GUARDIAN_ID, {
-    thread_source: 'subagent',
-    source: { subagent: { other: 'guardian' } },
-  });
+  const guardianPath = writeRollout(rootDir, GUARDIAN_ID, GUARDIAN_META);
+  // Same mtime, different size: a same-millisecond append must not be skipped.
+  const cursors = new Map([[guardianPath, cursorFor(guardianPath, { size: statSync(guardianPath).size + 1 })]]);
 
-  const units = createCodexProvider({ rootDir }).discover({
-    lastCursor: () => cursorAt(guardianPath, -10000),
-  });
-  assert.equal(units.length, 1, 'stale cursor forces re-planning');
+  const units = discoverWith(rootDir, cursors);
+  assert.equal(units.length, 1, 'a changed signature forces re-planning');
   assert.equal(units[0].sessionId, '', 'guardian units carry no session id');
   assert.equal(units[0].meta.guardian, true, 'guardian detection runs for re-planned files');
+});
+
+test('codex discovery re-plans a guardian transcript behind a legacy mtime-only cursor', () => {
+  const rootDir = makeTempDir('obelisk-codex-discover-');
+  const guardianPath = writeRollout(rootDir, GUARDIAN_ID, GUARDIAN_META);
+  const legacyCursor = `${String(statSync(guardianPath).mtimeMs - 10000)}:2`;
+  const cursors = new Map([[guardianPath, legacyCursor]]);
+
+  const units = discoverWith(rootDir, cursors);
+  assert.equal(units.length, 1, 'a stale legacy cursor forces re-planning');
+  assert.equal(units[0].meta.guardian, true);
 });


### PR DESCRIPTION
> Stacked on #121 — base retargets to main automatically once #121 merges.

## Background

#104: codex incremental discovery skips files on an mtime-only cursor comparison, so a same-millisecond rewrite (rapid append landing in the same mtime tick, or a same-size-at-same-mtime replacement) is silently missed. CONTRIBUTING requires cursors to detect same-millisecond rewrites via mtime + ctime + size + inode; claude already implements this, codex is the outlier.

This was originally part of #121 and was split out to keep that PR minimal. #121's marker bump to `__codex_canonical_transcript_v3__` is the migration carrier for this cursor-format change, as #114 anticipated.

## Changes

- `packages/core/src/parsing.ts`: `cursorSignatureDiffers` moved here from `claude.ts` so both providers share one implementation of the documented signature check. No behavior change for claude.
- `packages/core/src/providers/codex.ts`: the discovery skip check uses `cursorSignatureDiffers`; `parse()` returns `${mtime}:${lines}:${size}:${ctimeMs}:${ino}`. Legacy two-part cursors keep the mtime-only gate and upgrade on the next parse; the v3 marker replay rewrites them outright wherever codex sessions exist.
- `.github/workflows/cli.yml`: add `codex-parse.test.mjs` to the CI test list (it asserts the codex parse contract and was not covered).
- `tests/codex-discover.test.mjs`: cursor fixtures move to the five-part format; new case pins that a same-mtime/different-size guardian rewrite is re-planned.

Runtime cost of the stronger check is zero: the skip path already called `statSync` for mtime; size/ctime/ino come from the same call. The only behavioral trade-off is that metadata-only changes (e.g. `chmod`) now cause one conservative re-parse — the safe direction.

## Scope

This closes the *cursor* half of #104. The watcher-side reconcile of moves/copies/deletes mentioned in CONTRIBUTING remains #104 scope.

## Verification

- Affected suites: 45/45 pass (codex-discover, codex-parse, codex-index, claude-parse, app-indexer, runtime). Full suite on the identical code state (pre-split): 564/564.
- `npm run typecheck`: clean. `eslint` on changed files: clean.

Refs #104