### PR TITLE
[Core] Bound ordinary incremental index finalization

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Verify adaptive watcher package
         run: |
           npm run build --workspace @obelisk-apps/adaptive-watcher
-          node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/claude-parse.test.mjs tests/codex-parse.test.mjs tests/codex-discover.test.mjs tests/app-indexer.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs tests/app-main-settings.test.mjs tests/app-indexer-watcher-filter.test.mjs tests/deepseek-tree.test.mjs
+          node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/claude-parse.test.mjs tests/codex-parse.test.mjs tests/codex-discover.test.mjs tests/app-indexer.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs tests/app-main-settings.test.mjs tests/app-indexer-watcher-filter.test.mjs tests/deepseek-tree.test.mjs tests/index-finalize.test.mjs
 
       - name: Verify query sandbox read-only contract
         run: node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/query.test.mjs

--- a/app/src/main/indexer.ts
+++ b/app/src/main/indexer.ts
@@ -7,6 +7,11 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import { createBuiltinProviderRegistry } from '../../../packages/core/src/providers/builtins.ts';
+import {
+  dropMessageFtsTriggers,
+  ensureFtsReady,
+  refreshSessionProjectPaths,
+} from '../../../packages/core/src/index-finalize.ts';
 import { healWorkflowParentLinks } from '../../../packages/core/src/indexer.ts';
 import type { ProviderRegistry } from '../../../packages/core/src/providers/registry.ts';
 import {
@@ -27,9 +32,7 @@ import { runWriteTransaction, configureConnection, betterSqliteTransactionAdapte
 import { migrateCoreSchemaColumns } from '../../../packages/core/src/schema-migrations.ts';
 import { acquireWriterLease, writerLockPathFor } from '../../../packages/core/src/writer-lease.ts';
 import { runRetryableWriteTransaction, isBeginBusyFailure, hasUnusableTransaction } from '../../../packages/core/src/write-coordinator.ts';
-import {
-  inferProjectPath,
-} from '../../../packages/core/src/parsing.ts';
+import { inferProjectPath } from '../../../packages/core/src/parsing.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -147,31 +150,6 @@ function sessionIdFromChangedPath(projectsDir, changedPath) {
   return null;
 }
 
-function refreshSessionProjectPaths(db, sessionIds: ReadonlySet<string> | null = null) {
-  const sessionById = db.prepare('SELECT id, project FROM sessions WHERE id = ?');
-  const sessions = sessionIds === null
-    ? db.prepare('SELECT id, project FROM sessions').all()
-    : [...sessionIds]
-      .map(sessionId => sessionById.get(sessionId))
-      .filter(Boolean);
-  const cwdStmt = db.prepare(`
-    SELECT cwd FROM messages
-    WHERE session_id = ? AND cwd IS NOT NULL AND cwd != ''
-    ORDER BY timestamp IS NULL, timestamp
-  `);
-  const update = db.prepare('UPDATE sessions SET project_path = ? WHERE id = ?');
-  for (const session of sessions) {
-    const cwds = cwdStmt.all(session.id).map(row => row.cwd);
-    const projectPath = inferProjectPath(session.project, cwds);
-    if (projectPath) update.run(projectPath, session.id);
-  }
-}
-
-function rebuildFts(db) {
-  db.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
-  db.exec("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')");
-}
-
 // PASSIVE by default: it checkpoints what it can without blocking concurrent
 // readers/writers, so it is safe to run after every build. A blocking TRUNCATE
 // (which reclaims the -wal file but needs exclusive access and can contend with
@@ -180,27 +158,6 @@ function checkpointDb(db, mode = 'PASSIVE') {
   try {
     db.pragma(`wal_checkpoint(${mode})`);
   } catch {}
-}
-
-const MESSAGE_FTS_TRIGGERS = [
-  'messages_fts_ai',
-  'messages_fts_ad',
-  'messages_fts_au',
-];
-
-function dropMessageFtsTriggers(db) {
-  for (const trigger of MESSAGE_FTS_TRIGGERS) {
-    db.exec(`DROP TRIGGER IF EXISTS ${trigger}`);
-  }
-}
-
-function ensureFtsReady(db, { force = false } = {}) {
-  const marker = '__fts_triggers_ready__';
-  const ready = db.prepare('SELECT jsonl_path FROM index_state WHERE jsonl_path = ?').get(marker);
-  if (ready && !force) return false;
-  rebuildFts(db);
-  writeIndexMarker(db, marker);
-  return true;
 }
 
 function writeIndexMarker(db, key, value = Date.now()) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
     ".": "./dist/core.js",
     "./db": "./dist/db.js",
     "./indexer": "./dist/indexer.js",
+    "./index-finalize": "./dist/index-finalize.js",
     "./parsing": "./dist/parsing.js",
     "./persist": "./dist/persist.js",
     "./provider-indexing": "./dist/provider-indexing.js",

--- a/packages/core/src/index-finalize.ts
+++ b/packages/core/src/index-finalize.ts
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Shared database-finalize policies for the passive CLI indexer and the app
+// daemon. Callers keep ownership of discovery, retries, watcher state, and
+// transactions; this module owns the invariants that must not diverge between
+// the two indexing modes.
+
+import { inferProjectPath } from './parsing.ts';
+import type { SqliteDb, SqliteRow } from './sqlite-types.ts';
+
+const FTS_TRIGGERS_READY_MARKER = '__fts_triggers_ready__';
+const MESSAGE_FTS_TRIGGERS = [
+  'messages_fts_ai',
+  'messages_fts_ad',
+  'messages_fts_au',
+] as const;
+
+/** Remove message FTS triggers before a caller-owned bulk replacement. */
+export function dropMessageFtsTriggers(db: SqliteDb): void {
+  for (const trigger of MESSAGE_FTS_TRIGGERS) {
+    db.exec(`DROP TRIGGER IF EXISTS ${trigger}`);
+  }
+}
+
+/**
+ * Rebuild both external-content FTS indexes only when the index has not yet
+ * recorded trigger readiness, or when a force snapshot explicitly requests a
+ * complete repair. The marker is written by the caller's transaction after
+ * both rebuilds succeed.
+ */
+export function ensureFtsReady(db: SqliteDb, { force = false }: { force?: boolean } = {}): boolean {
+  const ready = db.prepare('SELECT jsonl_path FROM index_state WHERE jsonl_path = ?')
+    .get(FTS_TRIGGERS_READY_MARKER);
+  if (ready && !force) return false;
+  db.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
+  db.exec("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')");
+  db.prepare(
+    'INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES (?, ?, 0)',
+  ).run(FTS_TRIGGERS_READY_MARKER, Date.now());
+  return true;
+}
+
+/**
+ * Refresh project paths for every session (`null`) or for one affected set.
+ * Scoped refreshes also repair unresolved rows, so legacy/null paths converge
+ * without turning every ordinary incremental build into a corpus-wide scan.
+ */
+export function refreshSessionProjectPaths(
+  db: SqliteDb,
+  sessionIds: ReadonlySet<string> | null = null,
+): void {
+  let sessions: SqliteRow[];
+  if (sessionIds === null) {
+    sessions = db.prepare('SELECT id, project FROM sessions').all();
+  } else {
+    const byId = new Map<string, SqliteRow>();
+    const sessionById = db.prepare('SELECT id, project FROM sessions WHERE id = ?');
+    for (const sessionId of sessionIds) {
+      const session = sessionById.get(sessionId);
+      if (session) byId.set(String(session.id), session);
+    }
+    for (const session of db.prepare(
+      "SELECT id, project FROM sessions WHERE project_path IS NULL OR project_path = ''",
+    ).all()) {
+      byId.set(String(session.id), session);
+    }
+    sessions = [...byId.values()];
+  }
+
+  const cwdStmt = db.prepare(`
+    SELECT cwd
+    FROM messages
+    WHERE session_id = ? AND cwd IS NOT NULL AND cwd != ''
+    ORDER BY timestamp IS NULL, timestamp
+  `);
+  const update = db.prepare('UPDATE sessions SET project_path = ? WHERE id = ?');
+  for (const session of sessions) {
+    const cwds = cwdStmt.all(session.id).map((row: SqliteRow) => row.cwd);
+    const projectPath = inferProjectPath(session.project, cwds);
+    if (projectPath) update.run(projectPath, session.id);
+  }
+}
+
+export { FTS_TRIGGERS_READY_MARKER };

--- a/packages/core/src/index-finalize.ts
+++ b/packages/core/src/index-finalize.ts
@@ -10,6 +10,7 @@ import { inferProjectPath } from './parsing.ts';
 import type { SqliteDb, SqliteRow } from './sqlite-types.ts';
 
 const FTS_TRIGGERS_READY_MARKER = '__fts_triggers_ready__';
+const PROJECT_PATH_BACKFILL_MARKER = '__project_path_backfill_v1__';
 const MESSAGE_FTS_TRIGGERS = [
   'messages_fts_ai',
   'messages_fts_ad',
@@ -26,8 +27,11 @@ export function dropMessageFtsTriggers(db: SqliteDb): void {
 /**
  * Rebuild both external-content FTS indexes only when the index has not yet
  * recorded trigger readiness, or when a force snapshot explicitly requests a
- * complete repair. The marker is written by the caller's transaction after
- * both rebuilds succeed.
+ * complete repair. Trigger-only maintenance is safe because persist writes
+ * messages with INSERT ... ON CONFLICT DO UPDATE (fires messages_fts_au) and
+ * removes them with plain DELETE (fires messages_fts_ad); it never uses
+ * INSERT OR REPLACE for messages. The marker is written by the caller's
+ * transaction after both rebuilds succeed.
  */
 export function ensureFtsReady(db: SqliteDb, { force = false }: { force?: boolean } = {}): boolean {
   const ready = db.prepare('SELECT jsonl_path FROM index_state WHERE jsonl_path = ?')
@@ -42,9 +46,7 @@ export function ensureFtsReady(db: SqliteDb, { force = false }: { force?: boolea
 }
 
 /**
- * Refresh project paths for every session (`null`) or for one affected set.
- * Scoped refreshes also repair unresolved rows, so legacy/null paths converge
- * without turning every ordinary incremental build into a corpus-wide scan.
+ * Refresh project paths for every session (`null`) or exactly one affected set.
  */
 export function refreshSessionProjectPaths(
   db: SqliteDb,
@@ -54,18 +56,10 @@ export function refreshSessionProjectPaths(
   if (sessionIds === null) {
     sessions = db.prepare('SELECT id, project FROM sessions').all();
   } else {
-    const byId = new Map<string, SqliteRow>();
     const sessionById = db.prepare('SELECT id, project FROM sessions WHERE id = ?');
-    for (const sessionId of sessionIds) {
-      const session = sessionById.get(sessionId);
-      if (session) byId.set(String(session.id), session);
-    }
-    for (const session of db.prepare(
-      "SELECT id, project FROM sessions WHERE project_path IS NULL OR project_path = ''",
-    ).all()) {
-      byId.set(String(session.id), session);
-    }
-    sessions = [...byId.values()];
+    sessions = [...sessionIds]
+      .map(sessionId => sessionById.get(sessionId))
+      .filter((session): session is SqliteRow => session !== undefined);
   }
 
   const cwdStmt = db.prepare(`
@@ -82,4 +76,19 @@ export function refreshSessionProjectPaths(
   }
 }
 
-export { FTS_TRIGGERS_READY_MARKER };
+/** Repair legacy unresolved project paths once; new/changed sessions use their unit transaction. */
+export function backfillUnresolvedSessionProjectPathsOnce(db: SqliteDb): boolean {
+  const done = db.prepare('SELECT jsonl_path FROM index_state WHERE jsonl_path = ?')
+    .get(PROJECT_PATH_BACKFILL_MARKER);
+  if (done) return false;
+  const unresolved = new Set(db.prepare(
+    "SELECT id FROM sessions WHERE project_path IS NULL OR project_path = ''",
+  ).all().map((session: SqliteRow) => String(session.id)));
+  refreshSessionProjectPaths(db, unresolved);
+  db.prepare(
+    'INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES (?, ?, 0)',
+  ).run(PROJECT_PATH_BACKFILL_MARKER, Date.now());
+  return true;
+}
+
+export { FTS_TRIGGERS_READY_MARKER, PROJECT_PATH_BACKFILL_MARKER };

--- a/packages/core/src/indexer.ts
+++ b/packages/core/src/indexer.ts
@@ -4,7 +4,11 @@
 // Passive-pull indexing orchestration for the Core package.
 import { existsSync } from 'node:fs';
 import { DB_PATH, openDb, openReadDb, openWriterLeaseDb } from './db.ts';
-import { ensureFtsReady, refreshSessionProjectPaths } from './index-finalize.ts';
+import {
+  backfillUnresolvedSessionProjectPathsOnce,
+  ensureFtsReady,
+  refreshSessionProjectPaths,
+} from './index-finalize.ts';
 import { inferProjectPath } from './parsing.ts';
 import {
   createProviderIndexPlan,
@@ -225,6 +229,7 @@ function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwne
               plan: providerPlan,
             });
             refreshSessionProjectPaths(db, null);
+            backfillUnresolvedSessionProjectPathsOnce(db);
             healWorkflowParentLinks(db);
             ensureFtsReady(db, { force: true });
             db.prepare("INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES ('__last_build__', ?, 0)").run(Date.now());
@@ -316,9 +321,9 @@ function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwne
       // the build (a half-finalized index would be inconsistent).
       try {
         runRetryableWriteTransaction(txDb, () => {
-          // Per-unit paths commit atomically with their provider cursors above.
-          // An empty scope still repairs legacy rows with no project_path.
-          refreshSessionProjectPaths(db, new Set());
+          // Per-unit paths commit atomically with their provider cursors above;
+          // legacy unresolved rows use one explicit, convergent backfill.
+          backfillUnresolvedSessionProjectPathsOnce(db);
           healWorkflowParentLinks(db);
           ensureFtsReady(db);
           db.prepare("INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES ('__last_build__', ?, 0)").run(Date.now());

--- a/packages/core/src/indexer.ts
+++ b/packages/core/src/indexer.ts
@@ -3,7 +3,8 @@
 
 // Passive-pull indexing orchestration for the Core package.
 import { existsSync } from 'node:fs';
-import { DB_PATH, openDb, openReadDb, openWriterLeaseDb, rebuildMemoryFts } from './db.ts';
+import { DB_PATH, openDb, openReadDb, openWriterLeaseDb } from './db.ts';
+import { ensureFtsReady, refreshSessionProjectPaths } from './index-finalize.ts';
 import { inferProjectPath } from './parsing.ts';
 import {
   createProviderIndexPlan,
@@ -22,7 +23,7 @@ import {
 } from './provider-settings.ts';
 import { coreSchemaNeedsMigration } from './schema-migrations.ts';
 import type { ProviderRegistry } from './providers/registry.ts';
-import type { NodeSqliteDb, SqliteDb, SqliteRow } from './sqlite-types.ts';
+import type { NodeSqliteDb, SqliteDb } from './sqlite-types.ts';
 
 interface SkippedFile {
   provider: string;
@@ -56,22 +57,6 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-
-function refreshSessionProjectPaths(db: NodeSqliteDb): void {
-  const sessions = db.prepare('SELECT id, project FROM sessions').all();
-  const cwdStmt = db.prepare(`
-    SELECT cwd
-    FROM messages
-    WHERE session_id = ? AND cwd IS NOT NULL AND cwd != ''
-    ORDER BY timestamp IS NULL, timestamp
-  `);
-  const update = db.prepare('UPDATE sessions SET project_path = ? WHERE id = ?');
-  for (const session of sessions) {
-    const cwds = cwdStmt.all(session.id).map((row: SqliteRow) => row.cwd);
-    const projectPath = inferProjectPath(session.project, cwds);
-    if (projectPath) update.run(projectPath, session.id);
-  }
-}
 
 // A workflow unit links to its parent Workflow tool call by matching the unique
 // run id in the tool_result text — but the run json can reach the index before
@@ -239,10 +224,9 @@ function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwne
               db,
               plan: providerPlan,
             });
-            refreshSessionProjectPaths(db);
+            refreshSessionProjectPaths(db, null);
             healWorkflowParentLinks(db);
-            db.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
-            rebuildMemoryFts(db);
+            ensureFtsReady(db, { force: true });
             db.prepare("INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES ('__last_build__', ?, 0)").run(Date.now());
             writeProviderIndexMarkers(db, providerPlan, providerResult);
           }, { label: 'force-rebuild' });
@@ -296,6 +280,12 @@ function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwne
         db,
         plan: providerPlan,
         runTransaction: (label, work) => runRetryableWriteTransaction(txDb, work, { label }),
+        onPersisted: ({ unit }) => {
+          refreshSessionProjectPaths(db, new Set([
+            unit.sessionId,
+            ...(unit.retractSessionIds ?? []),
+          ]));
+        },
         onError: (error, { provider, unit }) => {
           if (isBeginBusyFailure(error)) return 'stop';
           if (hasUnusableTransaction(error)) throw error;
@@ -326,10 +316,11 @@ function buildIndex({ force = false, ignoreRecentBuild = false, ignoreDaemonOwne
       // the build (a half-finalized index would be inconsistent).
       try {
         runRetryableWriteTransaction(txDb, () => {
-          refreshSessionProjectPaths(db);
+          // Per-unit paths commit atomically with their provider cursors above.
+          // An empty scope still repairs legacy rows with no project_path.
+          refreshSessionProjectPaths(db, new Set());
           healWorkflowParentLinks(db);
-          db.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')");
-          rebuildMemoryFts(db);
+          ensureFtsReady(db);
           db.prepare("INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES ('__last_build__', ?, 0)").run(Date.now());
           writeProviderIndexMarkers(db, providerPlan, providerResult);
         }, { label: 'finalize' });

--- a/packages/core/src/provider-indexing.ts
+++ b/packages/core/src/provider-indexing.ts
@@ -255,12 +255,15 @@ export function indexProviderPlan({
   db,
   plan,
   runTransaction,
+  onPersisted = () => {},
   onCommitted = () => {},
   onError,
 }: {
   db: SqliteDb;
   plan: ProviderIndexPlan;
   runTransaction: <T>(label: string, work: () => T) => T;
+  /** Runs after persist but inside the same transaction, before its commit. */
+  onPersisted?: (item: ProviderIndexItem, cursor: Cursor) => void;
   onCommitted?: (item: ProviderIndexItem, cursor: Cursor) => void;
   onError: (error: unknown, item: ProviderIndexItem) => 'skip' | 'stop';
 }): ProviderIndexResult {
@@ -269,9 +272,11 @@ export function indexProviderPlan({
   const failedItems: ProviderIndexItem[] = [];
   for (const item of plan.items) {
     try {
-      const cursor = runTransaction(`provider:${item.provider.name}:${item.unit.key}`, () => (
-        persist(db, item.unit, item.provider.parse(item.unit, item.cursor))
-      ));
+      const cursor = runTransaction(`provider:${item.provider.name}:${item.unit.key}`, () => {
+        const nextCursor = persist(db, item.unit, item.provider.parse(item.unit, item.cursor));
+        onPersisted(item, nextCursor);
+        return nextCursor;
+      });
       committed.push(item);
       onCommitted(item, cursor);
     } catch (error) {
@@ -300,16 +305,19 @@ export function indexProviderPlan({
 export function indexProviderPlanStrict({
   db,
   plan,
+  onPersisted = () => {},
   onCommitted = () => {},
 }: {
   db: SqliteDb;
   plan: ProviderIndexPlan;
+  onPersisted?: (item: ProviderIndexItem, cursor: Cursor) => void;
   onCommitted?: (item: ProviderIndexItem, cursor: Cursor) => void;
 }): ProviderIndexResult {
   return indexProviderPlan({
     db,
     plan,
     runTransaction: (_label, work) => work(),
+    onPersisted,
     onCommitted,
     onError: (error, item) => {
       throw new ProviderIndexFailure(error, item);

--- a/tests/incremental-index.test.mjs
+++ b/tests/incremental-index.test.mjs
@@ -41,6 +41,10 @@ function counts(home) {
   return JSON.parse(r.stdout);
 }
 
+function ftsHits(db, query) {
+  return db.prepare('SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH ?').get(query).count;
+}
+
 test('incremental buildIndex resumes from cursor and accumulates message_count', () => {
   const home = makeTempDir('obelisk-incr-');
   const projDir = join(home, '.claude', 'projects', '-tmp-proj');
@@ -67,6 +71,41 @@ test('incremental buildIndex resumes from cursor and accumulates message_count',
   assert.equal(afterAppend.mc, 4, 'message_count accumulated to 4');
   assert.equal(afterAppend.n, 4, 'exactly four messages, no duplicates');
   assert.equal(afterAppend.lp, 4, 'cursor advanced to 4 lines');
+});
+
+test('ordinary incremental finalize keeps trigger-maintained FTS and scopes project paths', () => {
+  const home = makeTempDir('obelisk-incr-finalize-');
+  const projDir = join(home, '.claude', 'projects', '-tmp-proj');
+  mkdirSync(projDir, { recursive: true });
+  const affected = join(projDir, 'affected.jsonl');
+  const unaffected = join(projDir, 'unaffected.jsonl');
+  writeFileSync(affected, line('affected-u1', 'user', '2026-06-10T10:00:00Z') + '\n');
+  writeFileSync(unaffected, line('unaffected-u1', 'user', '2026-06-10T10:00:00Z') + '\n');
+  assert.equal(runRuntime(['--build'], home).status, 0);
+
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  let db = new DatabaseSync(dbPath);
+  assert.ok(db.prepare("SELECT 1 FROM index_state WHERE jsonl_path='__fts_triggers_ready__'").get());
+  db.prepare('INSERT INTO messages_fts(rowid, uuid, session_id, text) VALUES (?,?,?,?)')
+    .run(999999, 'poison', 'affected', 'poisonword');
+  db.prepare("UPDATE sessions SET project_path='/stale/affected' WHERE id='affected'").run();
+  db.prepare("UPDATE sessions SET project_path='/stale/unaffected' WHERE id='unaffected'").run();
+  db.close();
+
+  appendFileSync(affected, line('freshneedle', 'user', '2026-06-10T10:01:00Z') + '\n');
+  const t = statSync(affected).mtimeMs / 1000 + 10;
+  utimesSync(affected, t, t);
+  clearBuildDebounce(home);
+
+  const result = runRuntime(['--search', 'freshneedle', '--nonce', 'freshneedle'], home);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  db = new DatabaseSync(dbPath);
+  assert.equal(ftsHits(db, 'freshneedle'), 1, 'message trigger indexed the appended row');
+  assert.equal(ftsHits(db, 'poisonword'), 1, 'poison survives because incremental finalize skipped wholesale rebuild');
+  assert.equal(db.prepare("SELECT project_path FROM sessions WHERE id='affected'").get().project_path, '/tmp/proj');
+  assert.equal(db.prepare("SELECT project_path FROM sessions WHERE id='unaffected'").get().project_path, '/stale/unaffected');
+  db.close();
 });
 
 test('force build purges sessions for deleted files and preserves memories', () => {

--- a/tests/incremental-index.test.mjs
+++ b/tests/incremental-index.test.mjs
@@ -41,10 +41,6 @@ function counts(home) {
   return JSON.parse(r.stdout);
 }
 
-function ftsHits(db, query) {
-  return db.prepare('SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH ?').get(query).count;
-}
-
 test('incremental buildIndex resumes from cursor and accumulates message_count', () => {
   const home = makeTempDir('obelisk-incr-');
   const projDir = join(home, '.claude', 'projects', '-tmp-proj');
@@ -71,41 +67,6 @@ test('incremental buildIndex resumes from cursor and accumulates message_count',
   assert.equal(afterAppend.mc, 4, 'message_count accumulated to 4');
   assert.equal(afterAppend.n, 4, 'exactly four messages, no duplicates');
   assert.equal(afterAppend.lp, 4, 'cursor advanced to 4 lines');
-});
-
-test('ordinary incremental finalize keeps trigger-maintained FTS and scopes project paths', () => {
-  const home = makeTempDir('obelisk-incr-finalize-');
-  const projDir = join(home, '.claude', 'projects', '-tmp-proj');
-  mkdirSync(projDir, { recursive: true });
-  const affected = join(projDir, 'affected.jsonl');
-  const unaffected = join(projDir, 'unaffected.jsonl');
-  writeFileSync(affected, line('affected-u1', 'user', '2026-06-10T10:00:00Z') + '\n');
-  writeFileSync(unaffected, line('unaffected-u1', 'user', '2026-06-10T10:00:00Z') + '\n');
-  assert.equal(runRuntime(['--build'], home).status, 0);
-
-  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
-  let db = new DatabaseSync(dbPath);
-  assert.ok(db.prepare("SELECT 1 FROM index_state WHERE jsonl_path='__fts_triggers_ready__'").get());
-  db.prepare('INSERT INTO messages_fts(rowid, uuid, session_id, text) VALUES (?,?,?,?)')
-    .run(999999, 'poison', 'affected', 'poisonword');
-  db.prepare("UPDATE sessions SET project_path='/stale/affected' WHERE id='affected'").run();
-  db.prepare("UPDATE sessions SET project_path='/stale/unaffected' WHERE id='unaffected'").run();
-  db.close();
-
-  appendFileSync(affected, line('freshneedle', 'user', '2026-06-10T10:01:00Z') + '\n');
-  const t = statSync(affected).mtimeMs / 1000 + 10;
-  utimesSync(affected, t, t);
-  clearBuildDebounce(home);
-
-  const result = runRuntime(['--search', 'freshneedle', '--nonce', 'freshneedle'], home);
-  assert.equal(result.status, 0, result.stderr || result.stdout);
-
-  db = new DatabaseSync(dbPath);
-  assert.equal(ftsHits(db, 'freshneedle'), 1, 'message trigger indexed the appended row');
-  assert.equal(ftsHits(db, 'poisonword'), 1, 'poison survives because incremental finalize skipped wholesale rebuild');
-  assert.equal(db.prepare("SELECT project_path FROM sessions WHERE id='affected'").get().project_path, '/tmp/proj');
-  assert.equal(db.prepare("SELECT project_path FROM sessions WHERE id='unaffected'").get().project_path, '/stale/unaffected');
-  db.close();
 });
 
 test('force build purges sessions for deleted files and preserves memories', () => {

--- a/tests/index-finalize.test.mjs
+++ b/tests/index-finalize.test.mjs
@@ -4,17 +4,24 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { readFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import {
   FTS_TRIGGERS_READY_MARKER,
+  PROJECT_PATH_BACKFILL_MARKER,
+  backfillUnresolvedSessionProjectPathsOnce,
   ensureFtsReady,
   refreshSessionProjectPaths,
 } from '../packages/core/src/index-finalize.ts';
+import { persist } from '../packages/core/src/persist.ts';
+import { runCli } from './cli-test-helpers.mjs';
+import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
 const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+const REAL_PI_FIXTURE = new URL('./fixtures/pi/real-model-session.jsonl', import.meta.url);
 
 function freshDb() {
   const db = new DatabaseSync(':memory:');
@@ -31,7 +38,35 @@ function insertSession(db, id, projectPath) {
   `).run(`message-${id}`, id, `text-${id}`, `/work/${id}`);
 }
 
-test('scoped project-path refresh touches affected and unresolved sessions only', () => {
+function* sessionRecords(text) {
+  yield {
+    kind: 'message', uuid: 'persisted-message', session_id: 'persisted-session',
+    type: 'assistant', parent_uuid: null, timestamp: '2026-08-31T00:00:00Z',
+    role: 'assistant', text, content_type: 'text', is_meta: 0, visibility: 'visible',
+    model: null, is_sidechain: 0, agent_id: null, input_tokens: null,
+    output_tokens: null, cwd: '/work/persisted', skill: null, source: 'claude',
+  };
+  yield {
+    kind: 'session', id: 'persisted-session', title: null, project: '-work-persisted',
+    started_at: '2026-08-31T00:00:00Z', ended_at: '2026-08-31T00:00:00Z',
+    git_branch: null, version: null, message_count: 1, countMode: 'total',
+    jsonl_path: '/source/persisted.jsonl', source: 'claude',
+  };
+  return '1:1';
+}
+
+function* deletionRecords() {
+  yield { kind: 'delete-session', sessionId: 'persisted-session' };
+  return '2:1';
+}
+
+const PERSIST_UNIT = {
+  key: '/source/persisted.jsonl',
+  sessionId: 'persisted-session',
+  project: '-work-persisted',
+};
+
+test('scoped project-path refresh touches affected sessions only', () => {
   const db = freshDb();
   insertSession(db, 'affected', '/stale/affected');
   insertSession(db, 'unaffected', '/stale/unaffected');
@@ -41,8 +76,24 @@ test('scoped project-path refresh touches affected and unresolved sessions only'
 
   const projectPath = id => db.prepare('SELECT project_path FROM sessions WHERE id = ?').get(id).project_path;
   assert.equal(projectPath('affected'), '/work/affected');
-  assert.equal(projectPath('unresolved'), '/work/unresolved');
+  assert.equal(projectPath('unresolved'), null);
   assert.equal(projectPath('unaffected'), '/stale/unaffected');
+  db.close();
+});
+
+test('legacy unresolved project paths are backfilled once, not on every finalize', () => {
+  const db = freshDb();
+  insertSession(db, 'repairable', null);
+  db.prepare("INSERT INTO sessions (id, project, project_path, source) VALUES ('permanent', NULL, NULL, 'claude')").run();
+
+  assert.equal(backfillUnresolvedSessionProjectPathsOnce(db), true);
+  assert.equal(db.prepare("SELECT project_path FROM sessions WHERE id='repairable'").get().project_path, '/work/repairable');
+  assert.equal(db.prepare("SELECT project_path FROM sessions WHERE id='permanent'").get().project_path, null);
+  assert.ok(db.prepare('SELECT 1 FROM index_state WHERE jsonl_path = ?').get(PROJECT_PATH_BACKFILL_MARKER));
+
+  insertSession(db, 'later', null);
+  assert.equal(backfillUnresolvedSessionProjectPathsOnce(db), false);
+  assert.equal(db.prepare("SELECT project_path FROM sessions WHERE id='later'").get().project_path, null);
   db.close();
 });
 
@@ -67,5 +118,55 @@ test('FTS readiness skips ordinary rebuilds and force repairs the complete index
   assert.equal(ensureFtsReady(db, { force: true }), true);
   assert.equal(db.prepare("SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH 'poisonword'").get().count, 0);
   db.exec("INSERT INTO messages_fts(messages_fts, rank) VALUES('integrity-check', 1)");
+  db.close();
+});
+
+test('persist update and delete shapes keep trigger-maintained FTS consistent', () => {
+  const db = freshDb();
+  persist(db, PERSIST_UNIT, sessionRecords('oldword'));
+  ensureFtsReady(db);
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH 'oldword'").get().count, 1);
+
+  persist(db, PERSIST_UNIT, sessionRecords('newword'));
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH 'oldword'").get().count, 0);
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH 'newword'").get().count, 1);
+
+  persist(db, PERSIST_UNIT, deletionRecords());
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH 'newword'").get().count, 0);
+  db.exec("INSERT INTO messages_fts(messages_fts, rank) VALUES('integrity-check', 1)");
+  db.close();
+});
+
+test('ordinary Core build skips corpus-wide FTS and project-path work', () => {
+  const home = makeTempDir('obelisk-finalize-integration-');
+  const piDir = join(home, '.pi', 'agent', 'sessions', 'project');
+  mkdirSync(piDir, { recursive: true });
+  copyFileSync(REAL_PI_FIXTURE, join(piDir, 'session.jsonl'));
+  assert.equal(runCli(['--build'], { home }).status, 0);
+
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  let db = new DatabaseSync(dbPath);
+  const session = db.prepare("SELECT id FROM sessions WHERE source='pi'").get();
+  assert.ok(session?.id);
+  db.prepare('INSERT INTO messages_fts(rowid, uuid, session_id, text) VALUES (?,?,?,?)')
+    .run(999999, 'poison', session.id, 'poisonword');
+  db.prepare('UPDATE sessions SET project_path = ? WHERE id = ?').run('/stale/unaffected', session.id);
+  db.prepare("DELETE FROM index_state WHERE jsonl_path='__last_build__'").run();
+  db.close();
+
+  const result = runCli(['--search', 'REAL_PI_PROBE_OK', '--nonce', 'REAL_PI_PROBE_OK'], { home });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  db = new DatabaseSync(dbPath);
+  assert.equal(
+    db.prepare("SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH 'poisonword'").get().count,
+    1,
+    'poison survives because ordinary finalize did not rebuild the complete FTS index',
+  );
+  assert.equal(
+    db.prepare('SELECT project_path FROM sessions WHERE id = ?').get(session.id).project_path,
+    '/stale/unaffected',
+    'an unchanged session is not included in ordinary project-path refresh',
+  );
   db.close();
 });

--- a/tests/index-finalize.test.mjs
+++ b/tests/index-finalize.test.mjs
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+
+import {
+  FTS_TRIGGERS_READY_MARKER,
+  ensureFtsReady,
+  refreshSessionProjectPaths,
+} from '../packages/core/src/index-finalize.ts';
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require('node:sqlite');
+const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+
+function freshDb() {
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  return db;
+}
+
+function insertSession(db, id, projectPath) {
+  db.prepare('INSERT INTO sessions (id, project, project_path, source) VALUES (?, ?, ?, ?)')
+    .run(id, `-${id}`, projectPath, 'claude');
+  db.prepare(`
+    INSERT INTO messages (uuid, session_id, type, timestamp, role, text, content_type, cwd, source)
+    VALUES (?, ?, 'user', '2026-08-31T00:00:00Z', 'user', ?, 'text', ?, 'claude')
+  `).run(`message-${id}`, id, `text-${id}`, `/work/${id}`);
+}
+
+test('scoped project-path refresh touches affected and unresolved sessions only', () => {
+  const db = freshDb();
+  insertSession(db, 'affected', '/stale/affected');
+  insertSession(db, 'unaffected', '/stale/unaffected');
+  insertSession(db, 'unresolved', null);
+
+  refreshSessionProjectPaths(db, new Set(['affected']));
+
+  const projectPath = id => db.prepare('SELECT project_path FROM sessions WHERE id = ?').get(id).project_path;
+  assert.equal(projectPath('affected'), '/work/affected');
+  assert.equal(projectPath('unresolved'), '/work/unresolved');
+  assert.equal(projectPath('unaffected'), '/stale/unaffected');
+  db.close();
+});
+
+test('FTS readiness skips ordinary rebuilds and force repairs the complete index', () => {
+  const db = freshDb();
+  insertSession(db, 'indexed', '/work/indexed');
+
+  assert.equal(ensureFtsReady(db), true);
+  assert.ok(db.prepare('SELECT 1 FROM index_state WHERE jsonl_path = ?').get(FTS_TRIGGERS_READY_MARKER));
+
+  db.prepare('INSERT INTO messages_fts(rowid, uuid, session_id, text) VALUES (?, ?, ?, ?)')
+    .run(999999, 'poison', 'indexed', 'poisonword');
+  db.prepare(`
+    INSERT INTO messages (uuid, session_id, type, role, text, content_type, source)
+    VALUES ('fresh', 'indexed', 'user', 'user', 'freshneedle', 'text', 'claude')
+  `).run();
+
+  assert.equal(ensureFtsReady(db), false);
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH 'poisonword'").get().count, 1);
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH 'freshneedle'").get().count, 1);
+
+  assert.equal(ensureFtsReady(db, { force: true }), true);
+  assert.equal(db.prepare("SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH 'poisonword'").get().count, 0);
+  db.exec("INSERT INTO messages_fts(messages_fts, rank) VALUES('integrity-check', 1)");
+  db.close();
+});

--- a/tests/index-finalize.test.mjs
+++ b/tests/index-finalize.test.mjs
@@ -5,7 +5,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 import { copyFileSync, mkdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, normalize } from 'node:path';
 
 import {
   FTS_TRIGGERS_READY_MARKER,
@@ -75,7 +75,7 @@ test('scoped project-path refresh touches affected sessions only', () => {
   refreshSessionProjectPaths(db, new Set(['affected']));
 
   const projectPath = id => db.prepare('SELECT project_path FROM sessions WHERE id = ?').get(id).project_path;
-  assert.equal(projectPath('affected'), '/work/affected');
+  assert.equal(projectPath('affected'), normalize('/work/affected'));
   assert.equal(projectPath('unresolved'), null);
   assert.equal(projectPath('unaffected'), '/stale/unaffected');
   db.close();
@@ -87,7 +87,10 @@ test('legacy unresolved project paths are backfilled once, not on every finalize
   db.prepare("INSERT INTO sessions (id, project, project_path, source) VALUES ('permanent', NULL, NULL, 'claude')").run();
 
   assert.equal(backfillUnresolvedSessionProjectPathsOnce(db), true);
-  assert.equal(db.prepare("SELECT project_path FROM sessions WHERE id='repairable'").get().project_path, '/work/repairable');
+  assert.equal(
+    db.prepare("SELECT project_path FROM sessions WHERE id='repairable'").get().project_path,
+    normalize('/work/repairable'),
+  );
   assert.equal(db.prepare("SELECT project_path FROM sessions WHERE id='permanent'").get().project_path, null);
   assert.ok(db.prepare('SELECT 1 FROM index_state WHERE jsonl_path = ?').get(PROJECT_PATH_BACKFILL_MARKER));
 

--- a/tests/index-finalize.test.mjs
+++ b/tests/index-finalize.test.mjs
@@ -97,6 +97,33 @@ test('legacy unresolved project paths are backfilled once, not on every finalize
   insertSession(db, 'later', null);
   assert.equal(backfillUnresolvedSessionProjectPathsOnce(db), false);
   assert.equal(db.prepare("SELECT project_path FROM sessions WHERE id='later'").get().project_path, null);
+  refreshSessionProjectPaths(db, new Set(['later']));
+  assert.equal(
+    db.prepare("SELECT project_path FROM sessions WHERE id='later'").get().project_path,
+    normalize('/work/later'),
+    'the backfill marker never blocks the affected-unit repair path',
+  );
+  db.close();
+});
+
+test('legacy project-path backfill retries cleanly after transaction rollback', () => {
+  const db = freshDb();
+  insertSession(db, 'rollback', null);
+
+  db.exec('BEGIN');
+  assert.equal(backfillUnresolvedSessionProjectPathsOnce(db), true);
+  db.exec('ROLLBACK');
+  assert.equal(db.prepare("SELECT project_path FROM sessions WHERE id='rollback'").get().project_path, null);
+  assert.equal(db.prepare('SELECT 1 FROM index_state WHERE jsonl_path = ?').get(PROJECT_PATH_BACKFILL_MARKER), undefined);
+
+  db.exec('BEGIN');
+  assert.equal(backfillUnresolvedSessionProjectPathsOnce(db), true);
+  db.exec('COMMIT');
+  assert.equal(
+    db.prepare("SELECT project_path FROM sessions WHERE id='rollback'").get().project_path,
+    normalize('/work/rollback'),
+  );
+  assert.ok(db.prepare('SELECT 1 FROM index_state WHERE jsonl_path = ?').get(PROJECT_PATH_BACKFILL_MARKER));
   db.close();
 });
 


### PR DESCRIPTION
## Summary

- Removes corpus-wide FTS and project-path work from ordinary Core/CLI incremental builds.
- Shares the proven database-finalize policies with the app while preserving each indexer's own orchestration.
- Reduces a real 1 GB index refresh from 34.00 s to 2.83 s (91.7%).

## Scope

- In scope:
  - shared FTS readiness and project-path refresh invariants
  - affected-session scoping for Core/CLI
  - atomic project-path refresh with provider cursor commits
  - force/marker-less recovery and app behavior regression coverage
- Out of scope:
  - provider discovery performance
  - invocation-session resolution latency
  - app watcher scheduling and UI behavior

## Key Changes

- Adds a binding-agnostic Core finalize module used by both `node:sqlite` and `better-sqlite3` indexers.
- Makes normal FTS maintenance trigger-driven; marker-less and force paths still rebuild and integrity-check the complete index.
- Refreshes Core/CLI project paths inside each provider unit transaction, so the path and cursor commit atomically; a versioned marker runs unresolved legacy repair once instead of on every unit/build.
- Reuses the shared policies from the app without moving its changed-path, retry, checkpoint, or trigger-restoration orchestration into Core.
- Documents and tests why trigger-only maintenance is safe: message writes use `ON CONFLICT DO UPDATE`, deletes use plain `DELETE`, and neither path uses `INSERT OR REPLACE`.

## Validation

- `npm test` (outside the managed sandbox so macOS FSEvents tests can run): pass, 575/575.
- `npm run typecheck`: pass for root and app TypeScript configurations.
- `git ls-files ... | npx eslint`: pass with 0 errors; 80 existing warnings.
- `npm --prefix app run test:electron:all`: pass, 5/5 Electron suites.
- Finalize policy + real-Pi Core integration tests: pass, 6/6; the test is included in the explicit CLI CI matrix. Coverage includes rollback/retry convergence and post-marker affected-session repair.
- Real-index SQL profiles (1.0 GB / 268k messages): 34.00 s before, 2.83 s for the comparable post-fix run; a later run processing 993 messages across five affected sessions completed in 3.69 s. Neither run rebuilt FTS or scanned unaffected session cwd rows.

## Risks and Rollback

- Main risk: trusting FTS triggers after readiness is recorded. Marker-less and force tests retain the wholesale repair path and run FTS5 integrity-check.
- Main risk: losing affected-session context after a finalize failure. Core refreshes project paths in the same transaction as each provider cursor, while app retains its existing retry-session flow.
- Rollback: revert this PR; no schema migration or irreversible data change is introduced.

## Related Issues

- Related to #75
- Related to #105
- Related to #114
- Supersedes the partial Core-only FTS approach in #77
- Preserves the app behavior introduced by #98

Closes #125
