### PR TITLE
feat(query): add bounded history retrieval controls

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,3 +14,17 @@ obelisk --query /tmp/query.mjs
 `obelisk install` installs the separate docs-only agent skill from
 `tommy0103/obelisk-skill`. The CLI itself remains daemon-free: each command
 refreshes the local index when write ownership is available, then exits.
+
+## Compact Retrieval
+
+Agent retrieval should bound the number of hits and neighboring messages, and
+use compact output to avoid embedding full conversations in tool results:
+
+```bash
+obelisk --search "keyword" --compact --limit 8 --context 0 --snippet-length 240
+```
+
+- `--limit N` caps the number of hits.
+- `--context N` caps neighboring messages per hit and accepts `0`.
+- `--compact` returns only stable IDs, metadata, and snippets.
+- `--snippet-length N` caps snippet length and enables compact output.

--- a/packages/cli/src/obelisk.ts
+++ b/packages/cli/src/obelisk.ts
@@ -15,6 +15,39 @@ import {
   executeAttune,
 } from '../../core/src/core.ts';
 
+function parseIntegerOption(name: string, value: string | undefined, minimum: number): number {
+  if (value === undefined || !/^\d+$/.test(value)) {
+    throw new Error(`${name} requires an integer >= ${minimum}`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    throw new Error(`${name} requires an integer >= ${minimum}`);
+  }
+  return parsed;
+}
+
+function compactSearchResults(value: unknown, snippetLength: number): unknown {
+  if (!Array.isArray(value)) return value;
+  const compactMessage = (message: any) => ({
+    uuid: message?.uuid,
+    role: message?.role,
+    timestamp: message?.timestamp,
+    content_type: message?.content_type,
+    is_meta: message?.is_meta,
+    visibility: message?.visibility,
+    source: message?.source,
+    snippet: typeof message?.text === 'string'
+      ? message.text.replace(/\s+/g, ' ').trim().slice(0, snippetLength)
+      : null,
+  });
+  return value.map((hit: any) => ({
+    message: compactMessage(hit?.message),
+    session: hit?.session,
+    rank: hit?.rank,
+    context: Array.isArray(hit?.context) ? hit.context.map(compactMessage) : [],
+  }));
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const fail = (value: unknown): void => {
@@ -60,17 +93,46 @@ async function main() {
     } catch (error) { fail(error); }
     return;
   }
-  if (args[0] === '--search' && args[1]) {
+  if (args[0] === '--search') {
     try {
       // --nonce <token> marks this invocation in the transcript so the query
       // layer can identify the invoking session; it is not part of the FTS text.
       let nonce: string | undefined;
+      let compact = false;
+      let snippetLength = 240;
+      const searchOptions: Record<string, unknown> = {};
       const textParts: string[] = [];
       const rest = args.slice(1);
       for (let i = 0; i < rest.length; i++) {
-        if (rest[i] === '--nonce' && rest[i + 1]) { nonce = rest[i + 1]; i++; } else { textParts.push(rest[i]); }
+        const arg = rest[i];
+        if (arg === '--compact') {
+          compact = true;
+          continue;
+        }
+        if (arg === '--nonce') {
+          if (!rest[i + 1]) throw new Error('--nonce requires a token');
+          nonce = rest[++i];
+          continue;
+        }
+        if (arg === '--limit') {
+          searchOptions.limit = parseIntegerOption(arg, rest[++i], 1);
+          continue;
+        }
+        if (arg === '--context') {
+          searchOptions.contextLimit = parseIntegerOption(arg, rest[++i], 0);
+          continue;
+        }
+        if (arg === '--snippet-length') {
+          snippetLength = parseIntegerOption(arg, rest[++i], 1);
+          compact = true;
+          continue;
+        }
+        if (arg.startsWith('--')) throw new Error(`Unknown --search option: ${arg}`);
+        textParts.push(arg);
       }
-      emit(searchText(textParts.join(' '), undefined, { invocationNonce: nonce }));
+      if (textParts.length === 0) throw new Error('--search requires text');
+      const results = searchText(textParts.join(' '), searchOptions, { invocationNonce: nonce });
+      emit(compact ? compactSearchResults(results, snippetLength) : results);
     } catch (error) { fail(error); }
     return;
   }
@@ -113,7 +175,7 @@ async function main() {
     }
     return;
   }
-  process.stderr.write('Usage:\n  obelisk install [skills options]\n  obelisk --build\n  obelisk --search "text" [--nonce <token>]\n  obelisk --query <file.js>\n  obelisk --attune <file.js>\n');
+  process.stderr.write('Usage:\n  obelisk install [skills options]\n  obelisk --build\n  obelisk --search "text" [--limit N] [--context N] [--compact] [--snippet-length N] [--nonce <token>]\n  obelisk --query <file.js>\n  obelisk --attune <file.js>\n');
   process.exitCode = 1;
 }
 

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -21,6 +21,8 @@ interface QueryOptions extends Record<string, any> {
   sessionId?: string;
   sessions?: string[];
   project?: string;
+  projectPath?: string;
+  excludeInvoking?: boolean;
   after?: string;
   before?: string;
   cwd?: string;
@@ -28,6 +30,7 @@ interface QueryOptions extends Record<string, any> {
   source?: string;
   includeMeta?: boolean;
   includeInactive?: boolean;
+  contextLimit?: number;
   query?: string;
   projectLimit?: number;
   memoryLimit?: number;
@@ -35,7 +38,9 @@ interface QueryOptions extends Record<string, any> {
 
 interface ColumnAliases {
   sessionId: string;
+  nullableSessionId?: boolean;
   project: string;
+  projectPath: string;
   timestamp: string;
   /** Optional per-direction overrides for range-typed rows (activity intervals). */
   timestampAfter?: string;
@@ -66,7 +71,7 @@ function normalizeOpts(optsOrScalar: QueryOptions | string | number | null | und
   return optsOrScalar;
 }
 
-function buildWhere(opts: QueryOptions, aliases: ColumnAliases) {
+function buildWhere(opts: QueryOptions, aliases: ColumnAliases, invokingSessionId?: string | null) {
   const clauses: string[] = [];
   const params: any[] = [];
   if (opts.sessionId) { clauses.push(`${aliases.sessionId} = ?`); params.push(opts.sessionId); }
@@ -75,6 +80,14 @@ function buildWhere(opts: QueryOptions, aliases: ColumnAliases) {
     params.push(...opts.sessions);
   }
   if (opts.project) { clauses.push(`${aliases.project} LIKE ?`); params.push(opts.project); }
+  if (opts.projectPath) { clauses.push(`${aliases.projectPath} = ?`); params.push(opts.projectPath); }
+  if (opts.excludeInvoking && invokingSessionId) {
+    const sessionClause = aliases.nullableSessionId
+      ? `(${aliases.sessionId} IS NULL OR ${aliases.sessionId} != ?)`
+      : `${aliases.sessionId} != ?`;
+    clauses.push(sessionClause);
+    params.push(invokingSessionId);
+  }
   if (opts.after) { clauses.push(`${aliases.timestampAfter ?? aliases.timestamp} > ?`); params.push(opts.after); }
   if (opts.before) { clauses.push(`${aliases.timestampBefore ?? aliases.timestamp} < ?`); params.push(opts.before); }
   if (opts.branch) { clauses.push(`${aliases.branch} = ?`); params.push(opts.branch); }
@@ -244,7 +257,6 @@ function prepareReadOnlyStatement(db: SqliteDb, sqlText: string): SqliteStatemen
   assertSingleStatement(sqlText, stmt);
   return stmt;
 }
-
 const CJK_TEXT_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
 
 function assertEnglishMemoryText(value: unknown, label: string): void {
@@ -289,21 +301,40 @@ function createQueryApi(
     const {
       limit = 20,
       sessionId,
+      sessions: sessionIds,
       project,
+      projectPath,
+      excludeInvoking = false,
       after,
       before,
       cwd,
+      branch,
       source,
       includeMeta = false,
       includeInactive = false,
     } = opts;
+    const contextLimit = typeof opts.contextLimit === 'number'
+      && Number.isSafeInteger(opts.contextLimit)
+      && opts.contextLimit >= 0
+      ? opts.contextLimit
+      : 6;
     let where = 'WHERE mf.text MATCH ?';
     const filterParams: any[] = [];
     if (sessionId) { where += ' AND mf.session_id=?'; filterParams.push(sessionId); }
+    if (sessionIds?.length) {
+      where += ` AND mf.session_id IN (${sessionIds.map(() => '?').join(',')})`;
+      filterParams.push(...sessionIds);
+    }
     if (project)   { where += ' AND s.project LIKE ?'; filterParams.push(project); }
+    if (projectPath) { where += ' AND s.project_path=?'; filterParams.push(projectPath); }
+    if (excludeInvoking && invokingSessionId) {
+      where += ' AND mf.session_id!=?';
+      filterParams.push(invokingSessionId);
+    }
     if (after)     { where += ' AND m.timestamp>?';    filterParams.push(after); }
     if (before)    { where += ' AND m.timestamp<?';    filterParams.push(before); }
     if (cwd)       { where += ' AND m.cwd LIKE ?';     filterParams.push(cwd); }
+    if (branch)    { where += ' AND s.git_branch=?';   filterParams.push(branch); }
     if (source && source !== 'all') { where += " AND COALESCE(m.source, s.source, 'claude')=?"; filterParams.push(source); }
     if (!includeMeta) where += ' AND COALESCE(m.is_meta,0)=0';
     where += ` AND ${visibilitySql('m', includeInactive)}`;
@@ -336,8 +367,8 @@ function createQueryApi(
          WHERE session_id=? AND uuid!=? ${metaClause}
            AND ${visibilitySql('messages', includeInactive)}
          ORDER BY ABS(JULIANDAY(timestamp)-JULIANDAY(?))
-         LIMIT 6`
-      ).all(r.session_id, r.uuid, r.timestamp)
+         LIMIT ?`
+      ).all(r.session_id, r.uuid, r.timestamp, contextLimit)
         .map(withVisibility)
         .sort((a: DbRow, b: DbRow) => a.timestamp < b.timestamp ? -1 : 1);
       const sourceValue = r.m_source || r.s_source || 'claude';
@@ -414,7 +445,7 @@ function createQueryApi(
   const subagents = (optsOrSid?: QueryOptions | string) => {
     const opts = normalizeOpts(optsOrSid);
     const { limit = 100 } = opts;
-    const needsJoin = opts.project || opts.branch || opts.source;
+    const needsJoin = opts.project || opts.projectPath || opts.branch || opts.source;
     // The subagents table has no timestamp column; scope time filters by the
     // subagent's activity interval instead of comparing session IDs. `after`
     // matches agents still active past the bound (latest message), `before`
@@ -422,7 +453,7 @@ function createQueryApi(
     // combined bounds select every agent active during the window.
     const firstMessageAt = '(SELECT MIN(m.timestamp) FROM messages m WHERE m.agent_id = sa.agent_id)';
     const lastMessageAt = '(SELECT MAX(m.timestamp) FROM messages m WHERE m.agent_id = sa.agent_id)';
-    const { where, params } = buildWhere(opts, { sessionId: 'sa.session_id', project: 's.project', timestamp: firstMessageAt, timestampAfter: lastMessageAt, timestampBefore: firstMessageAt, branch: 's.git_branch', source: 's.source' });
+    const { where, params } = buildWhere(opts, { sessionId: 'sa.session_id', project: 's.project', projectPath: 's.project_path', timestamp: firstMessageAt, timestampAfter: lastMessageAt, timestampBefore: firstMessageAt, branch: 's.git_branch', source: 's.source' }, invokingSessionId);
     params.push(limit);
     const join = needsJoin ? 'LEFT JOIN sessions s ON s.id=sa.session_id' : '';
     return db.prepare(`SELECT sa.* FROM subagents sa ${join} WHERE ${where} LIMIT ?`).all(...params).map((r: DbRow) => {
@@ -434,8 +465,8 @@ function createQueryApi(
   const workflows = (optsOrSid?: QueryOptions | string) => {
     const opts = normalizeOpts(optsOrSid);
     const { limit = 100 } = opts;
-    const needsJoin = opts.project || opts.branch || opts.source;
-    const { where, params } = buildWhere(opts, { sessionId: 'w.session_id', project: 's.project', timestamp: 'w.timestamp', branch: 's.git_branch', source: 's.source' });
+    const needsJoin = opts.project || opts.projectPath || opts.branch || opts.source;
+    const { where, params } = buildWhere(opts, { sessionId: 'w.session_id', project: 's.project', projectPath: 's.project_path', timestamp: 'w.timestamp', branch: 's.git_branch', source: 's.source' }, invokingSessionId);
     params.push(limit);
     const join = needsJoin ? 'LEFT JOIN sessions s ON s.id=w.session_id' : '';
     return db.prepare(`SELECT w.* FROM workflows w ${join} WHERE ${where} ORDER BY w.timestamp DESC LIMIT ?`).all(...params);
@@ -454,12 +485,17 @@ function createQueryApi(
   };
 
   const fileHistory = (fp: string, opts: QueryOptions = {}) => {
-    const { limit = 200, after, before, source, includeInactive = false } = opts;
-    let where = `tc.file_path=? AND ${visibilitySql('m', includeInactive)}`;
-    const params: any[] = [fp];
-    if (after)  { where += ' AND m.timestamp > ?'; params.push(after); }
-    if (before) { where += ' AND m.timestamp < ?'; params.push(before); }
-    if (source && source !== 'all') { where += " AND COALESCE(s.source, 'claude') = ?"; params.push(source); }
+    const { limit = 200, includeInactive = false } = opts;
+    const { where: scopeWhere, params: scopeParams } = buildWhere(opts, {
+      sessionId: 'tc.session_id',
+      project: 's.project',
+      projectPath: 's.project_path',
+      timestamp: 'm.timestamp',
+      branch: 's.git_branch',
+      source: 's.source',
+    }, invokingSessionId);
+    const where = `tc.file_path=? AND ${visibilitySql('m', includeInactive)} AND ${scopeWhere}`;
+    const params: any[] = [fp, ...scopeParams];
     params.push(limit);
     return db.prepare(
       `SELECT tc.*,s.title as s_title,s.project as s_project,m.timestamp as ts,
@@ -482,8 +518,8 @@ function createQueryApi(
     const opts = normalizeOpts(optsOrSid);
     const { limit = 50 } = opts;
     const includeInactive = opts.includeInactive === true;
-    const needsJoin = opts.project || opts.branch || opts.source;
-    const { where, params: filterParams } = buildWhere(opts, { sessionId: 'tr.session_id', project: 's.project', timestamp: 'rm.timestamp', branch: 's.git_branch', source: 's.source' });
+    const needsJoin = opts.project || opts.projectPath || opts.branch || opts.source;
+    const { where, params: filterParams } = buildWhere(opts, { sessionId: 'tr.session_id', project: 's.project', projectPath: 's.project_path', timestamp: 'rm.timestamp', branch: 's.git_branch', source: 's.source' }, invokingSessionId);
     const join = needsJoin ? 'LEFT JOIN sessions s ON s.id=tr.session_id' : '';
     const errorCond = [
       `(tr.is_error = 1 OR tr.content LIKE '${BASH_EXIT_PAT}')`,
@@ -533,7 +569,7 @@ function createQueryApi(
   const sessions = (optsOrN?: QueryOptions | number | string) => {
     const opts = normalizeOpts(optsOrN, 'sessionId');
     const { limit = 50 } = opts;
-    const { where, params } = buildWhere(opts, { sessionId: 's.id', project: 's.project', timestamp: 's.started_at', branch: 's.git_branch', source: 's.source' });
+    const { where, params } = buildWhere(opts, { sessionId: 's.id', project: 's.project', projectPath: 's.project_path', timestamp: 's.started_at', branch: 's.git_branch', source: 's.source' }, invokingSessionId);
     params.push(limit);
     return db.prepare(`SELECT * FROM sessions s WHERE ${where} ORDER BY ended_at DESC LIMIT ?`).all(...params)
       .map((row: DbRow) => invokingSessionId && row.id === invokingSessionId ? { ...row, is_invoking: true } : row);
@@ -545,7 +581,7 @@ function createQueryApi(
     const opts = normalizeOpts(optsOrSid);
     const { limit = 100 } = opts;
     const includeInactive = opts.includeInactive === true;
-    const { where, params } = buildWhere(opts, { sessionId: 'su.session_id', project: 's.project', timestamp: 'su.timestamp', branch: 's.git_branch', source: 's.source' });
+    const { where, params } = buildWhere(opts, { sessionId: 'su.session_id', project: 's.project', projectPath: 's.project_path', timestamp: 'su.timestamp', branch: 's.git_branch', source: 's.source' }, invokingSessionId);
     params.push(limit);
     return db.prepare(`
       SELECT su.*, s.title as session_title, s.project
@@ -776,14 +812,17 @@ function createQueryApi(
     const opts = normalizeOpts(optsOrSid);
     const { limit = 50, query } = opts;
     assertEnglishMemoryText(query, 'memories() query');
-    const needsJoin = opts.branch || opts.source;
+    const needsJoin = opts.projectPath || opts.branch || opts.source
+      || (opts.excludeInvoking && invokingSessionId);
     const { where: baseWhere, params } = buildWhere(opts, {
       sessionId: 'mem.session_id',
+      nullableSessionId: true,
       project: 'mem.project',
+      projectPath: 's.project_path',
       timestamp: 'mem.created_at',
       branch: 's.git_branch',
       source: 's.source',
-    });
+    }, invokingSessionId);
     const where = baseWhere + ' AND mem.deleted_at IS NULL';
     const join = needsJoin ? 'LEFT JOIN sessions s ON s.id=mem.session_id' : '';
     const hasQuery = String(query || '').trim().length > 0;

--- a/skill-doc/SKILL.md
+++ b/skill-doc/SKILL.md
@@ -56,7 +56,7 @@ the transcript records the command as typed, so a shell substitution like
 `$(uuidgen)` never expands there and can never resolve:
 
 ```bash
-obelisk --search "keyword" --nonce "obq-<unique-token-you-invent>"
+obelisk --search "keyword" --compact --limit 8 --context 0 --snippet-length 240 --nonce "obq-<unique-token-you-invent>"
 ```
 
 Custom query:
@@ -238,7 +238,11 @@ display-suppressed or transport-only records and is never returned by these
 helpers, even with the option enabled.
 
 Opts:
-`{ limit, sessionId, project, after, before, cwd, source, includeMeta, includeInactive }`.
+`{ limit, contextLimit, sessionId, sessions, project, projectPath, excludeInvoking, after, before, cwd, branch, source, includeMeta, includeInactive }`.
+
+`projectPath` exactly matches `sessions.project_path`; `excludeInvoking: true`
+excludes the current query session when the invocation nonce resolves.
+`contextLimit` controls neighboring messages per hit and accepts `0`.
 
 `project` is a SQL `LIKE` filter over `sessions.project`, not an exact project
 identity. Results are already ordered by FTS5 rank; lower rank sorts earlier.
@@ -286,12 +290,12 @@ not replace `sql()`, but they are the default first-pass surface. Use `sql()`
 when you need an exact aggregation or a join the helper does not expose.
 
 All list helpers accept a bounded `limit`. Many also accept:
-`{ project, after, before, sessionId, sessions, branch, source }`. Check
+`{ project, projectPath, excludeInvoking, after, before, sessionId, sessions, branch, source }`. Check
 `references/api-reference.md` or a tiny sample before relying on less common
 filters or return fields.
 
 - `overview(opts?)` -- compact orientation map. Returns current cwd/project if knowable, the invoking session id (`current.session_id`) when the invocation nonce resolved, global project/source counts, and current-project recent sessions plus memory records. It is a map, not evidence.
-- `sessions(opts?)` -- session rows, newest first. `project` is a SQL `LIKE` pattern. `message_count` counts the visible canonical transcript; inactive and hidden records are excluded. The invoking session row carries `is_invoking: true`.
+- `sessions(opts?)` -- session rows, newest first. `project` is a SQL `LIKE` pattern; `projectPath` is an exact absolute-path match. `message_count` counts the visible canonical transcript; inactive and hidden records are excluded. The invoking session row carries `is_invoking: true` unless `excludeInvoking: true` removes it.
 - `recent(n?)` -- shorthand for recent sessions.
 - `summaries(opts?)` -- summary rows, newest first: `{ id, session_id, timestamp, source, content, visibility, session_title, project }`; inactive rows require `includeInactive: true`, hidden rows are never returned, and `source` is the summary kind rather than the transcript provider.
 - `subagents(opts?)` -- subagent metadata plus `messageCount`.
@@ -302,7 +306,7 @@ filters or return fields.
 - `trace(uuid, opts?)` -- parent chain from root to message.
 - `thread(sessionId, opts?)` -- session messages ordered by timestamp, omitting meta messages by default. Pass `{ includeMeta: true }` for injected context or `{ includeInactive: true }` for superseded Pi history.
 - `raw(uuid, opts?)` -- windowed source access for one visible message. Pi returns the selected source-message container whether it was stored directly or inside a retained tail. Inactive targets require `includeInactive: true`; hidden targets return `null`.
-- `memories(opts?)` -- recall memory layer. opts: `{ query, project, sessionId, sessions, after, before, branch, limit }`. Without `query`, returns active memory records newest first. With `query`, searches `summary`/`path` through safe FTS5 tokenization and returns `rank`; lower rank sorts earlier. Records may include nullable JSON `anchors` for explicit recall surfaces such as files. Read the file at `path` for full content.
+- `memories(opts?)` -- recall memory layer. opts: `{ query, project, projectPath, excludeInvoking, sessionId, sessions, after, before, branch, limit }`. Without `query`, returns active memory records newest first. With `query`, searches `summary`/`path` through safe FTS5 tokenization and returns `rank`; lower rank sorts earlier. Records may include nullable JSON `anchors` for explicit recall surfaces such as files. Read the file at `path` for full content.
 
 ## Retrieval Contract
 

--- a/skill-doc/references/api-reference.md
+++ b/skill-doc/references/api-reference.md
@@ -17,7 +17,7 @@ memory mutation helpers.
 Obelisk refreshes the index before each query, so the invoking agent's own live
 session appears in results. The CLI carries an invocation nonce to identify it:
 
-- `obelisk --search "text" --nonce <token>` — pass a unique token, for example
+- `obelisk --search "text" --compact --limit 8 --context 0 --snippet-length 240 --nonce <token>` — pass a unique token, for example
   `--nonce "$(uuidgen 2>/dev/null || echo "$$.$RANDOM.$RANDOM")"` (prefers
   `uuidgen`, falls back to shell builtins). The nonce is never part of the FTS
   search text.
@@ -64,7 +64,7 @@ subagents, workflows, workflowTree, fileHistory, failures
 ```
 
 All list helpers accept bounded `limit` options. Many helpers also accept
-`project`, `sessionId`, `sessions`, `after`, `before`, `branch`, and `source`
+`project`, `projectPath`, `excludeInvoking`, `sessionId`, `sessions`, `after`, `before`, `branch`, and `source`
 when the underlying table can express that scope. Passing a string to many list
 helpers is treated as `sessionId`; passing a number is treated as `limit`.
 
@@ -96,11 +96,16 @@ Full-text search across all indexed message text using FTS5.
 | --- | --- | --- |
 | `text` | `string` | FTS5 query string |
 | `opts.limit` | `number` | Max results, default 20 |
+| `opts.contextLimit` | `number` | Max neighboring messages per hit, default 6; accepts 0 |
 | `opts.sessionId` | `string` | Restrict to one session |
+| `opts.sessions` | `string[]` | Restrict to session IDs |
 | `opts.project` | `string` | SQL `LIKE` pattern over `sessions.project` |
+| `opts.projectPath` | `string` | Exact match on `sessions.project_path` |
+| `opts.excludeInvoking` | `boolean` | Exclude the invoking session when the nonce resolves |
 | `opts.after` | `string` | ISO lower bound on message timestamp |
 | `opts.before` | `string` | ISO upper bound on message timestamp |
 | `opts.cwd` | `string` | SQL `LIKE` filter over `messages.cwd` |
+| `opts.branch` | `string` | Exact source session branch |
 | `opts.source` | `string` | Provider ID such as `"claude"`, `"codex"`, `"deepseek"`, `"kimi"`, or `"pi"` |
 | `opts.includeMeta` | `boolean` | Include `is_meta=1` rows, default false |
 | `opts.includeInactive` | `boolean` | Include provider-attested superseded rows, default false |
@@ -245,6 +250,8 @@ Session rows ordered by `ended_at` descending. Passing a number is treated as
 | Param | Type | Description |
 | --- | --- | --- |
 | `opts.project` | `string` | SQL `LIKE` pattern over `sessions.project` |
+| `opts.projectPath` | `string` | Exact match on `sessions.project_path` |
+| `opts.excludeInvoking` | `boolean` | Exclude the invoking session when the nonce resolves |
 | `opts.after` | `string` | ISO lower bound on `started_at` |
 | `opts.before` | `string` | ISO upper bound on `started_at` |
 | `opts.limit` | `number` | Max rows, default 50 |
@@ -274,6 +281,8 @@ is treated as `sessionId`; passing a number is treated as `limit`.
 | `opts.sessionId` | `string` | Restrict to one session |
 | `opts.sessions` | `string[]` | Restrict to session IDs |
 | `opts.project` | `string` | SQL `LIKE` pattern over source session project |
+| `opts.projectPath` | `string` | Exact match on the source session's `project_path` |
+| `opts.excludeInvoking` | `boolean` | Exclude summaries associated with the invoking session |
 | `opts.after` | `string` | ISO lower bound on summary timestamp |
 | `opts.before` | `string` | ISO upper bound on summary timestamp |
 | `opts.branch` | `string` | Exact source session branch |
@@ -302,6 +311,8 @@ Active registered markdown memory records. Passing a string is treated as
 | --- | --- | --- |
 | `opts.query` | `string` | English recall query over `summary` and `path` |
 | `opts.project` | `string` | SQL `LIKE` pattern over `memories.project` |
+| `opts.projectPath` | `string` | Exact match on the source session's `project_path` |
+| `opts.excludeInvoking` | `boolean` | Exclude memories associated with the invoking session; unattributed memories remain included |
 | `opts.sessionId` | `string` | Restrict to one source session |
 | `opts.sessions` | `string[]` | Restrict to source session IDs |
 | `opts.after` | `string` | ISO lower bound on `created_at` |
@@ -384,6 +395,8 @@ Subagent metadata plus message counts. Passing a string is treated as
 | --- | --- | --- |
 | `opts.sessionId` | `string` | Restrict to one session |
 | `opts.project` | `string` | SQL `LIKE` pattern over source session project |
+| `opts.projectPath` | `string` | Exact match on the source session's `project_path` |
+| `opts.excludeInvoking` | `boolean` | Exclude subagents from the invoking session |
 | `opts.after` | `string` | ISO lower bound; matches subagents still active past it (latest message) |
 | `opts.before` | `string` | ISO upper bound; matches subagents already started by it (earliest message) |
 | `opts.source` | `string` | Provider filter |
@@ -404,6 +417,8 @@ Workflow run rows ordered newest first. Passing a string is treated as
 | --- | --- | --- |
 | `opts.sessionId` | `string` | Restrict to one session |
 | `opts.project` | `string` | SQL `LIKE` pattern over source session project |
+| `opts.projectPath` | `string` | Exact match on the source session's `project_path` |
+| `opts.excludeInvoking` | `boolean` | Exclude workflows from the invoking session |
 | `opts.after` | `string` | ISO lower bound on workflow timestamp |
 | `opts.before` | `string` | ISO upper bound on workflow timestamp |
 | `opts.source` | `string` | Provider filter |
@@ -437,6 +452,8 @@ well as `Edit`/`Write`.
 | `opts.after` | `string` | ISO lower bound |
 | `opts.before` | `string` | ISO upper bound |
 | `opts.source` | `string` | Provider filter |
+| `opts.projectPath` | `string` | Exact match on the source session's `project_path` |
+| `opts.excludeInvoking` | `boolean` | Exclude file operations from the invoking session |
 | `opts.limit` | `number` | Max rows, default 200 |
 | `opts.includeInactive` | `boolean` | Include superseded tool evidence, default false |
 
@@ -463,6 +480,8 @@ the failure. Passing a string is treated as `sessionId`.
 | --- | --- | --- |
 | `opts.sessionId` | `string` | Restrict to one session |
 | `opts.project` | `string` | SQL `LIKE` pattern over source session project |
+| `opts.projectPath` | `string` | Exact match on the source session's `project_path` |
+| `opts.excludeInvoking` | `boolean` | Exclude failures from the invoking session |
 | `opts.after` | `string` | ISO lower bound on result message timestamp |
 | `opts.before` | `string` | ISO upper bound on result message timestamp |
 | `opts.source` | `string` | Provider filter |

--- a/skill-doc/references/query-patterns.md
+++ b/skill-doc/references/query-patterns.md
@@ -21,13 +21,17 @@ or terms.
 const topic = 'English topic terms translated from the user request';
 const map = overview({ limit: 6 });
 const project = map.current.project?.project;
-const scoped = project ? { project } : {};
+const projectPath = map.current.project?.project_path;
+const scoped = projectPath
+  ? { projectPath, excludeInvoking: true }
+  : project ? { project, excludeInvoking: true } : { excludeInvoking: true };
 
 return {
   query_plan: {
     mode: 'first_pass',
     topic,
     project: project || null,
+    project_path: projectPath || null,
     limits: { sessions: 6, memories: 5, search: 8 },
   },
   orientation: map.current_project && {

--- a/tests/query.test.mjs
+++ b/tests/query.test.mjs
@@ -97,6 +97,7 @@ test('search exposes content_type on hits and temporal context', () => {
   assert.equal(rows[0].context[0].uuid, 'msg-thinking');
   assert.equal(rows[0].context[0].content_type, 'thinking');
   assert.equal(rows[0].context[0].is_meta, 0);
+  assert.deepEqual(api.search('needle', { limit: 1, contextLimit: 0 })[0].context, []);
   db.close();
 });
 
@@ -457,6 +458,89 @@ test('memories follows list-helper scalar opts and filters by query within scope
     api.memories({ project: '%quiet-zero%', query: 'parallel agents', limit: 5 }).map(m => m.id),
     ['mem-1'],
   );
+
+  db.close();
+});
+
+test('memories keeps unattributed records when excluding the invoking session', () => {
+  const db = memoryDb();
+  db.prepare(`
+    INSERT INTO memories (id, session_id, project, path, summary, created_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(
+    'mem-unattributed',
+    null,
+    'quiet-zero',
+    '.obelisk/memories/unattributed.md',
+    'Unattributed memory record.',
+    '2026-06-12T12:00:00Z',
+  );
+  const api = createQueryApi(db, { invokingSessionId: 'sid-2' });
+
+  assert.deepEqual(
+    api.memories({ excludeInvoking: true }).map(memory => memory.id),
+    ['mem-unattributed', 'mem-3', 'mem-1'],
+  );
+
+  db.close();
+});
+
+test('list helpers share exact project-path and invoking-session filters', () => {
+  const db = memoryDb();
+  const insertMessage = db.prepare(`
+    INSERT INTO messages (uuid,session_id,type,role,text,timestamp,visibility,agent_id,source)
+    VALUES (?,?,?,?,?,?,?,?,?)
+  `);
+  const insertCall = db.prepare(`
+    INSERT INTO tool_calls (id,message_uuid,session_id,name,input_json,file_path)
+    VALUES (?,?,?,?,?,?)
+  `);
+  const insertResult = db.prepare(`
+    INSERT INTO tool_results (tool_use_id,message_uuid,session_id,content,is_error)
+    VALUES (?,?,?,?,?)
+  `);
+  const insertAgent = db.prepare(`
+    INSERT INTO subagents (agent_id,session_id,agent_type,description)
+    VALUES (?,?,?,?)
+  `);
+  const insertWorkflow = db.prepare(`
+    INSERT INTO workflows (run_id,session_id,timestamp,status,workflow_name)
+    VALUES (?,?,?,?,?)
+  `);
+  const insertSummary = db.prepare(`
+    INSERT INTO summaries (id,session_id,timestamp,source,content,visibility)
+    VALUES (?,?,?,?,?,?)
+  `);
+  for (const [index, sessionId] of ['sid-1', 'sid-2', 'sid-3'].entries()) {
+    const timestamp = `2026-06-${String(index + 9).padStart(2, '0')}T10:30:00Z`;
+    const messageId = `scope-message-${sessionId}`;
+    const callId = `scope-call-${sessionId}`;
+    const agentId = `scope-agent-${sessionId}`;
+    insertMessage.run(messageId, sessionId, 'assistant', 'assistant', 'scoped needle evidence', timestamp, 'visible', agentId, 'claude');
+    insertCall.run(callId, messageId, sessionId, 'read', '{}', '/tmp/scoped.ts');
+    insertResult.run(callId, messageId, sessionId, 'scoped failure', 1);
+    insertAgent.run(agentId, sessionId, 'review', 'Scoped review');
+    insertWorkflow.run(`scope-run-${sessionId}`, sessionId, timestamp, 'completed', 'Scoped workflow');
+    insertSummary.run(`scope-summary-${sessionId}`, sessionId, timestamp, 'compact', 'Scoped summary', 'visible');
+  }
+
+  const api = createQueryApi(db, { invokingSessionId: 'sid-2' });
+  const scope = {
+    projectPath: '/tmp/quiet-zero-test',
+    excludeInvoking: true,
+  };
+
+  assert.deepEqual(api.sessions(scope).map(row => row.id), ['sid-1']);
+  assert.deepEqual(
+    api.search('scoped needle', { ...scope, contextLimit: 0 }).map(row => row.session.id),
+    ['sid-1'],
+  );
+  assert.deepEqual(api.memories(scope).map(row => row.id), ['mem-1']);
+  assert.deepEqual(api.subagents(scope).map(row => row.session_id), ['sid-1']);
+  assert.deepEqual(api.workflows(scope).map(row => row.session_id), ['sid-1']);
+  assert.deepEqual(api.fileHistory('/tmp/scoped.ts', scope).map(row => row.session.id), ['sid-1']);
+  assert.deepEqual(api.failures(scope).map(row => row.session.id), ['sid-1']);
+  assert.deepEqual(api.summaries(scope).map(row => row.session_id), ['sid-1']);
 
   db.close();
 });

--- a/tests/runtime-cli-envelope.test.mjs
+++ b/tests/runtime-cli-envelope.test.mjs
@@ -52,6 +52,50 @@ test('--search emits a JSON array envelope', () => {
   assert.ok(Array.isArray(payload), 'search must return a JSON array');
 });
 
+test('--search compact mode bounds hits, context, and snippets', () => {
+  const home = tempHome();
+  const projectDir = join(home, '.claude', 'projects', '-tmp-compact');
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(join(projectDir, 'compact-session.jsonl'), [
+    {
+      uuid: 'compact-user',
+      type: 'user',
+      timestamp: '2026-08-25T10:00:00.000Z',
+      cwd: '/tmp/compact',
+      message: { role: 'user', content: 'compact needle with a deliberately long payload' },
+    },
+    {
+      uuid: 'compact-assistant',
+      type: 'assistant',
+      parentUuid: 'compact-user',
+      timestamp: '2026-08-25T10:00:01.000Z',
+      cwd: '/tmp/compact',
+      message: { role: 'assistant', content: 'nearby context that should be omitted' },
+    },
+  ].map(line => JSON.stringify(line)).join('\n') + '\n');
+
+  const result = runRuntime([
+    '--search', 'compact needle',
+    '--compact', '--limit', '1', '--context', '0', '--snippet-length', '12',
+  ], { home });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.length, 1);
+  assert.equal(payload[0].message.snippet, 'compact need');
+  assert.equal('text' in payload[0].message, false);
+  assert.deepEqual(payload[0].context, []);
+  assert.equal(payload[0].session.id, 'compact-session');
+});
+
+test('--search rejects invalid output bounds', () => {
+  const home = tempHome();
+  const result = runRuntime(['--search', 'needle', '--context', '-1'], { home });
+
+  assert.equal(result.status, 1);
+  assert.match(JSON.parse(result.stdout).error, /--context requires an integer >= 0/);
+});
+
 test('--query returns a pretty-printed JSON result on success', () => {
   const home = tempHome();
   const scriptPath = join(home, 'ok.mjs');


### PR DESCRIPTION
## Summary

- add exact project-path and invoking-session filters across query helpers
- add configurable search context limits and compact CLI output
- preserve unattributed memories when excluding the invoking session

This is the provider-agnostic query work split from #82 following review feedback.

## Testing

- `npm test` — 573 passed
- `npm run typecheck`
- `npm run lint` — 0 errors