### PR TITLE
fix(core): strengthen Codex cursors to the mtime+ctime+size+inode signature

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm ci
       - run: npm run build:cli
       - name: Verify CLI package and runtime contract
-        run: node --experimental-test-module-mocks --test tests/cli-package.test.mjs tests/runtime-cli-envelope.test.mjs tests/runtime.test.mjs
+        run: node --experimental-test-module-mocks --test tests/cli-package.test.mjs tests/runtime-cli-envelope.test.mjs tests/runtime.test.mjs tests/codex-index.test.mjs
 
       - name: Verify DSH plugin package
         run: |
@@ -42,7 +42,7 @@ jobs:
       - name: Verify adaptive watcher package
         run: |
           npm run build --workspace @obelisk-apps/adaptive-watcher
-          node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/claude-parse.test.mjs tests/codex-discover.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs tests/app-main-settings.test.mjs tests/app-indexer-watcher-filter.test.mjs tests/deepseek-tree.test.mjs
+          node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/claude-parse.test.mjs tests/codex-parse.test.mjs tests/codex-discover.test.mjs tests/app-indexer.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs tests/app-main-settings.test.mjs tests/app-indexer-watcher-filter.test.mjs tests/deepseek-tree.test.mjs
 
       - name: Verify query sandbox read-only contract
         run: node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/query.test.mjs

--- a/packages/core/src/providers/codex.ts
+++ b/packages/core/src/providers/codex.ts
@@ -57,6 +57,23 @@ function codexTranscriptDirs(rootDir: string): string[] {
   ];
 }
 
+// Cursor format: `${mtime}:${lines}:${size}:${ctimeMs}:${ino}`. The
+// mtime+ctime+size+inode signature (CONTRIBUTING: cursors must detect
+// same-millisecond rewrites) lets a same-mtime tail completion or a
+// same-mtime replacement back into discovery. Unlike claude's legacy gate
+// (#102), two-part cursors here fail closed: codex never shipped a five-part
+// cursor before v3, so every legacy cursor can only prove "mtime not older",
+// never "unchanged" — it re-parses once and upgrades to the full signature.
+function codexCursorSignatureDiffers(cursor: string, filePath: string): boolean {
+  const stat = statSync(filePath);
+  const parts = cursor.split(':');
+  if (parts.length < 5) return true;
+  return Number(parts[0]) !== stat.mtimeMs
+    || Number(parts[2]) !== stat.size
+    || Number(parts[3]) !== stat.ctimeMs
+    || Number(parts[4]) !== stat.ino;
+}
+
 function discoverAt(rootDir: string, ctx: DiscoverContext): IndexUnit[] {
   const [sessionsDir, archivedSessionsDir] = codexTranscriptDirs(rootDir);
   if (!existsSync(sessionsDir) && (ctx.indexedSessions?.().length ?? 0) > 0) {
@@ -99,10 +116,11 @@ function discoverAt(rootDir: string, ctx: DiscoverContext): IndexUnit[] {
       if (ctx.changedPaths !== undefined && !sessionIndexChanged && !fileChanged) return [];
       const cursor = ctx.lastCursor(file.path);
       // Skip unchanged files before paying for guardian detection: guardian
-      // status is content-derived, so a cursor-clean file's status cannot
-      // have changed. Pre-v3 databases may still hold guardian session rows;
-      // the v3 marker bump forces one full replay that retracts them.
-      if (!sessionIndexChanged && !fileChanged && cursor !== null && Number(cursor.split(':')[0]) >= statSync(file.path).mtimeMs) {
+      // status is content-derived, so a file whose cursor signature still
+      // matches cannot have changed status. Pre-v3 databases may still hold
+      // guardian session rows; the v3 marker bump forces one full replay that
+      // retracts them.
+      if (!sessionIndexChanged && !fileChanged && cursor !== null && !codexCursorSignatureDiffers(cursor, file.path)) {
         return [];
       }
       const guardian = readCodexGuardianThreadInfo(file.path);
@@ -138,14 +156,14 @@ export function discover(ctx: DiscoverContext): IndexUnit[] {
 }
 
 export function* parse(unit: IndexUnit, _cursor: Cursor): Generator<TranscriptRecord, Cursor> {
-  const mtime = statSync(unit.key).mtimeMs;
+  const stat = statSync(unit.key);
   const records: { lineNum: number; obj: any }[] = [];
   let lineNum = 0;
   readLines(unit.key, (line: string) => {
     lineNum++;
     try { records.push({ lineNum, obj: JSON.parse(line) }); } catch { /* skip malformed */ }
   });
-  const outCursor = `${mtime}:${lineNum}`;
+  const outCursor = `${stat.mtimeMs}:${lineNum}:${stat.size}:${stat.ctimeMs}:${stat.ino}`;
 
   const metaRecord = records.find(r => r.obj?.type === 'session_meta' && r.obj.payload?.id);
   if (!metaRecord) return outCursor;

--- a/tests/app-indexer.test.mjs
+++ b/tests/app-indexer.test.mjs
@@ -5,7 +5,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 import { appendFileSync, mkdirSync, statSync, utimesSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, normalize } from 'node:path';
 import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
@@ -63,7 +63,7 @@ test('app indexer records build success without claiming daemon ownership', () =
   assert.equal(db.prepare("SELECT uuid FROM messages_fts WHERE messages_fts MATCH 'hello'").get().uuid, 'msg-app-1');
   assert.equal(db.prepare("SELECT jsonl_path FROM index_state WHERE jsonl_path='__app_heartbeat__'").get(), undefined);
   assert.equal(db.prepare("SELECT jsonl_path FROM index_state WHERE jsonl_path='__app_last_successful_build__'").get().jsonl_path, '__app_last_successful_build__');
-  assert.equal(db.prepare('SELECT project_path FROM sessions WHERE id=?').get(sessionId).project_path, '/tmp/obelisk-app');
+  assert.equal(db.prepare('SELECT project_path FROM sessions WHERE id=?').get(sessionId).project_path, normalize('/tmp/obelisk-app'));
   db.prepare('UPDATE sessions SET project_path=? WHERE id=?').run('/tmp/stale-affected', sessionId);
   db.prepare('INSERT INTO sessions (id,project,project_path,source) VALUES (?,?,?,?)')
     .run('session-app-unaffected', '-tmp-unaffected', '/tmp/stale-unaffected', 'claude');
@@ -100,7 +100,7 @@ test('app indexer records build success without claiming daemon ownership', () =
   const db2 = new TestDatabase(dbPath);
   assert.equal(db2.prepare("SELECT uuid FROM messages_fts WHERE messages_fts MATCH 'companion'").get().uuid, 'msg-app-2');
   assert.equal(db2.prepare('SELECT message_count FROM sessions WHERE id=?').get(sessionId).message_count, 2);
-  assert.equal(db2.prepare('SELECT project_path FROM sessions WHERE id=?').get(sessionId).project_path, '/tmp/obelisk-app');
+  assert.equal(db2.prepare('SELECT project_path FROM sessions WHERE id=?').get(sessionId).project_path, normalize('/tmp/obelisk-app'));
   assert.equal(
     db2.prepare('SELECT project_path FROM sessions WHERE id=?').get('session-app-unaffected').project_path,
     '/tmp/stale-unaffected',
@@ -117,7 +117,7 @@ test('app indexer records build success without claiming daemon ownership', () =
   const retryDb = new TestDatabase(dbPath);
   assert.equal(
     retryDb.prepare('SELECT project_path FROM sessions WHERE id=?').get('session-app-unaffected').project_path,
-    '/tmp/unaffected',
+    normalize('/tmp/unaffected'),
   );
   retryDb.prepare('UPDATE sessions SET project_path=? WHERE id=?')
     .run('/tmp/stale-unaffected', 'session-app-unaffected');
@@ -127,7 +127,7 @@ test('app indexer records build success without claiming daemon ownership', () =
   const repairedDb = new TestDatabase(dbPath);
   assert.equal(
     repairedDb.prepare('SELECT project_path FROM sessions WHERE id=?').get('session-app-unaffected').project_path,
-    '/tmp/unaffected',
+    normalize('/tmp/unaffected'),
   );
   repairedDb.close();
 });
@@ -465,7 +465,7 @@ test('app indexer loads Codex root sessions into the shared schema', () => {
   const session = db.prepare('SELECT * FROM sessions WHERE id=?').get(`codex:${codexId}`);
   assert.equal(session.source, 'codex');
   assert.equal(session.project, '-tmp-obelisk-app');
-  assert.equal(session.project_path, '/tmp/obelisk-app');
+  assert.equal(session.project_path, normalize('/tmp/obelisk-app'));
   assert.equal(session.git_branch, 'feat/codex');
   assert.equal(session.version, '0.135.0-alpha.1');
   assert.equal(session.message_count, 3);
@@ -534,6 +534,68 @@ test('app indexer accepts Codex changed paths relative to the sessions directory
   assert.equal(
     db.prepare('SELECT text FROM messages WHERE session_id=?').get(`codex:${codexId}`).text,
     'sessions-relative codex change',
+  );
+  db.close();
+});
+
+// A changedPaths report must re-plan the file even when the cursor could not
+// prove it changed — this is the path watchers actually use. (Exact
+// matching-signature precedence is covered by the discovery unit tests; a
+// real rewrite always moves ctime, so this end-to-end case verifies the
+// database converges through the changedPaths path.)
+test('app indexer re-plans a Codex file reported via changedPaths and updates the database', () => {
+  const home = makeTempDir('obelisk-app-indexer-codex-changedpath-mtime-');
+  const claudeDir = join(home, '.claude');
+  const codexDir = join(home, '.codex');
+  const codexSessionDir = join(codexDir, 'sessions', '2026', '06', '15');
+  mkdirSync(join(claudeDir, 'projects'), { recursive: true });
+  mkdirSync(codexSessionDir, { recursive: true });
+
+  const codexId = '019ec6ee-cebd-7431-9c93-ceec89a98a60';
+  const filename = `rollout-2026-06-15T00-19-59-${codexId}.jsonl`;
+  const jsonlPath = join(codexSessionDir, filename);
+  const rollout = (message) => [
+    JSON.stringify({
+      timestamp: '2026-06-14T16:19:59.842Z',
+      type: 'session_meta',
+      payload: {
+        id: codexId,
+        timestamp: '2026-06-14T16:19:59.842Z',
+        cwd: '/tmp/obelisk-app',
+        cli_version: '0.135.0-alpha.1',
+        thread_source: 'user',
+      },
+    }),
+    JSON.stringify({
+      timestamp: '2026-06-14T16:20:00.000Z',
+      type: 'event_msg',
+      payload: { type: 'user_message', message, images: [], local_images: [], text_elements: [] },
+    }),
+    '',
+  ].join('\n');
+
+  // 'alpha' and 'omega' are equal length, and the rewrite is forced back to
+  // the original mtime, so the mtime+size legs alone could not catch it.
+  writeFileSync(jsonlPath, rollout('codex alpha value'));
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  buildIndex({ claudeDir, codexDir, dbPath, DatabaseImpl: TestDatabase });
+
+  const orig = statSync(jsonlPath).mtimeMs / 1000;
+  writeFileSync(jsonlPath, rollout('codex omega value'));
+  utimesSync(jsonlPath, orig, orig);
+
+  buildIndex({
+    claudeDir,
+    codexDir,
+    dbPath,
+    DatabaseImpl: TestDatabase,
+    changedPaths: [join('2026', '06', '15', filename)],
+  });
+
+  const db = new TestDatabase(dbPath);
+  assert.equal(
+    db.prepare('SELECT text FROM messages WHERE session_id=?').get(`codex:${codexId}`).text,
+    'codex omega value',
   );
   db.close();
 });

--- a/tests/codex-discover.test.mjs
+++ b/tests/codex-discover.test.mjs
@@ -1,10 +1,12 @@
 // Copyright (C) 2026 tommy0103 and contributors.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Codex discovery skip logic (#114): a cursor-clean transcript — guardian or
-// not — is skipped without reading its contents. Guardian detection only runs
-// for files that actually need re-parsing; stale guardian rows from pre-fix
-// databases are retracted by the marker-driven full replay instead.
+// Codex discovery skip logic (#114): a transcript whose cursor signature still
+// matches — guardian or not — is skipped without reading its contents. Guardian
+// detection only runs for files that actually need re-parsing; stale guardian
+// rows from pre-fix databases are retracted by the marker-driven full replay
+// instead. Codex cursors use the shared mtime+ctime+size+inode signature
+// (CONTRIBUTING), so a same-mtime rewrite is re-planned even for guardians.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -16,6 +18,11 @@ import { makeTempDir } from './temp-dirs.mjs';
 
 const GUARDIAN_ID = '019ed5c4-8d52-7bc0-91f3-447a15e987d1';
 const PLAIN_ID = '019e8951-3e7d-7343-a3e3-05bff48a317d';
+
+const GUARDIAN_META = {
+  thread_source: 'subagent',
+  source: { subagent: { other: 'guardian' } },
+};
 
 function writeRollout(rootDir, id, metaExtra) {
   const dir = join(rootDir, 'sessions', '2026', '06', '15');
@@ -33,39 +40,69 @@ function writeRollout(rootDir, id, metaExtra) {
   return path;
 }
 
-function cursorAt(path, offsetMs) {
-  return `${String(statSync(path).mtimeMs + offsetMs)}:2`;
+// `${mtime}:${lines}:${size}:${ctimeMs}:${ino}` — see codexCursorSignatureDiffers.
+function cursorFor(path, overrides = {}) {
+  const s = statSync(path);
+  return [overrides.mtimeMs ?? s.mtimeMs, 2, overrides.size ?? s.size, s.ctimeMs, s.ino].join(':');
 }
 
-test('codex discovery skips guardian and plain transcripts with clean cursors', () => {
-  const rootDir = makeTempDir('obelisk-codex-discover-');
-  const guardianPath = writeRollout(rootDir, GUARDIAN_ID, {
-    thread_source: 'subagent',
-    source: { subagent: { other: 'guardian' } },
-  });
-  const plainPath = writeRollout(rootDir, PLAIN_ID, {});
-  const cursors = new Map([
-    [guardianPath, cursorAt(guardianPath, 1000)],
-    [plainPath, cursorAt(plainPath, 1000)],
-  ]);
-
-  const units = createCodexProvider({ rootDir }).discover({
+function discoverWith(rootDir, cursors) {
+  return createCodexProvider({ rootDir }).discover({
     lastCursor: (key) => cursors.get(key) ?? null,
   });
-  assert.deepEqual(units, [], 'both cursor-clean files are skipped');
+}
+
+test('codex discovery skips guardian and plain transcripts with matching cursor signatures', () => {
+  const rootDir = makeTempDir('obelisk-codex-discover-');
+  const guardianPath = writeRollout(rootDir, GUARDIAN_ID, GUARDIAN_META);
+  const plainPath = writeRollout(rootDir, PLAIN_ID, {});
+  const cursors = new Map([
+    [guardianPath, cursorFor(guardianPath)],
+    [plainPath, cursorFor(plainPath)],
+  ]);
+
+  assert.deepEqual(discoverWith(rootDir, cursors), [], 'both cursor-clean files are skipped');
 });
 
-test('codex discovery still flags a guardian transcript whose cursor is stale', () => {
+test('codex discovery re-plans a guardian transcript rewritten at the same mtime', () => {
   const rootDir = makeTempDir('obelisk-codex-discover-');
-  const guardianPath = writeRollout(rootDir, GUARDIAN_ID, {
-    thread_source: 'subagent',
-    source: { subagent: { other: 'guardian' } },
-  });
+  const guardianPath = writeRollout(rootDir, GUARDIAN_ID, GUARDIAN_META);
+  // Same mtime, different size: a same-millisecond append must not be skipped.
+  const cursors = new Map([[guardianPath, cursorFor(guardianPath, { size: statSync(guardianPath).size + 1 })]]);
 
-  const units = createCodexProvider({ rootDir }).discover({
-    lastCursor: () => cursorAt(guardianPath, -10000),
-  });
-  assert.equal(units.length, 1, 'stale cursor forces re-planning');
+  const units = discoverWith(rootDir, cursors);
+  assert.equal(units.length, 1, 'a changed signature forces re-planning');
   assert.equal(units[0].sessionId, '', 'guardian units carry no session id');
   assert.equal(units[0].meta.guardian, true, 'guardian detection runs for re-planned files');
+});
+
+test('codex discovery fails closed on a legacy mtime-only cursor, even at the current mtime', () => {
+  const rootDir = makeTempDir('obelisk-codex-discover-');
+  const guardianPath = writeRollout(rootDir, GUARDIAN_ID, GUARDIAN_META);
+  // A two-part cursor cannot prove the file is unchanged, so it re-parses
+  // once and upgrades to the full signature — even when mtimes match.
+  const legacyCursor = `${String(statSync(guardianPath).mtimeMs)}:2`;
+  const cursors = new Map([[guardianPath, legacyCursor]]);
+
+  const units = discoverWith(rootDir, cursors);
+  assert.equal(units.length, 1, 'a legacy cursor at the current mtime is re-planned');
+  assert.equal(units[0].meta.guardian, true);
+});
+
+test('codex discovery honors an exact changedPaths report over a matching cursor', () => {
+  const rootDir = makeTempDir('obelisk-codex-discover-');
+  const guardianPath = writeRollout(rootDir, GUARDIAN_ID, GUARDIAN_META);
+  const plainPath = writeRollout(rootDir, PLAIN_ID, {});
+  const cursors = new Map([
+    [guardianPath, cursorFor(guardianPath)],
+    [plainPath, cursorFor(plainPath)],
+  ]);
+
+  // The watcher path: an exact change report must re-plan the file even when
+  // its cursor signature still matches.
+  const units = createCodexProvider({ rootDir }).discover({
+    lastCursor: (key) => cursors.get(key) ?? null,
+    changedPaths: [guardianPath],
+  });
+  assert.deepEqual(units.map((u) => u.key), [guardianPath], 'only the reported file is re-planned');
 });

--- a/tests/codex-index.test.mjs
+++ b/tests/codex-index.test.mjs
@@ -9,7 +9,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdirSync, writeFileSync, appendFileSync, utimesSync, statSync } from 'node:fs';
+import { mkdirSync, writeFileSync, appendFileSync, utimesSync, statSync, rmSync, renameSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { runCli } from './cli-test-helpers.mjs';
@@ -75,4 +75,84 @@ test('codex full build then incremental rebuild replaces the total count without
   assert.equal(c.mc, 3, 'message_count replaced with the new total');
   assert.equal(c.msgs, 3, 'exactly three messages, upserted (no duplicates)');
   assert.equal(c.hits, 1, 'the appended message is searchable');
+});
+
+// #104: a real same-mtime append must survive the full discover → parse →
+// persist path — the mtime is forced back after appending, so only the
+// size/ctime legs of the cursor signature can catch it.
+test('codex incremental rebuild detects a real append forced to the same mtime', () => {
+  const home = makeTempDir('obelisk-codex-samemtime-');
+  const dir = join(home, '.codex', 'sessions', '2026', '06', '15');
+  mkdirSync(dir, { recursive: true });
+  const jsonl = join(dir, `rollout-2026-06-15T10-00-00-${ID}.jsonl`);
+
+  writeFileSync(jsonl, [metaLine(), evt('user_message', 'codex hello', '2026-06-15T10:00:01Z'), evt('agent_message', 'codex reply', '2026-06-15T10:00:02Z')].join('\n') + '\n');
+  assert.equal(runRuntime(['--build'], home).status, 0);
+  assert.equal(codexCounts(home).msgs, 2);
+
+  const orig = statSync(jsonl).mtimeMs / 1000;
+  appendFileSync(jsonl, evt('user_message', 'same-mtime followup', '2026-06-15T10:01:00Z') + '\n');
+  utimesSync(jsonl, orig, orig); // force the mtime back — same-millisecond append
+  clearDebounce(home);
+
+  const c = codexCounts(home);
+  assert.equal(c.msgs, 3, 'the same-mtime append is re-parsed');
+  assert.equal(c.hits, 1, 'the appended message is searchable');
+});
+
+// #104: an in-place rewrite that preserves size AND mtime can only be caught
+// by ctime/ino. Node reports ctime as the status-change time on every
+// platform (birthtime is the creation time), so this runs everywhere.
+test('codex incremental rebuild detects a same-size rewrite forced to the same mtime', () => {
+  const home = makeTempDir('obelisk-codex-samemtime-rewrite-');
+  const dir = join(home, '.codex', 'sessions', '2026', '06', '15');
+  mkdirSync(dir, { recursive: true });
+  const jsonl = join(dir, `rollout-2026-06-15T10-00-00-${ID}.jsonl`);
+
+  // 'alpha' and 'omega' are equal length, keeping size identical.
+  writeFileSync(jsonl, [metaLine(), evt('user_message', 'codex alpha value', '2026-06-15T10:00:01Z'), evt('agent_message', 'codex reply', '2026-06-15T10:00:02Z')].join('\n') + '\n');
+  assert.equal(runRuntime(['--build'], home).status, 0);
+
+  const orig = statSync(jsonl).mtimeMs / 1000;
+  writeFileSync(jsonl, [metaLine(), evt('user_message', 'codex omega value', '2026-06-15T10:00:01Z'), evt('agent_message', 'codex reply', '2026-06-15T10:00:02Z')].join('\n') + '\n');
+  utimesSync(jsonl, orig, orig);
+  clearDebounce(home);
+
+  writeFileSync(join(home, 'q.mjs'), `return {
+    alpha: search('alpha', { source: 'codex', limit: 5 }).length,
+    omega: search('omega', { source: 'codex', limit: 5 }).length,
+  };`);
+  const r = runRuntime(['--query', join(home, 'q.mjs')], home);
+  assert.equal(r.status, 0, r.stderr || r.stdout);
+  assert.deepEqual(JSON.parse(r.stdout), { alpha: 0, omega: 1 }, 'the rewritten content replaces the old text');
+});
+
+// #104: a real replacement swaps the file identity itself (write temp +
+// rename over). Size and mtime are forced equal, so only the ctime/ino legs
+// can catch it.
+test('codex incremental rebuild detects a rename replacement forced to the same mtime', () => {
+  const home = makeTempDir('obelisk-codex-samemtime-replace-');
+  const dir = join(home, '.codex', 'sessions', '2026', '06', '15');
+  mkdirSync(dir, { recursive: true });
+  const jsonl = join(dir, `rollout-2026-06-15T10-00-00-${ID}.jsonl`);
+
+  // 'alpha' and 'omega' are equal length, keeping size identical.
+  writeFileSync(jsonl, [metaLine(), evt('user_message', 'codex alpha value', '2026-06-15T10:00:01Z'), evt('agent_message', 'codex reply', '2026-06-15T10:00:02Z')].join('\n') + '\n');
+  assert.equal(runRuntime(['--build'], home).status, 0);
+
+  const orig = statSync(jsonl).mtimeMs / 1000;
+  const tmp = join(dir, 'replacement.tmp');
+  writeFileSync(tmp, [metaLine(), evt('user_message', 'codex omega value', '2026-06-15T10:00:01Z'), evt('agent_message', 'codex reply', '2026-06-15T10:00:02Z')].join('\n') + '\n');
+  utimesSync(tmp, orig, orig);
+  rmSync(jsonl); // Windows cannot rename over an existing path
+  renameSync(tmp, jsonl);
+  clearDebounce(home);
+
+  writeFileSync(join(home, 'q.mjs'), `return {
+    alpha: search('alpha', { source: 'codex', limit: 5 }).length,
+    omega: search('omega', { source: 'codex', limit: 5 }).length,
+  };`);
+  const r = runRuntime(['--query', join(home, 'q.mjs')], home);
+  assert.equal(r.status, 0, r.stderr || r.stdout);
+  assert.deepEqual(JSON.parse(r.stdout), { alpha: 0, omega: 1 }, 'the replacement content replaces the old text');
 });


### PR DESCRIPTION
> Stacked on #121 — base retargets to main automatically once #121 merges. Supersedes the closed #122.

## Background

#104: codex incremental discovery skipped files on an mtime-only cursor comparison, so a same-millisecond rewrite (a rapid append landing in the same mtime tick, or a same-size-at-same-mtime replacement) is silently missed. CONTRIBUTING requires cursors to detect same-millisecond rewrites via mtime + ctime + size + inode; claude adopted that signature in #102, codex is the outlier.

Stacking note: because this PR lands on top of #121, the cursor change rides #121's `__codex_canonical_transcript_v3__` marker bump — no v3→v4 sequencing is needed, since no released database can hold a v3 marker with two-part codex cursors. The fail-closed legacy branch additionally covers any out-of-band stragglers.

## Changes

- `packages/core/src/providers/codex.ts`: `parse()` returns `${mtime}:${lines}:${size}:${ctimeMs}:${ino}`; the discovery skip check uses a codex-local `codexCursorSignatureDiffers`. Unlike claude's legacy gate (#102), codex's two-part cursors fail closed: codex never shipped a five-part cursor, so every pre-v3 cursor can only prove "mtime not older", never "unchanged" — each re-parses once and upgrades to the full signature. Claude is deliberately untouched; its legacy gate stays as #102 designed it.
- `.github/workflows/cli.yml`: add `codex-parse.test.mjs`, `codex-index.test.mjs`, and `app-indexer.test.mjs` to the explicit CI test lists — all three assert codex index behavior and were absent from CI.
- `tests/app-indexer.test.mjs`: five pre-existing assertions compared production-normalized `project_path` values against POSIX literals, which only ever passed because the file was not in CI on Windows; they now compare against `normalize(...)`. No behavior change.
- Runtime cost is zero: the skip path already called `statSync` for mtime; size/ctime/ino come from the same call. The trade-off is that metadata-only changes (e.g. `chmod`) cause one conservative re-parse — the safe direction.

## Tests

All end-to-end cases force the mtime back to the indexed value, so only the size/ctime/ino legs (or a watcher report) can catch the change:

- `tests/codex-index.test.mjs`, real file operations through discover → parse → persist → DB contents:
  - a real **append** forced to the same mtime (size leg);
  - a real **in-place rewrite** preserving size (ctime leg) — runs on all platforms, since Node reports ctime as the status-change time everywhere (birthtime is the creation time);
  - a real **rename replacement** preserving size (file-identity/ino leg — temp file renamed over the original).
- `tests/app-indexer.test.mjs`: an exact **changedPaths** report re-plans the file and updates the DB (the watcher path); exact matching-signature precedence is covered by the discovery unit tests.
- `tests/codex-discover.test.mjs`: matching-signature guardian and plain transcripts are skipped; a same-mtime/different-size guardian rewrite is re-planned; a legacy two-part cursor fails closed even at the current mtime.

## Scope

This closes the *cursor* half of #104. The watcher-side reconcile of moves/copies/deletes remains #104 scope.

## Verification

- Full local suite: **569/569 pass** (`npm test`, incl. CLI rebuild via pretest).
- CI: green on ubuntu / macOS / **Windows** — the same-mtime rewrite assertions now execute on Windows, and the newly-included `app-indexer.test.mjs` passes there after the normalization fixes above.
- `npm run typecheck` (root + app): clean. `eslint` on changed files: clean.

Refs #104