### PR TITLE
[Kimi] Bound unchanged discovery to metadata

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Verify adaptive watcher package
         run: |
           npm run build --workspace @obelisk-apps/adaptive-watcher
-          node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/claude-parse.test.mjs tests/codex-parse.test.mjs tests/codex-discover.test.mjs tests/app-indexer.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs tests/app-main-settings.test.mjs tests/app-indexer-watcher-filter.test.mjs tests/deepseek-tree.test.mjs tests/index-finalize.test.mjs
+          node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/adaptive-watcher.test.mjs tests/core-watch-hints.test.mjs tests/claude-parse.test.mjs tests/codex-parse.test.mjs tests/codex-discover.test.mjs tests/kimi-parse.test.mjs tests/kimi-manifest.test.mjs tests/app-kimi-index.test.mjs tests/app-indexer.test.mjs tests/app-indexer-watcher.test.mjs tests/app-indexer-service.test.mjs tests/app-main-settings.test.mjs tests/app-indexer-watcher-filter.test.mjs tests/deepseek-tree.test.mjs tests/index-finalize.test.mjs
 
       - name: Verify query sandbox read-only contract
         run: node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/query.test.mjs

--- a/docs/adr/0001-parse-core-and-persist-layers.md
+++ b/docs/adr/0001-parse-core-and-persist-layers.md
@@ -70,6 +70,64 @@ One narrow exception: the invocation-nonce freshness build may index
 incrementally under a fresh daemon heartbeat, arbitrated by the writer lease
 (see the 2026-08-11 amendment in ADR-0006).
 
+**Amendment (2026-09-01): Kimi session-manifest cursors.** A Kimi session
+directory remains one atomic `IndexUnit`: `state.json`, the main wire, and
+subagent wires jointly define one canonical timeline, and a genuinely changed
+unit may still require a complete replay for undo, clear, compaction, member
+removal, and cross-wire tool relationships. That snapshot policy does not
+justify reading every unchanged wire body during discovery. Passive-pull
+discovery must scale with member metadata, not total transcript bytes.
+
+Kimi therefore separates three internal operations behind the unchanged
+provider interface: collect one normalized session-member snapshot, encode that
+snapshot as a cursor, and classify a stored cursor as current, upgradeable, or
+requiring replay. The snapshot contains the sorted relative member paths and
+their identity/change metadata (`dev`, `ino`, `size`, `mtime`, and `ctime`) for
+`state.json`, current agent wires, and the legacy root wire when applicable.
+Discovery hashes only this metadata; it never hashes or counts wire contents to
+decide that an unhinted session is unchanged. The cursor keeps the two numeric
+compatibility slots followed by a provider-owned format tag and digest, for
+example `maxMtime:0:kimi-manifest-v1:<digest>`. Path normalization, sort order,
+included fields, serialization, and digest algorithm are all part of that
+cursor-format version.
+
+The discovery snapshot travels in `IndexUnit.meta`. Parse takes a fresh snapshot
+before reading and another after projection; a member-set or metadata change at
+either boundary rejects the torn unit and leaves its prior cursor and canonical
+rows intact. A watcher hint continues to re-plan its session even when the
+stored cursor matches. An indexed session that loses a member, including its
+last wire, is a changed/tombstone unit rather than an unchanged session to skip.
+An enumeration/stat race is reported as incomplete or unstable inventory and is
+retried; it must not publish a cursor for a snapshot the adapter did not prove.
+
+Cursor-format versions and canonical-transcript markers have different
+lifecycles. A legacy or unknown Kimi cursor never proves that a unit is
+unchanged, but it also does not throw: it fails closed to replay and is replaced
+atomically only after that unit succeeds. For a future manifest version, the
+adapter may compute both old and new fingerprints from one metadata snapshot;
+when the stored old fingerprint still matches, `parse` may yield no transcript
+records and return only the new cursor, giving a per-unit cursor-only migration.
+If the old format cannot validate the current snapshot, the unit replays once.
+Failed units retain their old cursor and retry independently.
+
+`indexVersionMarker` is not bumped for a cursor-format change alone. It is the
+provider-wide repair boundary for changes that affect already-stored canonical
+rows (UUIDs, roles, visibility, projection semantics, or stale rows requiring
+retraction). Using it for manifest serialization would conflate control-state
+migration with transcript migration and force an unnecessary destructive
+provider replay. The former `maxMtime:totalLines` Kimi cursor violated this
+decision because computing it reread the complete wire corpus merely to return
+no changed units; issue #128 records the measured impact and migration context.
+
+Rejected alternatives are: directory mtime alone, which cannot prove nested
+member stability; content hashing or line counting during every discovery,
+which makes unchanged cost proportional to transcript bytes; and bumping the
+canonical marker merely to change cursor encoding. Metadata cannot detect a
+rewrite for which a platform exposes no changed path, identity, size, mtime, or
+ctime; watcher hints remain the live invalidation path, while reconciliation
+provides the strongest portable metadata check required by the provider cursor
+contract.
+
 **Consequences.** Golden tests anchor on each adapter's `parse` output (feed
 fixture JSONL, assert the yielded record sequence) — independent of binding and
 persistence. The app's richer changed-path discovery becomes a `discover`

--- a/docs/adr/0001-parse-core-and-persist-layers.md
+++ b/docs/adr/0001-parse-core-and-persist-layers.md
@@ -100,6 +100,23 @@ last wire, is a changed/tombstone unit rather than an unchanged session to skip.
 An enumeration/stat race is reported as incomplete or unstable inventory and is
 retried; it must not publish a cursor for a snapshot the adapter did not prove.
 
+Kimi deletion reconciliation is identity-based, not path-ordered. The
+namespaced native session id remains stable when Kimi moves a session directory
+between workspaces, so discovery first builds a provider-wide identity census
+and then routes work to the current directory. A missing old path never produces
+a tombstone while the same identity is live elsewhere; the current directory is
+replayed instead, updating canonical provenance atomically. Duplicate live
+directories for one identity make the census ambiguous and fail closed.
+
+`changedPaths` is an invalidation/routing hint, not evidence that a missing path
+was intentionally deleted. Discovery-known retractions are emitted through
+`IndexUnit.retractSessionIds` only after the complete identity census proves the
+identity absent. If the sessions root, a workspace, or a required member cannot
+be inventoried, Kimi may still replay source-local readable units, but it must
+withhold tombstones and moved-provenance replacement until a later complete
+census. This preserves the last-good canonical snapshot across unmounts,
+permission failures, and observation races.
+
 Cursor-format versions and canonical-transcript markers have different
 lifecycles. A legacy or unknown Kimi cursor never proves that a unit is
 unchanged, but it also does not throw: it fails closed to replay and is replaced

--- a/packages/core/src/providers/kimi-manifest.ts
+++ b/packages/core/src/providers/kimi-manifest.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { createHash } from 'node:crypto';
-import { existsSync, readdirSync, statSync } from 'node:fs';
+import { readdirSync, statSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
 
 import type { Cursor } from './types.ts';
@@ -44,44 +44,103 @@ interface KimiManifestMember {
   readonly ctimeNs: string;
 }
 
+interface CapturedKimiSession extends KimiSessionSnapshot {
+  readonly members: readonly KimiManifestMember[];
+}
+
 function normalizedRelativePath(sessionDir: string, path: string): string {
   return relative(sessionDir, path).split(sep).join('/');
 }
 
-function listWireFiles(sessionDir: string): KimiWireFile[] {
-  const agentsDir = join(sessionDir, 'agents');
-  const files: KimiWireFile[] = [];
-  if (existsSync(agentsDir)) {
-    for (const entry of readdirSync(agentsDir, { withFileTypes: true })) {
-      if (!entry.isDirectory()) continue;
-      const path = join(agentsDir, entry.name, 'wire.jsonl');
-      if (existsSync(path)) files.push({ agentId: entry.name, main: entry.name === 'main', path });
-    }
-  }
-  if (!files.some((file) => file.main)) {
-    const legacy = join(sessionDir, 'wire.jsonl');
-    if (existsSync(legacy)) files.push({ agentId: 'main', main: true, path: legacy });
-  }
-  return files.sort((a, b) => Number(b.main) - Number(a.main) || a.agentId.localeCompare(b.agentId));
+function isMissing(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
 }
 
-function manifestCursor(sessionDir: string, paths: readonly string[]): string {
-  let maxMtimeNs = 0n;
-  const members = paths.filter(existsSync).map((path): KimiManifestMember => {
-    const stat = statSync(path, { bigint: true });
-    if (stat.mtimeNs > maxMtimeNs) maxMtimeNs = stat.mtimeNs;
-    return {
-      relativePath: normalizedRelativePath(sessionDir, path),
-      dev: String(stat.dev),
-      ino: String(stat.ino),
-      size: String(stat.size),
-      mtimeNs: String(stat.mtimeNs),
-      ctimeNs: String(stat.ctimeNs),
-    };
-  }).sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+function optionalDirectoryEntries(path: string) {
+  try {
+    return readdirSync(path, { withFileTypes: true });
+  } catch (error) {
+    if (isMissing(error)) return null;
+    throw error;
+  }
+}
+
+function listedMember(sessionDir: string, path: string): KimiManifestMember {
+  // The caller observed this exact entry in a directory listing. Any stat
+  // failure, including ENOENT, means the snapshot raced a mutation rather than
+  // proving that the member was absent.
+  const stat = statSync(path, { bigint: true });
+  return {
+    relativePath: normalizedRelativePath(sessionDir, path),
+    dev: String(stat.dev),
+    ino: String(stat.ino),
+    size: String(stat.size),
+    mtimeNs: String(stat.mtimeNs),
+    ctimeNs: String(stat.ctimeNs),
+  };
+}
+
+function manifestCursor(members: readonly KimiManifestMember[]): string {
+  const maxMtimeNs = members.reduce((latest, member) => {
+    const mtimeNs = BigInt(member.mtimeNs);
+    return mtimeNs > latest ? mtimeNs : latest;
+  }, 0n);
   const digest = createHash('sha256').update(JSON.stringify(members)).digest('base64url');
   const maxMtimeMs = maxMtimeNs / 1_000_000n;
   return `${maxMtimeMs}:0:${KIMI_MANIFEST_CURSOR_FORMAT}:${digest}`;
+}
+
+function captureKimiSession(sessionDir: string): CapturedKimiSession {
+  const statePath = join(sessionDir, 'state.json');
+  const sessionEntries = optionalDirectoryEntries(sessionDir);
+  if (sessionEntries === null) {
+    const members: KimiManifestMember[] = [];
+    return {
+      sessionDir,
+      statePath,
+      wireFiles: [],
+      members,
+      currentCursor: manifestCursor(members),
+    };
+  }
+
+  const members: KimiManifestMember[] = [];
+  if (sessionEntries.some((entry) => entry.name === 'state.json')) {
+    members.push(listedMember(sessionDir, statePath));
+  }
+
+  const wireFiles: KimiWireFile[] = [];
+  const agentsEntry = sessionEntries.find((entry) => entry.name === 'agents' && entry.isDirectory());
+  if (agentsEntry !== undefined) {
+    const agentsDir = join(sessionDir, agentsEntry.name);
+    const agentEntries = readdirSync(agentsDir, { withFileTypes: true });
+    for (const agentEntry of agentEntries) {
+      if (!agentEntry.isDirectory()) continue;
+      const agentDir = join(agentsDir, agentEntry.name);
+      const entries = readdirSync(agentDir, { withFileTypes: true });
+      if (!entries.some((entry) => entry.name === 'wire.jsonl')) continue;
+      const path = join(agentDir, 'wire.jsonl');
+      members.push(listedMember(sessionDir, path));
+      wireFiles.push({ agentId: agentEntry.name, main: agentEntry.name === 'main', path });
+    }
+  }
+
+  if (!wireFiles.some((file) => file.main) && sessionEntries.some((entry) => entry.name === 'wire.jsonl')) {
+    const path = join(sessionDir, 'wire.jsonl');
+    members.push(listedMember(sessionDir, path));
+    wireFiles.push({ agentId: 'main', main: true, path });
+  }
+
+  members.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  wireFiles.sort((a, b) => Number(b.main) - Number(a.main) || a.agentId.localeCompare(b.agentId));
+  return {
+    sessionDir,
+    statePath,
+    wireFiles,
+    members,
+    currentCursor: manifestCursor(members),
+  };
 }
 
 /**
@@ -90,12 +149,15 @@ function manifestCursor(sessionDir: string, paths: readonly string[]): string {
  * digest encoding; changing any of those requires a new cursor-format tag.
  */
 export function snapshotKimiSession(sessionDir: string): KimiSessionSnapshot {
-  const statePath = join(sessionDir, 'state.json');
-  const wireFiles = listWireFiles(sessionDir);
+  const before = captureKimiSession(sessionDir);
+  const after = captureKimiSession(sessionDir);
+  if (before.currentCursor !== after.currentCursor) {
+    throw new Error(`Kimi session changed while snapshotting: ${sessionDir}`);
+  }
   return {
-    sessionDir,
-    statePath,
-    wireFiles,
-    currentCursor: manifestCursor(sessionDir, [statePath, ...wireFiles.map((wire) => wire.path)]),
+    sessionDir: after.sessionDir,
+    statePath: after.statePath,
+    wireFiles: after.wireFiles,
+    currentCursor: after.currentCursor,
   };
 }

--- a/packages/core/src/providers/kimi-manifest.ts
+++ b/packages/core/src/providers/kimi-manifest.ts
@@ -1,0 +1,101 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { createHash } from 'node:crypto';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+import type { Cursor } from './types.ts';
+
+export const KIMI_MANIFEST_CURSOR_FORMAT = 'kimi-manifest-v1';
+export type KimiCursorDisposition = 'current' | 'replay';
+
+export interface KimiWireFile {
+  readonly agentId: string;
+  readonly main: boolean;
+  readonly path: string;
+}
+
+export interface KimiSessionSnapshot {
+  readonly sessionDir: string;
+  readonly statePath: string;
+  readonly wireFiles: readonly KimiWireFile[];
+  readonly currentCursor: Exclude<Cursor, null>;
+}
+
+/**
+ * Only an exact current-format match can prove that a Kimi session is clean.
+ * Legacy and unknown cursors fail closed to one replay; they never poison the
+ * provider with a version error.
+ */
+export function classifyKimiCursor(
+  storedCursor: Cursor,
+  currentCursor: Exclude<Cursor, null>,
+): KimiCursorDisposition {
+  return storedCursor === currentCursor ? 'current' : 'replay';
+}
+
+interface KimiManifestMember {
+  readonly relativePath: string;
+  readonly dev: string;
+  readonly ino: string;
+  readonly size: string;
+  readonly mtimeNs: string;
+  readonly ctimeNs: string;
+}
+
+function normalizedRelativePath(sessionDir: string, path: string): string {
+  return relative(sessionDir, path).split(sep).join('/');
+}
+
+function listWireFiles(sessionDir: string): KimiWireFile[] {
+  const agentsDir = join(sessionDir, 'agents');
+  const files: KimiWireFile[] = [];
+  if (existsSync(agentsDir)) {
+    for (const entry of readdirSync(agentsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const path = join(agentsDir, entry.name, 'wire.jsonl');
+      if (existsSync(path)) files.push({ agentId: entry.name, main: entry.name === 'main', path });
+    }
+  }
+  if (!files.some((file) => file.main)) {
+    const legacy = join(sessionDir, 'wire.jsonl');
+    if (existsSync(legacy)) files.push({ agentId: 'main', main: true, path: legacy });
+  }
+  return files.sort((a, b) => Number(b.main) - Number(a.main) || a.agentId.localeCompare(b.agentId));
+}
+
+function manifestCursor(sessionDir: string, paths: readonly string[]): string {
+  let maxMtimeNs = 0n;
+  const members = paths.filter(existsSync).map((path): KimiManifestMember => {
+    const stat = statSync(path, { bigint: true });
+    if (stat.mtimeNs > maxMtimeNs) maxMtimeNs = stat.mtimeNs;
+    return {
+      relativePath: normalizedRelativePath(sessionDir, path),
+      dev: String(stat.dev),
+      ino: String(stat.ino),
+      size: String(stat.size),
+      mtimeNs: String(stat.mtimeNs),
+      ctimeNs: String(stat.ctimeNs),
+    };
+  }).sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  const digest = createHash('sha256').update(JSON.stringify(members)).digest('base64url');
+  const maxMtimeMs = maxMtimeNs / 1_000_000n;
+  return `${maxMtimeMs}:0:${KIMI_MANIFEST_CURSOR_FORMAT}:${digest}`;
+}
+
+/**
+ * Capture one deterministic, body-free view of the Kimi session members.
+ * The manifest format owns path normalization, ordering, metadata fields, and
+ * digest encoding; changing any of those requires a new cursor-format tag.
+ */
+export function snapshotKimiSession(sessionDir: string): KimiSessionSnapshot {
+  const statePath = join(sessionDir, 'state.json');
+  const wireFiles = listWireFiles(sessionDir);
+  return {
+    sessionDir,
+    statePath,
+    wireFiles,
+    currentCursor: manifestCursor(sessionDir, [statePath, ...wireFiles.map((wire) => wire.path)]),
+  };
+}

--- a/packages/core/src/providers/kimi.ts
+++ b/packages/core/src/providers/kimi.ts
@@ -646,22 +646,44 @@ export function createKimiProvider({ rootDir = defaultKimiRoot() }: { rootDir?: 
     discover(ctx: DiscoverContext): IndexUnit[] {
       const units: IndexUnit[] = [];
       const sessionsDir = join(rootDir, 'sessions');
-      if (!existsSync(sessionsDir) && (ctx.indexedSessions?.().length ?? 0) > 0) {
-        ctx.reportIncompleteInventory?.({ path: sessionsDir, error: 'Source folder is unavailable' });
+      const indexedSessions = ctx.indexedSessions?.() ?? [];
+      let inventoryComplete = true;
+      const reportIssue = (issue: InventoryIssue): void => {
+        inventoryComplete = false;
+        ctx.reportIncompleteInventory?.(issue);
+      };
+      if (!existsSync(sessionsDir) && indexedSessions.length > 0) {
+        reportIssue({ path: sessionsDir, error: 'Source folder is unavailable' });
       }
       const changedSessions = ctx.changedPaths === undefined
         ? null
         : changedSessionDirectories(rootDir, ctx.changedPaths);
-      const indexedSessionDirs = new Set((ctx.indexedSessions?.() ?? []).map(
+      const indexedSessionDirs = new Set(indexedSessions.map(
         ({ jsonlPath }) => sessionDirectoryFromWirePath(jsonlPath),
       ));
-      for (const sessionDir of sessionDirectories(rootDir, ctx.reportIncompleteInventory)) {
-        if (changedSessions !== null && !changedSessions.has(sessionDir)) continue;
+      const discoveredSessionDirs = sessionDirectories(rootDir, reportIssue);
+      const candidateSessionDirs = new Set(
+        changedSessions === null
+          ? discoveredSessionDirs
+          : discoveredSessionDirs.filter((sessionDir) => changedSessions.has(sessionDir)),
+      );
+      if (changedSessions === null && inventoryComplete) {
+        for (const indexedSessionDir of indexedSessionDirs) {
+          const inside = relative(sessionsDir, indexedSessionDir);
+          if (inside && !inside.startsWith('..') && !isAbsolute(inside)) {
+            candidateSessionDirs.add(indexedSessionDir);
+          }
+        }
+      } else if (changedSessions !== null) {
+        for (const changedSessionDir of changedSessions) candidateSessionDirs.add(changedSessionDir);
+      }
+
+      for (const sessionDir of [...candidateSessionDirs].sort()) {
         let snapshot: KimiSessionSnapshot;
         try {
           snapshot = snapshotKimiSession(sessionDir);
         } catch (error) {
-          ctx.reportIncompleteInventory?.(sourceInventoryIssue(sessionDir, error));
+          reportIssue(sourceInventoryIssue(sessionDir, error));
           continue;
         }
         const { statePath, wireFiles, currentCursor } = snapshot;

--- a/packages/core/src/providers/kimi.ts
+++ b/packages/core/src/providers/kimi.ts
@@ -5,12 +5,13 @@ import {
   existsSync,
   readdirSync,
   readFileSync,
-  statSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, dirname, isAbsolute, join, normalize, relative, sep } from 'node:path';
 
 import { filePath, projectSlugFromPath, sourceInventoryIssue, trunc, truncJson } from '../parsing.ts';
+import { classifyKimiCursor, snapshotKimiSession } from './kimi-manifest.ts';
+import type { KimiSessionSnapshot } from './kimi-manifest.ts';
 import type {
   Cursor,
   DiscoverContext,
@@ -29,18 +30,9 @@ import type {
 
 type JsonRecord = Record<string, any>;
 
-interface KimiWireFile {
-  readonly agentId: string;
-  readonly main: boolean;
-  readonly path: string;
-}
-
-interface KimiSessionUnitMeta {
+interface KimiSessionUnitMeta extends KimiSessionSnapshot {
   readonly kind: 'session';
-  readonly sessionDir: string;
-  readonly statePath: string;
-  readonly wireFiles: readonly KimiWireFile[];
-  readonly currentCursor: Exclude<Cursor, null>;
+  readonly mode: 'replay' | 'tombstone';
 }
 
 interface LineRecord {
@@ -93,41 +85,6 @@ function readWire(path: string): LineRecord[] {
     }
   }
   return records;
-}
-
-function listWireFiles(sessionDir: string): KimiWireFile[] {
-  const agentsDir = join(sessionDir, 'agents');
-  const files: KimiWireFile[] = [];
-  if (existsSync(agentsDir)) {
-    for (const entry of readdirSync(agentsDir, { withFileTypes: true })) {
-      if (!entry.isDirectory()) continue;
-      const path = join(agentsDir, entry.name, 'wire.jsonl');
-      if (existsSync(path)) files.push({ agentId: entry.name, main: entry.name === 'main', path });
-    }
-  }
-  if (!files.some((file) => file.main)) {
-    const legacy = join(sessionDir, 'wire.jsonl');
-    if (existsSync(legacy)) files.push({ agentId: 'main', main: true, path: legacy });
-  }
-  return files.sort((a, b) => Number(b.main) - Number(a.main) || a.agentId.localeCompare(b.agentId));
-}
-
-function fileLineCount(path: string): number {
-  const raw = readFileSync(path, 'utf8');
-  if (raw.length === 0) return 0;
-  const newlines = raw.match(/\n/g)?.length ?? 0;
-  return newlines + (raw.endsWith('\n') ? 0 : 1);
-}
-
-function cursorFor(statePath: string, wires: readonly KimiWireFile[]): Exclude<Cursor, null> {
-  const paths = [statePath, ...wires.map((wire) => wire.path)].filter(existsSync);
-  let maxMtime = 0;
-  let totalLines = 0;
-  for (const path of paths) {
-    maxMtime = Math.max(maxMtime, statSync(path).mtimeMs);
-    totalLines += fileLineCount(path);
-  }
-  return `${maxMtime}:${totalLines}`;
 }
 
 function normalizeTime(value: unknown): string | null {
@@ -695,31 +652,64 @@ export function createKimiProvider({ rootDir = defaultKimiRoot() }: { rootDir?: 
       const changedSessions = ctx.changedPaths === undefined
         ? null
         : changedSessionDirectories(rootDir, ctx.changedPaths);
+      const indexedSessionDirs = new Set((ctx.indexedSessions?.() ?? []).map(
+        ({ jsonlPath }) => sessionDirectoryFromWirePath(jsonlPath),
+      ));
       for (const sessionDir of sessionDirectories(rootDir, ctx.reportIncompleteInventory)) {
         if (changedSessions !== null && !changedSessions.has(sessionDir)) continue;
-        const statePath = join(sessionDir, 'state.json');
-        const wireFiles = listWireFiles(sessionDir);
-        if (wireFiles.length === 0) continue;
-        const currentCursor = cursorFor(statePath, wireFiles);
-        if (changedSessions === null && ctx.lastCursor(sessionDir) === currentCursor) continue;
+        let snapshot: KimiSessionSnapshot;
+        try {
+          snapshot = snapshotKimiSession(sessionDir);
+        } catch (error) {
+          ctx.reportIncompleteInventory?.(sourceInventoryIssue(sessionDir, error));
+          continue;
+        }
+        const { statePath, wireFiles, currentCursor } = snapshot;
+        const storedCursor = ctx.lastCursor(sessionDir);
+        if (
+          wireFiles.length === 0
+          && storedCursor === null
+          && !indexedSessionDirs.has(sessionDir)
+        ) continue;
+        if (
+          changedSessions === null
+          && classifyKimiCursor(storedCursor, currentCursor) === 'current'
+        ) continue;
         const state = readState(statePath);
         const cwd = typeof state.cwd === 'string' ? state.cwd : typeof state.workDir === 'string' ? state.workDir : null;
         units.push({
           key: sessionDir,
           sessionId: namespacedSessionId(basename(sessionDir)),
           project: projectSlugFromPath(cwd) ?? undefined,
-          meta: { kind: 'session', sessionDir, statePath, wireFiles, currentCursor } satisfies KimiSessionUnitMeta,
+          meta: {
+            kind: 'session',
+            mode: wireFiles.length === 0 ? 'tombstone' : 'replay',
+            ...snapshot,
+          } satisfies KimiSessionUnitMeta,
         });
       }
       return units;
     },
     *parse(unit: IndexUnit, _cursor: Cursor): Generator<TranscriptRecord, Cursor> {
       const meta = unit.meta as KimiSessionUnitMeta;
-      const before = cursorFor(meta.statePath, meta.wireFiles);
+      const before = snapshotKimiSession(meta.sessionDir);
+      if (before.currentCursor !== meta.currentCursor) {
+        throw new Error(`Kimi session changed while indexing: ${meta.sessionDir}`);
+      }
+      if (meta.mode === 'tombstone') {
+        yield { kind: 'delete-session', sessionId: unit.sessionId };
+        const afterTombstone = snapshotKimiSession(meta.sessionDir);
+        if (before.currentCursor !== afterTombstone.currentCursor) {
+          throw new Error(`Kimi session changed while indexing: ${meta.sessionDir}`);
+        }
+        return afterTombstone.currentCursor;
+      }
       const state = readState(meta.statePath);
       const projected = projectSession(meta, unit.sessionId, state);
-      const after = cursorFor(meta.statePath, meta.wireFiles);
-      if (before !== after) throw new Error(`Kimi session changed while indexing: ${meta.sessionDir}`);
+      const after = snapshotKimiSession(meta.sessionDir);
+      if (before.currentCursor !== after.currentCursor) {
+        throw new Error(`Kimi session changed while indexing: ${meta.sessionDir}`);
+      }
 
       yield { kind: 'delete-session', sessionId: unit.sessionId };
       // Kimi persists a titled session before the first prompt; keep it retracted until user evidence exists.
@@ -727,7 +717,7 @@ export function createKimiProvider({ rootDir = defaultKimiRoot() }: { rootDir?: 
       const hasProjectedUserPrompt = projected.messages.some((message) => (
         message.agent_id === null && message.role === 'user' && !message.is_meta
       ));
-      if (state.title === 'New Session' && !hasLastPrompt && !hasProjectedUserPrompt) return after;
+      if (state.title === 'New Session' && !hasLastPrompt && !hasProjectedUserPrompt) return after.currentCursor;
       yield {
         kind: 'session',
         id: unit.sessionId,
@@ -752,7 +742,7 @@ export function createKimiProvider({ rootDir = defaultKimiRoot() }: { rootDir?: 
       yield* projected.summaries;
       yield* projected.subagents;
       yield* projected.durations;
-      return after;
+      return after.currentCursor;
     },
     raw(input: RawLookup): RawRecord | null {
       const mainPath = typeof input.session?.jsonl_path === 'string' ? input.session.jsonl_path : null;

--- a/packages/core/src/providers/kimi.ts
+++ b/packages/core/src/providers/kimi.ts
@@ -33,6 +33,12 @@ type JsonRecord = Record<string, any>;
 interface KimiSessionUnitMeta extends KimiSessionSnapshot {
   readonly kind: 'session';
   readonly mode: 'replay' | 'tombstone';
+  readonly identityWitnesses?: readonly KimiIdentityWitness[];
+}
+
+interface KimiIdentityWitness {
+  readonly sessionId: string;
+  readonly snapshots: readonly KimiSessionSnapshot[];
 }
 
 interface LineRecord {
@@ -571,7 +577,7 @@ function sessionDirectories(
   return result.sort();
 }
 
-function changedSessionDirectories(rootDir: string, changedPaths: readonly string[]): Set<string> {
+function changedSessionDirectories(rootDir: string, changedPaths: readonly string[]): Set<string> | null {
   const sessionsDir = join(rootDir, 'sessions');
   const result = new Set<string>();
   for (const changedPath of changedPaths) {
@@ -579,8 +585,10 @@ function changedSessionDirectories(rootDir: string, changedPaths: readonly strin
       ? normalize(changedPath)
       : normalize(join(sessionsDir, changedPath));
     const inside = relative(sessionsDir, absolute);
-    if (!inside || inside.startsWith('..') || isAbsolute(inside)) continue;
+    if (!inside) return null;
+    if (inside.startsWith('..') || isAbsolute(inside)) continue;
     const [workspaceId, sessionId] = inside.split(sep);
+    if (workspaceId && !sessionId) return null;
     if (workspaceId && sessionId) result.add(join(sessionsDir, workspaceId, sessionId));
   }
   return result;
@@ -591,6 +599,38 @@ function sessionDirectoryFromWirePath(wirePath: string): string {
   return basename(parent) === 'main' && basename(dirname(parent)) === 'agents'
     ? dirname(dirname(parent))
     : parent;
+}
+
+function verifyKimiIdentityWitnesses(
+  rootDir: string,
+  witnesses: readonly KimiIdentityWitness[] | undefined,
+): void {
+  if (witnesses === undefined || witnesses.length === 0) return;
+  const sessionsDir = join(rootDir, 'sessions');
+  if (!existsSync(sessionsDir)) {
+    throw new Error(`Kimi session identity changed while indexing: ${sessionsDir}`);
+  }
+  const currentSessionDirs = sessionDirectories(rootDir, (issue) => {
+    throw new Error(`Kimi session identity changed while indexing: ${issue.path}: ${issue.error}`);
+  });
+  for (const witness of witnesses) {
+    const expectedDirs = witness.snapshots.map(({ sessionDir }) => sessionDir).sort();
+    const currentDirs = currentSessionDirs.filter((sessionDir) => (
+      namespacedSessionId(basename(sessionDir)) === witness.sessionId
+    ));
+    if (
+      currentDirs.length !== expectedDirs.length
+      || currentDirs.some((sessionDir, index) => sessionDir !== expectedDirs[index])
+    ) {
+      throw new Error(`Kimi session identity changed while indexing: ${witness.sessionId}`);
+    }
+    for (const expected of witness.snapshots) {
+      const current = snapshotKimiSession(expected.sessionDir);
+      if (current.currentCursor !== expected.currentCursor) {
+        throw new Error(`Kimi session identity changed while indexing: ${witness.sessionId}`);
+      }
+    }
+  }
 }
 
 function rawFromWire(path: string, messageUuid: string): RawRecord | null {
@@ -658,72 +698,252 @@ export function createKimiProvider({ rootDir = defaultKimiRoot() }: { rootDir?: 
       const changedSessions = ctx.changedPaths === undefined
         ? null
         : changedSessionDirectories(rootDir, ctx.changedPaths);
-      const indexedSessionDirs = new Set(indexedSessions.map(
-        ({ jsonlPath }) => sessionDirectoryFromWirePath(jsonlPath),
+      const indexedSessionDirById = new Map(indexedSessions.map(
+        ({ sessionId, jsonlPath }) => [sessionId, sessionDirectoryFromWirePath(jsonlPath)],
       ));
+      const indexedSessionByDir = new Map(indexedSessions.map((indexed) => (
+        [sessionDirectoryFromWirePath(indexed.jsonlPath), indexed]
+      )));
       const discoveredSessionDirs = sessionDirectories(rootDir, reportIssue);
-      const candidateSessionDirs = new Set(
+      const discoveredBySessionId = new Map<string, string[]>();
+      for (const sessionDir of discoveredSessionDirs) {
+        const sessionId = namespacedSessionId(basename(sessionDir));
+        discoveredBySessionId.set(sessionId, [
+          ...(discoveredBySessionId.get(sessionId) ?? []),
+          sessionDir,
+        ]);
+      }
+      const candidateSessionDirs = new Set<string>(
         changedSessions === null
           ? discoveredSessionDirs
           : discoveredSessionDirs.filter((sessionDir) => changedSessions.has(sessionDir)),
       );
-      if (changedSessions === null && inventoryComplete) {
-        for (const indexedSessionDir of indexedSessionDirs) {
-          const inside = relative(sessionsDir, indexedSessionDir);
-          if (inside && !inside.startsWith('..') && !isAbsolute(inside)) {
-            candidateSessionDirs.add(indexedSessionDir);
-          }
+      for (const sessionDirs of discoveredBySessionId.values()) {
+        if (sessionDirs.length < 2) continue;
+        for (const sessionDir of sessionDirs) candidateSessionDirs.add(sessionDir);
+      }
+      for (const indexed of indexedSessions) {
+        const indexedSessionDir = sessionDirectoryFromWirePath(indexed.jsonlPath);
+        const inside = relative(sessionsDir, indexedSessionDir);
+        if (!inside || inside.startsWith('..') || isAbsolute(inside)) continue;
+        const shouldReconcile = changedSessions === null || changedSessions.has(indexedSessionDir);
+        if (!shouldReconcile) continue;
+        const movedSessionDirs = discoveredBySessionId.get(indexed.sessionId) ?? [];
+        if (movedSessionDirs.length === 1 && movedSessionDirs[0] !== indexedSessionDir) {
+          candidateSessionDirs.add(movedSessionDirs[0]!);
         }
-      } else if (changedSessions !== null) {
-        for (const changedSessionDir of changedSessions) candidateSessionDirs.add(changedSessionDir);
       }
 
-      for (const sessionDir of [...candidateSessionDirs].sort()) {
-        let snapshot: KimiSessionSnapshot;
+      const snapshots = new Map<string, KimiSessionSnapshot>();
+      for (const sessionDir of discoveredSessionDirs) {
         try {
-          snapshot = snapshotKimiSession(sessionDir);
+          snapshots.set(sessionDir, snapshotKimiSession(sessionDir));
         } catch (error) {
           reportIssue(sourceInventoryIssue(sessionDir, error));
-          continue;
         }
-        const { statePath, wireFiles, currentCursor } = snapshot;
+      }
+
+      const liveSessionDirsById = new Map<string, string[]>();
+      for (const [sessionDir, snapshot] of snapshots) {
+        if (snapshot.wireFiles.length === 0) continue;
+        const sessionId = namespacedSessionId(basename(sessionDir));
+        liveSessionDirsById.set(sessionId, [
+          ...(liveSessionDirsById.get(sessionId) ?? []),
+          sessionDir,
+        ]);
+      }
+      const ambiguousSessionIds = new Set<string>();
+      for (const [sessionId, sessionDirs] of liveSessionDirsById) {
+        if (sessionDirs.length < 2) continue;
+        ambiguousSessionIds.add(sessionId);
+        reportIssue({
+          path: sessionsDir,
+          error: `Multiple live Kimi session directories share identity ${sessionId}`,
+        });
+      }
+
+      const liveSessionIds = new Set(liveSessionDirsById.keys());
+      const touchedSessionIds = new Set<string>();
+      const replayCandidates: Array<{
+        sessionDir: string;
+        sessionId: string;
+        snapshot: KimiSessionSnapshot;
+        sourceLocal: boolean;
+        retractSessionIds: readonly string[];
+      }> = [];
+      const plannedRetractions = new Set<string>();
+      for (const sessionDir of [...candidateSessionDirs].sort()) {
+        const snapshot = snapshots.get(sessionDir);
+        if (snapshot === undefined) continue;
+        const sessionId = namespacedSessionId(basename(sessionDir));
+        touchedSessionIds.add(sessionId);
+        const { wireFiles, currentCursor } = snapshot;
+        if (wireFiles.length === 0) continue;
+        if (ambiguousSessionIds.has(sessionId)) continue;
         const storedCursor = ctx.lastCursor(sessionDir);
-        if (
-          wireFiles.length === 0
-          && storedCursor === null
-          && !indexedSessionDirs.has(sessionDir)
-        ) continue;
+        const indexedSessionDir = indexedSessionDirById.get(sessionId);
+        const indexedAtDir = indexedSessionByDir.get(sessionDir);
+        const ownsIndexedProvenance = indexedSessionDir === sessionDir;
+        const cursorCanProveProvenance = ownsIndexedProvenance
+          || (indexedSessionDir === undefined && indexedAtDir === undefined);
+        const sourceLocal = cursorCanProveProvenance;
+        const retractSessionIds = indexedAtDir !== undefined
+          && indexedAtDir.sessionId !== sessionId
+          && !liveSessionIds.has(indexedAtDir.sessionId)
+          ? [indexedAtDir.sessionId]
+          : [];
         if (
           changedSessions === null
+          && cursorCanProveProvenance
           && classifyKimiCursor(storedCursor, currentCursor) === 'current'
         ) continue;
-        const state = readState(statePath);
+        for (const retractedSessionId of retractSessionIds) plannedRetractions.add(retractedSessionId);
+        replayCandidates.push({
+          sessionDir,
+          sessionId,
+          snapshot,
+          sourceLocal,
+          retractSessionIds,
+        });
+      }
+
+      const pendingTombstones: Array<{
+        indexed: (typeof indexedSessions)[number];
+        sessionDir: string;
+        snapshot: KimiSessionSnapshot;
+      }> = [];
+      for (const indexed of indexedSessions) {
+        if (
+          ambiguousSessionIds.has(indexed.sessionId)
+          || liveSessionIds.has(indexed.sessionId)
+          || plannedRetractions.has(indexed.sessionId)
+        ) continue;
+        const indexedSessionDir = sessionDirectoryFromWirePath(indexed.jsonlPath);
+        const shouldReconcile = changedSessions === null
+          || changedSessions.has(indexedSessionDir)
+          || touchedSessionIds.has(indexed.sessionId);
+        if (!shouldReconcile || !inventoryComplete) continue;
+        let snapshot = snapshots.get(indexedSessionDir);
+        if (snapshot === undefined) {
+          try {
+            snapshot = snapshotKimiSession(indexedSessionDir);
+          } catch (error) {
+            reportIssue(sourceInventoryIssue(indexedSessionDir, error));
+            continue;
+          }
+        }
+        if (snapshot.wireFiles.length > 0) {
+          reportIssue({
+            path: indexedSessionDir,
+            error: 'Kimi session appeared after the identity census',
+          });
+          continue;
+        }
+        pendingTombstones.push({ indexed, sessionDir: indexedSessionDir, snapshot });
+      }
+
+      const verifiedSessionDirs = sessionDirectories(rootDir, reportIssue);
+      if (inventoryComplete && !existsSync(sessionsDir) && indexedSessions.length > 0) {
+        reportIssue({ path: sessionsDir, error: 'Source folder became unavailable during discovery' });
+      }
+      if (
+        verifiedSessionDirs.length !== discoveredSessionDirs.length
+        || verifiedSessionDirs.some((sessionDir, index) => sessionDir !== discoveredSessionDirs[index])
+      ) {
+        reportIssue({ path: sessionsDir, error: 'Kimi session inventory changed during discovery' });
+      }
+
+      const destructiveSessionIds = new Set([
+        ...plannedRetractions,
+        ...pendingTombstones.map(({ indexed }) => indexed.sessionId),
+        ...replayCandidates.filter(({ sourceLocal }) => !sourceLocal).map(({ sessionId }) => sessionId),
+      ]);
+      for (const sessionId of destructiveSessionIds) {
+        for (const sessionDir of discoveredBySessionId.get(sessionId) ?? []) {
+          const before = snapshots.get(sessionDir);
+          let after: KimiSessionSnapshot;
+          try {
+            after = snapshotKimiSession(sessionDir);
+          } catch (error) {
+            reportIssue(sourceInventoryIssue(sessionDir, error));
+            continue;
+          }
+          if (before === undefined || before.currentCursor !== after.currentCursor) {
+            reportIssue({
+              path: sessionDir,
+              error: 'Kimi session identity changed during discovery',
+            });
+          }
+        }
+      }
+
+      const identityWitnessesFor = (sessionIds: readonly string[]): KimiIdentityWitness[] => (
+        [...new Set(sessionIds)].map((sessionId) => ({
+          sessionId,
+          snapshots: (discoveredBySessionId.get(sessionId) ?? []).flatMap((sessionDir) => {
+            const snapshot = snapshots.get(sessionDir);
+            return snapshot === undefined ? [] : [snapshot];
+          }),
+        }))
+      );
+
+      for (const {
+        sessionDir,
+        sessionId,
+        snapshot,
+        sourceLocal,
+        retractSessionIds,
+      } of replayCandidates) {
+        if (!inventoryComplete && !sourceLocal) continue;
+        const state = readState(snapshot.statePath);
         const cwd = typeof state.cwd === 'string' ? state.cwd : typeof state.workDir === 'string' ? state.workDir : null;
+        const identityWitnesses = sourceLocal && retractSessionIds.length === 0
+          ? []
+          : identityWitnessesFor([sessionId, ...retractSessionIds]);
         units.push({
           key: sessionDir,
-          sessionId: namespacedSessionId(basename(sessionDir)),
+          sessionId,
+          ...(retractSessionIds.length === 0 ? {} : { retractSessionIds }),
           project: projectSlugFromPath(cwd) ?? undefined,
           meta: {
             kind: 'session',
-            mode: wireFiles.length === 0 ? 'tombstone' : 'replay',
+            mode: 'replay',
+            ...(identityWitnesses.length === 0 ? {} : { identityWitnesses }),
             ...snapshot,
           } satisfies KimiSessionUnitMeta,
         });
+      }
+      if (inventoryComplete) {
+        for (const { indexed, sessionDir, snapshot } of pendingTombstones) {
+          const identityWitnesses = identityWitnessesFor([indexed.sessionId]);
+          units.push({
+            key: sessionDir,
+            sessionId: indexed.sessionId,
+            retractSessionIds: [indexed.sessionId],
+            meta: {
+              kind: 'session',
+              mode: 'tombstone',
+              identityWitnesses,
+              ...snapshot,
+            } satisfies KimiSessionUnitMeta,
+          });
+        }
       }
       return units;
     },
     *parse(unit: IndexUnit, _cursor: Cursor): Generator<TranscriptRecord, Cursor> {
       const meta = unit.meta as KimiSessionUnitMeta;
+      verifyKimiIdentityWitnesses(rootDir, meta.identityWitnesses);
       const before = snapshotKimiSession(meta.sessionDir);
       if (before.currentCursor !== meta.currentCursor) {
         throw new Error(`Kimi session changed while indexing: ${meta.sessionDir}`);
       }
       if (meta.mode === 'tombstone') {
-        yield { kind: 'delete-session', sessionId: unit.sessionId };
         const afterTombstone = snapshotKimiSession(meta.sessionDir);
         if (before.currentCursor !== afterTombstone.currentCursor) {
           throw new Error(`Kimi session changed while indexing: ${meta.sessionDir}`);
         }
+        verifyKimiIdentityWitnesses(rootDir, meta.identityWitnesses);
         return afterTombstone.currentCursor;
       }
       const state = readState(meta.statePath);
@@ -732,6 +952,7 @@ export function createKimiProvider({ rootDir = defaultKimiRoot() }: { rootDir?: 
       if (before.currentCursor !== after.currentCursor) {
         throw new Error(`Kimi session changed while indexing: ${meta.sessionDir}`);
       }
+      verifyKimiIdentityWitnesses(rootDir, meta.identityWitnesses);
 
       yield { kind: 'delete-session', sessionId: unit.sessionId };
       // Kimi persists a titled session before the first prompt; keep it retracted until user evidence exists.

--- a/tests/app-kimi-index.test.mjs
+++ b/tests/app-kimi-index.test.mjs
@@ -4,7 +4,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { buildIndex } from '../app/src/main/indexer.ts';
@@ -283,5 +283,78 @@ test('Kimi canonical transcript marker replays unchanged sessions once', () => {
     { text: '/obelisk find prior decisions', is_meta: 0 },
   );
   assert.equal(db.prepare('SELECT COUNT(*) AS c FROM index_state WHERE jsonl_path=?').get(marker).c, 1);
+  db.close();
+});
+
+test('Kimi legacy cursors replay once into manifest-v1 without a canonical marker bump', () => {
+  const home = makeTempDir('obelisk-kimi-manifest-legacy-replay-');
+  const kimiDir = join(home, '.kimi-code');
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  const { sessionDir } = writeSession(kimiDir);
+  const options = {
+    claudeDir: join(home, '.claude'),
+    codexDir: join(home, '.codex'),
+    providerRoots: { kimi: kimiDir },
+    dbPath,
+    DatabaseImpl: TestDatabase,
+  };
+
+  buildIndex(options);
+  let db = new TestDatabase(dbPath);
+  const currentCursor = db.prepare(
+    'SELECT cursor FROM index_state WHERE jsonl_path = ?',
+  ).get(sessionDir).cursor;
+  const legacyCursor = `${currentCursor.split(':')[0]}:3`;
+  db.prepare('UPDATE index_state SET cursor = ?, mtime = ?, lines_processed = ? WHERE jsonl_path = ?')
+    .run(legacyCursor, Number(currentCursor.split(':')[0]), 3, sessionDir);
+  db.prepare("UPDATE messages SET text = 'stale legacy projection' WHERE source = 'kimi'").run();
+  db.close();
+
+  const migrated = buildIndex(options);
+  assert.deepEqual(migrated.affectedSessionIds, ['kimi:session-index-1']);
+  db = new TestDatabase(dbPath);
+  assert.equal(db.prepare("SELECT text FROM messages WHERE source = 'kimi'").get().text, 'kimi index needle');
+  assert.match(
+    db.prepare('SELECT cursor FROM index_state WHERE jsonl_path = ?').get(sessionDir).cursor,
+    /^\d+:0:kimi-manifest-v1:[A-Za-z0-9_-]{43}$/,
+  );
+  assert.equal(
+    db.prepare("SELECT COUNT(*) AS c FROM index_state WHERE jsonl_path = '__kimi_canonical_transcript_v6__'").get().c,
+    1,
+  );
+  assert.equal(
+    db.prepare("SELECT COUNT(*) AS c FROM index_state WHERE jsonl_path = '__kimi_canonical_transcript_v7__'").get().c,
+    0,
+  );
+  db.close();
+
+  assert.deepEqual(buildIndex(options).affectedSessionIds, []);
+});
+
+test('Kimi manifest replay retracts an indexed session whose last wire is removed', () => {
+  const home = makeTempDir('obelisk-kimi-manifest-last-wire-index-');
+  const kimiDir = join(home, '.kimi-code');
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  const { sessionDir, wirePath } = writeSession(kimiDir);
+  const options = {
+    claudeDir: join(home, '.claude'),
+    codexDir: join(home, '.codex'),
+    providerRoots: { kimi: kimiDir },
+    dbPath,
+    DatabaseImpl: TestDatabase,
+  };
+
+  buildIndex(options);
+  rmSync(wirePath);
+  const replay = buildIndex(options);
+  assert.deepEqual(replay.affectedSessionIds, ['kimi:session-index-1']);
+
+  const db = new TestDatabase(dbPath);
+  assert.equal(db.prepare("SELECT COUNT(*) AS c FROM sessions WHERE source = 'kimi'").get().c, 0);
+  assert.equal(db.prepare("SELECT COUNT(*) AS c FROM messages WHERE source = 'kimi'").get().c, 0);
+  assert.match(
+    db.prepare('SELECT cursor FROM index_state WHERE jsonl_path = ?').get(sessionDir).cursor,
+    /^\d+:0:kimi-manifest-v1:[A-Za-z0-9_-]{43}$/,
+  );
   db.close();
 });

--- a/tests/app-kimi-index.test.mjs
+++ b/tests/app-kimi-index.test.mjs
@@ -4,7 +4,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { buildIndex } from '../app/src/main/indexer.ts';
@@ -398,5 +398,170 @@ test('Kimi manifest replay retracts an indexed session directory that is deleted
   const db = new TestDatabase(dbPath);
   assert.equal(db.prepare("SELECT COUNT(*) AS c FROM sessions WHERE source = 'kimi'").get().c, 0);
   assert.equal(db.prepare("SELECT COUNT(*) AS c FROM messages WHERE source = 'kimi'").get().c, 0);
+  db.close();
+});
+
+test('Kimi reconciliation preserves a session moved across workspaces', () => {
+  const home = makeTempDir('obelisk-kimi-manifest-session-move-index-');
+  const kimiDir = join(home, '.kimi-code');
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  const { sessionDir } = writeManifestSession(kimiDir);
+  const options = {
+    claudeDir: join(home, '.claude'),
+    codexDir: join(home, '.codex'),
+    providerRoots: { kimi: kimiDir },
+    dbPath,
+    DatabaseImpl: TestDatabase,
+  };
+
+  buildIndex(options);
+  const movedSessionDir = join(kimiDir, 'sessions', 'a-workspace', 'session-manifest-1');
+  mkdirSync(join(kimiDir, 'sessions', 'a-workspace'), { recursive: true });
+  renameSync(sessionDir, movedSessionDir);
+  const replay = buildIndex(options);
+  assert.deepEqual(replay.affectedSessionIds, ['kimi:session-manifest-1']);
+
+  const db = new TestDatabase(dbPath);
+  assert.deepEqual(
+    { ...db.prepare("SELECT id,jsonl_path FROM sessions WHERE source='kimi'").get() },
+    {
+      id: 'kimi:session-manifest-1',
+      jsonl_path: join(movedSessionDir, 'agents', 'main', 'wire.jsonl'),
+    },
+  );
+  db.close();
+});
+
+test('Kimi reconciliation follows a moved identity from an old-path-only change', () => {
+  const home = makeTempDir('obelisk-kimi-manifest-old-path-move-index-');
+  const kimiDir = join(home, '.kimi-code');
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  const { sessionDir } = writeManifestSession(kimiDir);
+  const options = {
+    claudeDir: join(home, '.claude'),
+    codexDir: join(home, '.codex'),
+    providerRoots: { kimi: kimiDir },
+    dbPath,
+    DatabaseImpl: TestDatabase,
+  };
+
+  buildIndex(options);
+  const movedSessionDir = join(kimiDir, 'sessions', 'a-workspace', 'session-manifest-1');
+  mkdirSync(join(kimiDir, 'sessions', 'a-workspace'), { recursive: true });
+  renameSync(sessionDir, movedSessionDir);
+  const replay = buildIndex({ ...options, changedPaths: [sessionDir] });
+  assert.deepEqual(replay.affectedSessionIds, ['kimi:session-manifest-1']);
+
+  const db = new TestDatabase(dbPath);
+  assert.equal(
+    db.prepare("SELECT jsonl_path FROM sessions WHERE source='kimi'").get().jsonl_path,
+    join(movedSessionDir, 'agents', 'main', 'wire.jsonl'),
+  );
+  db.close();
+});
+
+test('Kimi reconciliation refreshes provenance after a round-trip workspace move', () => {
+  const home = makeTempDir('obelisk-kimi-manifest-round-trip-move-index-');
+  const kimiDir = join(home, '.kimi-code');
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  const { sessionDir } = writeManifestSession(kimiDir);
+  const options = {
+    claudeDir: join(home, '.claude'),
+    codexDir: join(home, '.codex'),
+    providerRoots: { kimi: kimiDir },
+    dbPath,
+    DatabaseImpl: TestDatabase,
+  };
+
+  buildIndex(options);
+  const movedSessionDir = join(kimiDir, 'sessions', 'workspace-2', 'session-manifest-1');
+  mkdirSync(join(kimiDir, 'sessions', 'workspace-2'), { recursive: true });
+  renameSync(sessionDir, movedSessionDir);
+  buildIndex(options);
+  renameSync(movedSessionDir, sessionDir);
+  const replay = buildIndex(options);
+  assert.deepEqual(replay.affectedSessionIds, ['kimi:session-manifest-1']);
+
+  const db = new TestDatabase(dbPath);
+  assert.equal(
+    db.prepare("SELECT jsonl_path FROM sessions WHERE source='kimi'").get().jsonl_path,
+    join(sessionDir, 'agents', 'main', 'wire.jsonl'),
+  );
+  db.close();
+});
+
+test('Kimi changed-path reconciliation preserves sessions when inventory is incomplete', () => {
+  const home = makeTempDir('obelisk-kimi-manifest-incomplete-index-');
+  const kimiDir = join(home, '.kimi-code');
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  const { sessionDir } = writeManifestSession(kimiDir);
+  const options = {
+    claudeDir: join(home, '.claude'),
+    codexDir: join(home, '.codex'),
+    providerRoots: { kimi: kimiDir },
+    dbPath,
+    DatabaseImpl: TestDatabase,
+  };
+
+  buildIndex(options);
+  rmSync(join(kimiDir, 'sessions'), { recursive: true });
+  const incomplete = buildIndex({ ...options, changedPaths: [sessionDir] });
+  assert.equal(incomplete.complete, false);
+  assert.deepEqual(incomplete.incompleteProviders, ['kimi']);
+
+  const db = new TestDatabase(dbPath);
+  assert.equal(db.prepare("SELECT COUNT(*) AS c FROM sessions WHERE source='kimi'").get().c, 1);
+  db.close();
+});
+
+test('Kimi reconciliation retracts sessions after a workspace-level deletion event', () => {
+  const home = makeTempDir('obelisk-kimi-manifest-workspace-delete-index-');
+  const kimiDir = join(home, '.kimi-code');
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  writeManifestSession(kimiDir);
+  const workspaceDir = join(kimiDir, 'sessions', 'workspace-1');
+  const options = {
+    claudeDir: join(home, '.claude'),
+    codexDir: join(home, '.codex'),
+    providerRoots: { kimi: kimiDir },
+    dbPath,
+    DatabaseImpl: TestDatabase,
+  };
+
+  buildIndex(options);
+  rmSync(workspaceDir, { recursive: true });
+  const replay = buildIndex({ ...options, changedPaths: [workspaceDir] });
+  assert.deepEqual(replay.affectedSessionIds, ['kimi:session-manifest-1']);
+
+  const db = new TestDatabase(dbPath);
+  assert.equal(db.prepare("SELECT COUNT(*) AS c FROM sessions WHERE source='kimi'").get().c, 0);
+  db.close();
+});
+
+test('Kimi reconciliation follows identities after a workspace-level rename event', () => {
+  const home = makeTempDir('obelisk-kimi-manifest-workspace-rename-index-');
+  const kimiDir = join(home, '.kimi-code');
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  writeManifestSession(kimiDir);
+  const oldWorkspaceDir = join(kimiDir, 'sessions', 'workspace-1');
+  const newWorkspaceDir = join(kimiDir, 'sessions', 'workspace-2');
+  const options = {
+    claudeDir: join(home, '.claude'),
+    codexDir: join(home, '.codex'),
+    providerRoots: { kimi: kimiDir },
+    dbPath,
+    DatabaseImpl: TestDatabase,
+  };
+
+  buildIndex(options);
+  renameSync(oldWorkspaceDir, newWorkspaceDir);
+  const replay = buildIndex({ ...options, changedPaths: [oldWorkspaceDir] });
+  assert.deepEqual(replay.affectedSessionIds, ['kimi:session-manifest-1']);
+
+  const db = new TestDatabase(dbPath);
+  assert.equal(
+    db.prepare("SELECT jsonl_path FROM sessions WHERE source='kimi'").get().jsonl_path,
+    join(newWorkspaceDir, 'session-manifest-1', 'agents', 'main', 'wire.jsonl'),
+  );
   db.close();
 });

--- a/tests/app-kimi-index.test.mjs
+++ b/tests/app-kimi-index.test.mjs
@@ -4,7 +4,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { buildIndex } from '../app/src/main/indexer.ts';
@@ -13,6 +13,14 @@ import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
+const REAL_MANIFEST_STATE = readFileSync(
+  new URL('./fixtures/kimi/manifest-session/state.json', import.meta.url),
+  'utf8',
+);
+const REAL_MANIFEST_WIRE = readFileSync(
+  new URL('./fixtures/kimi/manifest-session/agents/main/wire.jsonl', import.meta.url),
+  'utf8',
+);
 
 class TestDatabase {
   constructor(dbPath) {
@@ -87,6 +95,16 @@ function writePlaceholderSession(kimiDir, { userPrompt = false } = {}) {
     wirePath,
     records.map((record) => JSON.stringify(record)).join('\n') + '\n',
   );
+  return { sessionDir, wirePath };
+}
+
+function writeManifestSession(kimiDir) {
+  const sessionDir = join(kimiDir, 'sessions', 'workspace-1', 'session-manifest-1');
+  const mainDir = join(sessionDir, 'agents', 'main');
+  mkdirSync(mainDir, { recursive: true });
+  writeFileSync(join(sessionDir, 'state.json'), REAL_MANIFEST_STATE);
+  const wirePath = join(mainDir, 'wire.jsonl');
+  writeFileSync(wirePath, REAL_MANIFEST_WIRE);
   return { sessionDir, wirePath };
 }
 
@@ -290,7 +308,7 @@ test('Kimi legacy cursors replay once into manifest-v1 without a canonical marke
   const home = makeTempDir('obelisk-kimi-manifest-legacy-replay-');
   const kimiDir = join(home, '.kimi-code');
   const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
-  const { sessionDir } = writeSession(kimiDir);
+  const { sessionDir } = writeManifestSession(kimiDir);
   const options = {
     claudeDir: join(home, '.claude'),
     codexDir: join(home, '.codex'),
@@ -307,13 +325,13 @@ test('Kimi legacy cursors replay once into manifest-v1 without a canonical marke
   const legacyCursor = `${currentCursor.split(':')[0]}:3`;
   db.prepare('UPDATE index_state SET cursor = ?, mtime = ?, lines_processed = ? WHERE jsonl_path = ?')
     .run(legacyCursor, Number(currentCursor.split(':')[0]), 3, sessionDir);
-  db.prepare("UPDATE messages SET text = 'stale legacy projection' WHERE source = 'kimi'").run();
+  db.prepare("UPDATE sessions SET title = 'stale legacy projection' WHERE source = 'kimi'").run();
   db.close();
 
   const migrated = buildIndex(options);
-  assert.deepEqual(migrated.affectedSessionIds, ['kimi:session-index-1']);
+  assert.deepEqual(migrated.affectedSessionIds, ['kimi:session-manifest-1']);
   db = new TestDatabase(dbPath);
-  assert.equal(db.prepare("SELECT text FROM messages WHERE source = 'kimi'").get().text, 'kimi index needle');
+  assert.equal(db.prepare("SELECT title FROM sessions WHERE source = 'kimi'").get().title, null);
   assert.match(
     db.prepare('SELECT cursor FROM index_state WHERE jsonl_path = ?').get(sessionDir).cursor,
     /^\d+:0:kimi-manifest-v1:[A-Za-z0-9_-]{43}$/,
@@ -335,7 +353,7 @@ test('Kimi manifest replay retracts an indexed session whose last wire is remove
   const home = makeTempDir('obelisk-kimi-manifest-last-wire-index-');
   const kimiDir = join(home, '.kimi-code');
   const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
-  const { sessionDir, wirePath } = writeSession(kimiDir);
+  const { sessionDir, wirePath } = writeManifestSession(kimiDir);
   const options = {
     claudeDir: join(home, '.claude'),
     codexDir: join(home, '.codex'),
@@ -347,7 +365,7 @@ test('Kimi manifest replay retracts an indexed session whose last wire is remove
   buildIndex(options);
   rmSync(wirePath);
   const replay = buildIndex(options);
-  assert.deepEqual(replay.affectedSessionIds, ['kimi:session-index-1']);
+  assert.deepEqual(replay.affectedSessionIds, ['kimi:session-manifest-1']);
 
   const db = new TestDatabase(dbPath);
   assert.equal(db.prepare("SELECT COUNT(*) AS c FROM sessions WHERE source = 'kimi'").get().c, 0);
@@ -356,5 +374,29 @@ test('Kimi manifest replay retracts an indexed session whose last wire is remove
     db.prepare('SELECT cursor FROM index_state WHERE jsonl_path = ?').get(sessionDir).cursor,
     /^\d+:0:kimi-manifest-v1:[A-Za-z0-9_-]{43}$/,
   );
+  db.close();
+});
+
+test('Kimi manifest replay retracts an indexed session directory that is deleted', () => {
+  const home = makeTempDir('obelisk-kimi-manifest-session-delete-index-');
+  const kimiDir = join(home, '.kimi-code');
+  const dbPath = join(home, '.obelisk', 'obelisk.sqlite');
+  const { sessionDir } = writeManifestSession(kimiDir);
+  const options = {
+    claudeDir: join(home, '.claude'),
+    codexDir: join(home, '.codex'),
+    providerRoots: { kimi: kimiDir },
+    dbPath,
+    DatabaseImpl: TestDatabase,
+  };
+
+  buildIndex(options);
+  rmSync(sessionDir, { recursive: true });
+  const replay = buildIndex(options);
+  assert.deepEqual(replay.affectedSessionIds, ['kimi:session-manifest-1']);
+
+  const db = new TestDatabase(dbPath);
+  assert.equal(db.prepare("SELECT COUNT(*) AS c FROM sessions WHERE source = 'kimi'").get().c, 0);
+  assert.equal(db.prepare("SELECT COUNT(*) AS c FROM messages WHERE source = 'kimi'").get().c, 0);
   db.close();
 });

--- a/tests/fixtures/kimi/README.md
+++ b/tests/fixtures/kimi/README.md
@@ -1,0 +1,6 @@
+# Kimi Code fixtures
+
+`manifest-session/` is a sanitized Kimi Code v2 session captured from a real
+local runtime-created session. Only session, workspace, runtime, and filesystem
+identifiers were replaced; the JSON field names, record shapes, and line
+framing are unchanged.

--- a/tests/fixtures/kimi/manifest-session/agents/main/wire.jsonl
+++ b/tests/fixtures/kimi/manifest-session/agents/main/wire.jsonl
@@ -1,0 +1,2 @@
+{"type":"metadata","protocol_version":"1.5","created_at":1787850634278}
+{"type":"runtime.set_binding","workspaceId":"wd_fixture_manifest","runtimeId":"local","agentId":"main","time":1787850634294}

--- a/tests/fixtures/kimi/manifest-session/state.json
+++ b/tests/fixtures/kimi/manifest-session/state.json
@@ -1,0 +1,1 @@
+{"id":"session_fixture_manifest","version":2,"cwd":"/tmp/kimi-manifest-fixture","createdAt":1787850634251,"updatedAt":1787850634251,"archived":false,"agents":{"main":{"homedir":"/tmp/kimi-manifest-fixture/agents/main","type":"main"}},"custom":{},"isCustomTitle":false}

--- a/tests/kimi-manifest.test.mjs
+++ b/tests/kimi-manifest.test.mjs
@@ -18,11 +18,32 @@ let failingStatCode = 'ENOENT';
 let hiddenExistsPath = null;
 let addMemberDuringStatSessionDir = null;
 let addedMemberDuringStat = false;
+let moveBeforeSessionReadFrom = null;
+let moveBeforeSessionReadTo = null;
+let addWireOnSecondInventory = null;
+let inventoryReadCount = 0;
 let mutateAfterReadPath = null;
 let mutatedAfterRead = false;
 const fsMock = mock.module('node:fs', {
   namedExports: {
     ...fs,
+    readdirSync(path, ...args) {
+      if (addWireOnSecondInventory !== null && String(path) === addWireOnSecondInventory.sessionsDir) {
+        inventoryReadCount += 1;
+        if (inventoryReadCount === 2) {
+          const mainDir = join(addWireOnSecondInventory.sessionDir, 'agents', 'main');
+          fs.mkdirSync(mainDir, { recursive: true });
+          fs.writeFileSync(join(mainDir, 'wire.jsonl'), REAL_METADATA_LINE);
+        }
+      }
+      if (moveBeforeSessionReadFrom !== null && String(path) === moveBeforeSessionReadFrom) {
+        const target = moveBeforeSessionReadTo;
+        moveBeforeSessionReadFrom = null;
+        moveBeforeSessionReadTo = null;
+        fs.renameSync(path, target);
+      }
+      return fs.readdirSync(path, ...args);
+    },
     existsSync(path) {
       if (hiddenExistsPath !== null && String(path) === hiddenExistsPath) return false;
       return fs.existsSync(path);
@@ -70,8 +91,8 @@ after(() => {
   mock.reset();
 });
 
-function writeSession(root) {
-  const sessionDir = join(root, 'sessions', 'workspace-1', 'session-1');
+function writeSession(root, { workspace = 'workspace-1', session = 'session-1' } = {}) {
+  const sessionDir = join(root, 'sessions', workspace, session);
   const mainDir = join(sessionDir, 'agents', 'main');
   fs.mkdirSync(mainDir, { recursive: true });
   fs.writeFileSync(join(sessionDir, 'state.json'), REAL_STATE);
@@ -108,6 +129,7 @@ test('Kimi unchanged discovery never reads state or wire bodies', async () => {
     forbidSessionBodyReads = true;
     assert.deepEqual(provider.discover({
       lastCursor: () => initial[0].meta.currentCursor,
+      indexedSessions: () => [],
     }), []);
   } finally {
     forbidSessionBodyReads = false;
@@ -141,13 +163,18 @@ test('Kimi discovery retracts an indexed session that loses its last wire', asyn
 
   const [tombstone] = provider.discover({
     lastCursor: () => initial.meta.currentCursor,
+    indexedSessions: () => [{
+      sessionId: 'kimi:session-1',
+      jsonlPath: join(sessionDir, 'agents', 'main', 'wire.jsonl'),
+    }],
   });
   assert.equal(tombstone.key, sessionDir);
   assert.deepEqual(tombstone.meta.wireFiles, []);
   assert.equal(tombstone.meta.mode, 'tombstone');
+  assert.deepEqual(tombstone.retractSessionIds, ['kimi:session-1']);
 
   const parsed = drain(provider.parse(tombstone, initial.meta.currentCursor));
-  assert.deepEqual(parsed.values, [{ kind: 'delete-session', sessionId: 'kimi:session-1' }]);
+  assert.deepEqual(parsed.values, []);
   assert.match(parsed.cursor, /^\d+:0:kimi-manifest-v1:[A-Za-z0-9_-]+$/);
 });
 
@@ -175,9 +202,10 @@ test('Kimi full replay retracts an indexed session after its last wire disappear
     indexedSessions: () => [{ sessionId: 'kimi:session-1', jsonlPath: mainWire }],
   });
   assert.equal(tombstone.key, sessionDir);
+  assert.deepEqual(tombstone.retractSessionIds, ['kimi:session-1']);
   assert.deepEqual(
     drain(createKimiProvider({ rootDir: root }).parse(tombstone, null)).values,
-    [{ kind: 'delete-session', sessionId: 'kimi:session-1' }],
+    [],
   );
 });
 
@@ -250,6 +278,33 @@ test('Kimi discovery rejects a member added while its snapshot is being captured
   assert.match(issues[0].error, /changed while snapshotting/);
 });
 
+test('Kimi discovery rejects a directory move during the identity census', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-directory-race-');
+  const sessionDir = writeSession(root);
+  const mainWire = join(sessionDir, 'agents', 'main', 'wire.jsonl');
+  const movedSessionDir = join(root, 'sessions', 'workspace-2', 'session-1');
+  fs.mkdirSync(join(root, 'sessions', 'workspace-2'), { recursive: true });
+  const { createKimiProvider } = await loadKimiProvider('directory-race');
+  const provider = createKimiProvider({ rootDir: root });
+  const initial = provider.discover({ lastCursor: () => null })[0];
+  const issues = [];
+
+  moveBeforeSessionReadFrom = sessionDir;
+  moveBeforeSessionReadTo = movedSessionDir;
+  try {
+    assert.deepEqual(provider.discover({
+      lastCursor: key => key === sessionDir ? initial.meta.currentCursor : null,
+      indexedSessions: () => [{ sessionId: 'kimi:session-1', jsonlPath: mainWire }],
+      reportIncompleteInventory: issue => issues.push(issue),
+    }), []);
+  } finally {
+    moveBeforeSessionReadFrom = null;
+    moveBeforeSessionReadTo = null;
+  }
+  assert.equal(issues.length, 1);
+  assert.match(issues[0].error, /inventory changed during discovery/);
+});
+
 test('Kimi discovery emits a tombstone when an indexed session directory is deleted', async () => {
   const root = makeTempDir('obelisk-kimi-manifest-session-delete-');
   const sessionDir = writeSession(root);
@@ -265,9 +320,164 @@ test('Kimi discovery emits a tombstone when an indexed session directory is dele
   });
   assert.equal(tombstone.key, sessionDir);
   assert.equal(tombstone.meta.mode, 'tombstone');
-  assert.deepEqual(drain(provider.parse(tombstone, initial.meta.currentCursor)).values, [
-    { kind: 'delete-session', sessionId: 'kimi:session-1' },
-  ]);
+  assert.deepEqual(tombstone.retractSessionIds, ['kimi:session-1']);
+  assert.deepEqual(drain(provider.parse(tombstone, initial.meta.currentCursor)).values, []);
+});
+
+test('Kimi discovery fails closed when two directories share one session identity', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-duplicate-identity-');
+  const sessionDir = writeSession(root);
+  const mainWire = join(sessionDir, 'agents', 'main', 'wire.jsonl');
+  const duplicateDir = join(root, 'sessions', 'workspace-2', 'session-1');
+  fs.cpSync(sessionDir, duplicateDir, { recursive: true });
+  const { createKimiProvider } = await loadKimiProvider('duplicate-identity');
+  const issues = [];
+
+  const units = createKimiProvider({ rootDir: root }).discover({
+    lastCursor: () => null,
+    indexedSessions: () => [{ sessionId: 'kimi:session-1', jsonlPath: mainWire }],
+    reportIncompleteInventory: issue => issues.push(issue),
+  });
+  assert.deepEqual(units, []);
+  assert.equal(issues.length, 1);
+  assert.match(issues[0].error, /share identity kimi:session-1/);
+});
+
+test('Kimi discovery ignores a stale empty duplicate when one live identity remains', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-stale-empty-identity-');
+  const indexedSessionDir = writeSession(root);
+  const indexedWire = join(indexedSessionDir, 'agents', 'main', 'wire.jsonl');
+  const liveSessionDir = join(root, 'sessions', 'workspace-2', 'session-1');
+  fs.mkdirSync(join(root, 'sessions', 'workspace-2'), { recursive: true });
+  fs.renameSync(indexedSessionDir, liveSessionDir);
+  fs.mkdirSync(indexedSessionDir, { recursive: true });
+  const { createKimiProvider } = await loadKimiProvider('stale-empty-identity');
+  const issues = [];
+
+  const [replay] = createKimiProvider({ rootDir: root }).discover({
+    lastCursor: () => null,
+    indexedSessions: () => [{ sessionId: 'kimi:session-1', jsonlPath: indexedWire }],
+    reportIncompleteInventory: issue => issues.push(issue),
+  });
+  assert.equal(replay.key, liveSessionDir);
+  assert.equal(replay.meta.mode, 'replay');
+  assert.deepEqual(issues, []);
+});
+
+test('Kimi discovery retracts an old identity replaced at the same path', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-identity-replacement-');
+  const sessionDir = writeSession(root);
+  const mainWire = join(sessionDir, 'agents', 'main', 'wire.jsonl');
+  const { createKimiProvider } = await loadKimiProvider('identity-replacement');
+  const issues = [];
+
+  const [replay] = createKimiProvider({ rootDir: root }).discover({
+    lastCursor: () => null,
+    indexedSessions: () => [{ sessionId: 'kimi:replaced-session', jsonlPath: mainWire }],
+    reportIncompleteInventory: issue => issues.push(issue),
+  });
+  assert.equal(replay.sessionId, 'kimi:session-1');
+  assert.deepEqual(replay.retractSessionIds, ['kimi:replaced-session']);
+  assert.deepEqual(issues, []);
+});
+
+test('Kimi changed-path replacement preserves the old identity live at another path', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-move-replacement-');
+  const oldIdentityDir = writeSession(root, { workspace: 'workspace-2', session: 'old-session' });
+  const replacementDir = writeSession(root, { workspace: 'workspace-1', session: 'new-session' });
+  const replacementWire = join(replacementDir, 'agents', 'main', 'wire.jsonl');
+  const { createKimiProvider } = await loadKimiProvider('move-replacement');
+
+  const units = createKimiProvider({ rootDir: root }).discover({
+    lastCursor: () => null,
+    changedPaths: [replacementDir],
+    indexedSessions: () => [{ sessionId: 'kimi:old-session', jsonlPath: replacementWire }],
+  });
+  assert.deepEqual(
+    units.map(unit => ({ key: unit.key, sessionId: unit.sessionId, retract: unit.retractSessionIds ?? [] })),
+    [
+      { key: replacementDir, sessionId: 'kimi:new-session', retract: [] },
+      { key: oldIdentityDir, sessionId: 'kimi:old-session', retract: [] },
+    ],
+  );
+});
+
+test('Kimi tombstones revalidate an empty identity directory before publication', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-late-wire-');
+  const sessionsDir = join(root, 'sessions');
+  const emptySessionDir = join(sessionsDir, 'workspace-2', 'session-1');
+  const oldSessionDir = join(sessionsDir, 'workspace-1', 'session-1');
+  fs.mkdirSync(emptySessionDir, { recursive: true });
+  fs.writeFileSync(join(emptySessionDir, 'state.json'), REAL_STATE);
+  const { createKimiProvider } = await loadKimiProvider('late-wire');
+  const issues = [];
+
+  addWireOnSecondInventory = { sessionsDir, sessionDir: emptySessionDir };
+  inventoryReadCount = 0;
+  try {
+    assert.deepEqual(createKimiProvider({ rootDir: root }).discover({
+      lastCursor: () => null,
+      indexedSessions: () => [{
+        sessionId: 'kimi:session-1',
+        jsonlPath: join(oldSessionDir, 'agents', 'main', 'wire.jsonl'),
+      }],
+      reportIncompleteInventory: issue => issues.push(issue),
+    }), []);
+  } finally {
+    addWireOnSecondInventory = null;
+    inventoryReadCount = 0;
+  }
+  assert.equal(issues.length, 1);
+  assert.match(issues[0].error, /changed during discovery/);
+});
+
+test('Kimi tombstone parse rejects an identity that becomes live after discovery', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-post-discovery-tombstone-');
+  const emptySessionDir = join(root, 'sessions', 'workspace-2', 'session-1');
+  const oldSessionDir = join(root, 'sessions', 'workspace-1', 'session-1');
+  fs.mkdirSync(emptySessionDir, { recursive: true });
+  fs.writeFileSync(join(emptySessionDir, 'state.json'), REAL_STATE);
+  const { createKimiProvider } = await loadKimiProvider('post-discovery-tombstone');
+  const provider = createKimiProvider({ rootDir: root });
+  const [tombstone] = provider.discover({
+    lastCursor: () => null,
+    indexedSessions: () => [{
+      sessionId: 'kimi:session-1',
+      jsonlPath: join(oldSessionDir, 'agents', 'main', 'wire.jsonl'),
+    }],
+  });
+
+  const mainDir = join(emptySessionDir, 'agents', 'main');
+  fs.mkdirSync(mainDir, { recursive: true });
+  fs.writeFileSync(join(mainDir, 'wire.jsonl'), REAL_METADATA_LINE);
+  assert.throws(
+    () => drain(provider.parse(tombstone, null)),
+    /identity changed while indexing/,
+  );
+});
+
+test('Kimi moved replay rejects a duplicate that becomes live after discovery', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-post-discovery-move-');
+  const indexedSessionDir = writeSession(root);
+  const indexedWire = join(indexedSessionDir, 'agents', 'main', 'wire.jsonl');
+  const liveSessionDir = join(root, 'sessions', 'workspace-2', 'session-1');
+  fs.mkdirSync(join(root, 'sessions', 'workspace-2'), { recursive: true });
+  fs.renameSync(indexedSessionDir, liveSessionDir);
+  fs.mkdirSync(indexedSessionDir, { recursive: true });
+  const { createKimiProvider } = await loadKimiProvider('post-discovery-move');
+  const provider = createKimiProvider({ rootDir: root });
+  const [replay] = provider.discover({
+    lastCursor: () => null,
+    indexedSessions: () => [{ sessionId: 'kimi:session-1', jsonlPath: indexedWire }],
+  });
+
+  const mainDir = join(indexedSessionDir, 'agents', 'main');
+  fs.mkdirSync(mainDir, { recursive: true });
+  fs.writeFileSync(join(mainDir, 'wire.jsonl'), REAL_METADATA_LINE);
+  assert.throws(
+    () => drain(provider.parse(replay, null)),
+    /identity changed while indexing/,
+  );
 });
 
 test('Kimi discovery detects an append even when mtime is restored', async () => {

--- a/tests/kimi-manifest.test.mjs
+++ b/tests/kimi-manifest.test.mjs
@@ -8,13 +8,25 @@ import { join } from 'node:path';
 
 import { makeTempDir } from './temp-dirs.mjs';
 
+const REAL_STATE = fs.readFileSync(new URL('./fixtures/kimi/manifest-session/state.json', import.meta.url), 'utf8');
+const REAL_WIRE = fs.readFileSync(new URL('./fixtures/kimi/manifest-session/agents/main/wire.jsonl', import.meta.url), 'utf8');
+const REAL_METADATA_LINE = `${REAL_WIRE.split('\n')[0]}\n`;
+
 let forbidSessionBodyReads = false;
 let failingStatPath = null;
+let failingStatCode = 'ENOENT';
+let hiddenExistsPath = null;
+let addMemberDuringStatSessionDir = null;
+let addedMemberDuringStat = false;
 let mutateAfterReadPath = null;
 let mutatedAfterRead = false;
 const fsMock = mock.module('node:fs', {
   namedExports: {
     ...fs,
+    existsSync(path) {
+      if (hiddenExistsPath !== null && String(path) === hiddenExistsPath) return false;
+      return fs.existsSync(path);
+    },
     readFileSync(path, ...args) {
       if (forbidSessionBodyReads && (
         String(path).endsWith('state.json') || String(path).endsWith('wire.jsonl')
@@ -28,14 +40,24 @@ const fsMock = mock.module('node:fs', {
         && !mutatedAfterRead
       ) {
         mutatedAfterRead = true;
-        fs.appendFileSync(path, '{"type":"metadata","created_at":3}\n');
+        fs.appendFileSync(path, REAL_METADATA_LINE);
       }
       return result;
     },
     statSync(path, ...args) {
+      if (
+        addMemberDuringStatSessionDir !== null
+        && !addedMemberDuringStat
+        && String(path).endsWith(join('agents', 'main', 'wire.jsonl'))
+      ) {
+        addedMemberDuringStat = true;
+        const childDir = join(addMemberDuringStatSessionDir, 'agents', 'raced-child');
+        fs.mkdirSync(childDir, { recursive: true });
+        fs.writeFileSync(join(childDir, 'wire.jsonl'), REAL_METADATA_LINE);
+      }
       if (failingStatPath !== null && String(path) === failingStatPath) {
         const error = new Error(`simulated disappearance: ${path}`);
-        error.code = 'ENOENT';
+        error.code = failingStatCode;
         throw error;
       }
       return fs.statSync(path, ...args);
@@ -52,19 +74,8 @@ function writeSession(root) {
   const sessionDir = join(root, 'sessions', 'workspace-1', 'session-1');
   const mainDir = join(sessionDir, 'agents', 'main');
   fs.mkdirSync(mainDir, { recursive: true });
-  fs.writeFileSync(join(sessionDir, 'state.json'), JSON.stringify({
-    title: 'Manifest fixture',
-    workDir: '/tmp/kimi-manifest',
-  }));
-  fs.writeFileSync(join(mainDir, 'wire.jsonl'), [
-    JSON.stringify({ type: 'metadata', protocol_version: '1.5', created_at: 1 }),
-    JSON.stringify({
-      type: 'context.append_message',
-      time: 2,
-      message: { role: 'user', content: 'hello', toolCalls: [], origin: { kind: 'user' } },
-    }),
-    '',
-  ].join('\n'));
+  fs.writeFileSync(join(sessionDir, 'state.json'), REAL_STATE);
+  fs.writeFileSync(join(mainDir, 'wire.jsonl'), REAL_WIRE);
   return sessionDir;
 }
 
@@ -112,7 +123,7 @@ test('Kimi parse rejects a member added after discovery', async () => {
 
   const childDir = join(sessionDir, 'agents', 'child-1');
   fs.mkdirSync(childDir, { recursive: true });
-  fs.writeFileSync(join(childDir, 'wire.jsonl'), '{"type":"metadata"}\n');
+  fs.writeFileSync(join(childDir, 'wire.jsonl'), REAL_METADATA_LINE);
 
   assert.throws(
     () => drain(provider.parse(unit, null)),
@@ -144,7 +155,7 @@ test('Kimi discovery ignores an empty session that was never indexed', async () 
   const root = makeTempDir('obelisk-kimi-manifest-new-empty-');
   const sessionDir = join(root, 'sessions', 'workspace-1', 'empty-session');
   fs.mkdirSync(sessionDir, { recursive: true });
-  fs.writeFileSync(join(sessionDir, 'state.json'), '{"title":"New Session"}\n');
+  fs.writeFileSync(join(sessionDir, 'state.json'), REAL_STATE);
   const { createKimiProvider } = await loadKimiProvider('new-empty');
 
   assert.deepEqual(createKimiProvider({ rootDir: root }).discover({
@@ -190,6 +201,75 @@ test('Kimi discovery reports a member that disappears during snapshotting', asyn
   assert.match(issues[0].error, /ENOENT|simulated disappearance/);
 });
 
+test('Kimi discovery never treats an inaccessible member as deleted', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-permission-');
+  const sessionDir = writeSession(root);
+  const wirePath = join(sessionDir, 'agents', 'main', 'wire.jsonl');
+  const { createKimiProvider } = await loadKimiProvider('permission');
+  const provider = createKimiProvider({ rootDir: root });
+  const initial = provider.discover({ lastCursor: () => null })[0];
+  const issues = [];
+  hiddenExistsPath = wirePath;
+  failingStatPath = wirePath;
+  failingStatCode = 'EACCES';
+  try {
+    assert.deepEqual(provider.discover({
+      lastCursor: () => initial.meta.currentCursor,
+      reportIncompleteInventory: issue => issues.push(issue),
+    }), []);
+  } finally {
+    hiddenExistsPath = null;
+    failingStatPath = null;
+    failingStatCode = 'ENOENT';
+  }
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].path, sessionDir);
+  assert.match(issues[0].error, /EACCES|simulated disappearance/);
+});
+
+test('Kimi discovery rejects a member added while its snapshot is being captured', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-member-race-');
+  const sessionDir = writeSession(root);
+  const { createKimiProvider } = await loadKimiProvider('member-race');
+  const provider = createKimiProvider({ rootDir: root });
+  const initial = provider.discover({ lastCursor: () => null })[0];
+  const issues = [];
+  addMemberDuringStatSessionDir = sessionDir;
+  addedMemberDuringStat = false;
+  try {
+    assert.deepEqual(provider.discover({
+      lastCursor: () => initial.meta.currentCursor,
+      reportIncompleteInventory: issue => issues.push(issue),
+    }), []);
+  } finally {
+    addMemberDuringStatSessionDir = null;
+    addedMemberDuringStat = false;
+  }
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].path, sessionDir);
+  assert.match(issues[0].error, /changed while snapshotting/);
+});
+
+test('Kimi discovery emits a tombstone when an indexed session directory is deleted', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-session-delete-');
+  const sessionDir = writeSession(root);
+  const mainWire = join(sessionDir, 'agents', 'main', 'wire.jsonl');
+  const { createKimiProvider } = await loadKimiProvider('session-delete');
+  const provider = createKimiProvider({ rootDir: root });
+  const initial = provider.discover({ lastCursor: () => null })[0];
+  fs.rmSync(sessionDir, { recursive: true });
+
+  const [tombstone] = provider.discover({
+    lastCursor: key => key === sessionDir ? initial.meta.currentCursor : null,
+    indexedSessions: () => [{ sessionId: 'kimi:session-1', jsonlPath: mainWire }],
+  });
+  assert.equal(tombstone.key, sessionDir);
+  assert.equal(tombstone.meta.mode, 'tombstone');
+  assert.deepEqual(drain(provider.parse(tombstone, initial.meta.currentCursor)).values, [
+    { kind: 'delete-session', sessionId: 'kimi:session-1' },
+  ]);
+});
+
 test('Kimi discovery detects an append even when mtime is restored', async () => {
   const root = makeTempDir('obelisk-kimi-manifest-same-mtime-append-');
   const sessionDir = writeSession(root);
@@ -199,7 +279,7 @@ test('Kimi discovery detects an append even when mtime is restored', async () =>
   const initial = provider.discover({ lastCursor: () => null })[0];
   const before = fs.statSync(wirePath);
 
-  fs.appendFileSync(wirePath, '{"type":"metadata","created_at":3}\n');
+  fs.appendFileSync(wirePath, REAL_METADATA_LINE);
   fs.utimesSync(wirePath, before.atime, before.mtime);
 
   assert.deepEqual(provider.discover({
@@ -207,9 +287,7 @@ test('Kimi discovery detects an append even when mtime is restored', async () =>
   }).map(unit => unit.key), [sessionDir]);
 });
 
-test('Kimi discovery detects a same-size rewrite with restored mtime', {
-  skip: process.platform === 'win32' && 'Windows ctime is creation time',
-}, async () => {
+test('Kimi discovery detects a same-size rewrite with restored mtime', async () => {
   const root = makeTempDir('obelisk-kimi-manifest-same-size-rewrite-');
   const sessionDir = writeSession(root);
   const wirePath = join(sessionDir, 'agents', 'main', 'wire.jsonl');
@@ -218,7 +296,7 @@ test('Kimi discovery detects a same-size rewrite with restored mtime', {
   const initial = provider.discover({ lastCursor: () => null })[0];
   const before = fs.statSync(wirePath);
   const original = fs.readFileSync(wirePath, 'utf8');
-  const rewritten = original.replace('hello', 'hullo');
+  const rewritten = original.replace('"runtimeId":"local"', '"runtimeId":"focal"');
   assert.equal(Buffer.byteLength(rewritten), Buffer.byteLength(original));
 
   fs.writeFileSync(wirePath, rewritten);
@@ -234,7 +312,7 @@ test('Kimi discovery detects removal of one member from a multi-wire session', a
   const sessionDir = writeSession(root);
   const childDir = join(sessionDir, 'agents', 'child-1');
   fs.mkdirSync(childDir, { recursive: true });
-  fs.writeFileSync(join(childDir, 'wire.jsonl'), '{"type":"metadata"}\n');
+  fs.writeFileSync(join(childDir, 'wire.jsonl'), REAL_METADATA_LINE);
   const { createKimiProvider } = await loadKimiProvider('member-removal');
   const provider = createKimiProvider({ rootDir: root });
   const initial = provider.discover({ lastCursor: () => null })[0];

--- a/tests/kimi-manifest.test.mjs
+++ b/tests/kimi-manifest.test.mjs
@@ -1,0 +1,267 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { after, test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import { join } from 'node:path';
+
+import { makeTempDir } from './temp-dirs.mjs';
+
+let forbidSessionBodyReads = false;
+let failingStatPath = null;
+let mutateAfterReadPath = null;
+let mutatedAfterRead = false;
+const fsMock = mock.module('node:fs', {
+  namedExports: {
+    ...fs,
+    readFileSync(path, ...args) {
+      if (forbidSessionBodyReads && (
+        String(path).endsWith('state.json') || String(path).endsWith('wire.jsonl')
+      )) {
+        throw new Error(`unchanged discovery read a session body: ${path}`);
+      }
+      const result = fs.readFileSync(path, ...args);
+      if (
+        mutateAfterReadPath !== null
+        && String(path) === mutateAfterReadPath
+        && !mutatedAfterRead
+      ) {
+        mutatedAfterRead = true;
+        fs.appendFileSync(path, '{"type":"metadata","created_at":3}\n');
+      }
+      return result;
+    },
+    statSync(path, ...args) {
+      if (failingStatPath !== null && String(path) === failingStatPath) {
+        const error = new Error(`simulated disappearance: ${path}`);
+        error.code = 'ENOENT';
+        throw error;
+      }
+      return fs.statSync(path, ...args);
+    },
+  },
+});
+
+after(() => {
+  fsMock.restore();
+  mock.reset();
+});
+
+function writeSession(root) {
+  const sessionDir = join(root, 'sessions', 'workspace-1', 'session-1');
+  const mainDir = join(sessionDir, 'agents', 'main');
+  fs.mkdirSync(mainDir, { recursive: true });
+  fs.writeFileSync(join(sessionDir, 'state.json'), JSON.stringify({
+    title: 'Manifest fixture',
+    workDir: '/tmp/kimi-manifest',
+  }));
+  fs.writeFileSync(join(mainDir, 'wire.jsonl'), [
+    JSON.stringify({ type: 'metadata', protocol_version: '1.5', created_at: 1 }),
+    JSON.stringify({
+      type: 'context.append_message',
+      time: 2,
+      message: { role: 'user', content: 'hello', toolCalls: [], origin: { kind: 'user' } },
+    }),
+    '',
+  ].join('\n'));
+  return sessionDir;
+}
+
+function drain(generator) {
+  const values = [];
+  let step = generator.next();
+  while (!step.done) {
+    values.push(step.value);
+    step = generator.next();
+  }
+  return { values, cursor: step.value };
+}
+
+async function loadKimiProvider(label) {
+  const moduleUrl = new URL('../packages/core/src/providers/kimi.ts', import.meta.url);
+  return import(`${moduleUrl.href}?manifest-test=${label}-${Date.now()}`);
+}
+
+test('Kimi unchanged discovery never reads state or wire bodies', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-no-body-read-');
+  const sessionDir = writeSession(root);
+  try {
+    const { createKimiProvider } = await loadKimiProvider('no-body-read');
+    const provider = createKimiProvider({ rootDir: root });
+    const initial = provider.discover({ lastCursor: () => null });
+    assert.equal(initial.length, 1);
+    assert.equal(initial[0].key, sessionDir);
+    assert.equal(initial[0].meta.mode, 'replay');
+
+    forbidSessionBodyReads = true;
+    assert.deepEqual(provider.discover({
+      lastCursor: () => initial[0].meta.currentCursor,
+    }), []);
+  } finally {
+    forbidSessionBodyReads = false;
+  }
+});
+
+test('Kimi parse rejects a member added after discovery', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-added-member-');
+  const sessionDir = writeSession(root);
+  const { createKimiProvider } = await loadKimiProvider('added-member');
+  const provider = createKimiProvider({ rootDir: root });
+  const unit = provider.discover({ lastCursor: () => null })[0];
+
+  const childDir = join(sessionDir, 'agents', 'child-1');
+  fs.mkdirSync(childDir, { recursive: true });
+  fs.writeFileSync(join(childDir, 'wire.jsonl'), '{"type":"metadata"}\n');
+
+  assert.throws(
+    () => drain(provider.parse(unit, null)),
+    /Kimi session changed while indexing/,
+  );
+});
+
+test('Kimi discovery retracts an indexed session that loses its last wire', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-last-wire-');
+  const sessionDir = writeSession(root);
+  const { createKimiProvider } = await loadKimiProvider('last-wire');
+  const provider = createKimiProvider({ rootDir: root });
+  const initial = provider.discover({ lastCursor: () => null })[0];
+  fs.rmSync(join(sessionDir, 'agents', 'main', 'wire.jsonl'));
+
+  const [tombstone] = provider.discover({
+    lastCursor: () => initial.meta.currentCursor,
+  });
+  assert.equal(tombstone.key, sessionDir);
+  assert.deepEqual(tombstone.meta.wireFiles, []);
+  assert.equal(tombstone.meta.mode, 'tombstone');
+
+  const parsed = drain(provider.parse(tombstone, initial.meta.currentCursor));
+  assert.deepEqual(parsed.values, [{ kind: 'delete-session', sessionId: 'kimi:session-1' }]);
+  assert.match(parsed.cursor, /^\d+:0:kimi-manifest-v1:[A-Za-z0-9_-]+$/);
+});
+
+test('Kimi discovery ignores an empty session that was never indexed', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-new-empty-');
+  const sessionDir = join(root, 'sessions', 'workspace-1', 'empty-session');
+  fs.mkdirSync(sessionDir, { recursive: true });
+  fs.writeFileSync(join(sessionDir, 'state.json'), '{"title":"New Session"}\n');
+  const { createKimiProvider } = await loadKimiProvider('new-empty');
+
+  assert.deepEqual(createKimiProvider({ rootDir: root }).discover({
+    lastCursor: () => null,
+  }), []);
+});
+
+test('Kimi full replay retracts an indexed session after its last wire disappears', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-full-replay-tombstone-');
+  const sessionDir = writeSession(root);
+  const mainWire = join(sessionDir, 'agents', 'main', 'wire.jsonl');
+  fs.rmSync(mainWire);
+  const { createKimiProvider } = await loadKimiProvider('full-replay-tombstone');
+
+  const [tombstone] = createKimiProvider({ rootDir: root }).discover({
+    lastCursor: () => null,
+    indexedSessions: () => [{ sessionId: 'kimi:session-1', jsonlPath: mainWire }],
+  });
+  assert.equal(tombstone.key, sessionDir);
+  assert.deepEqual(
+    drain(createKimiProvider({ rootDir: root }).parse(tombstone, null)).values,
+    [{ kind: 'delete-session', sessionId: 'kimi:session-1' }],
+  );
+});
+
+test('Kimi discovery reports a member that disappears during snapshotting', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-stat-race-');
+  const sessionDir = writeSession(root);
+  const wirePath = join(sessionDir, 'agents', 'main', 'wire.jsonl');
+  const { createKimiProvider } = await loadKimiProvider('stat-race');
+  const issues = [];
+  failingStatPath = wirePath;
+  try {
+    assert.deepEqual(createKimiProvider({ rootDir: root }).discover({
+      lastCursor: () => null,
+      reportIncompleteInventory: issue => issues.push(issue),
+    }), []);
+  } finally {
+    failingStatPath = null;
+  }
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].path, sessionDir);
+  assert.match(issues[0].error, /ENOENT|simulated disappearance/);
+});
+
+test('Kimi discovery detects an append even when mtime is restored', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-same-mtime-append-');
+  const sessionDir = writeSession(root);
+  const wirePath = join(sessionDir, 'agents', 'main', 'wire.jsonl');
+  const { createKimiProvider } = await loadKimiProvider('same-mtime-append');
+  const provider = createKimiProvider({ rootDir: root });
+  const initial = provider.discover({ lastCursor: () => null })[0];
+  const before = fs.statSync(wirePath);
+
+  fs.appendFileSync(wirePath, '{"type":"metadata","created_at":3}\n');
+  fs.utimesSync(wirePath, before.atime, before.mtime);
+
+  assert.deepEqual(provider.discover({
+    lastCursor: () => initial.meta.currentCursor,
+  }).map(unit => unit.key), [sessionDir]);
+});
+
+test('Kimi discovery detects a same-size rewrite with restored mtime', {
+  skip: process.platform === 'win32' && 'Windows ctime is creation time',
+}, async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-same-size-rewrite-');
+  const sessionDir = writeSession(root);
+  const wirePath = join(sessionDir, 'agents', 'main', 'wire.jsonl');
+  const { createKimiProvider } = await loadKimiProvider('same-size-rewrite');
+  const provider = createKimiProvider({ rootDir: root });
+  const initial = provider.discover({ lastCursor: () => null })[0];
+  const before = fs.statSync(wirePath);
+  const original = fs.readFileSync(wirePath, 'utf8');
+  const rewritten = original.replace('hello', 'hullo');
+  assert.equal(Buffer.byteLength(rewritten), Buffer.byteLength(original));
+
+  fs.writeFileSync(wirePath, rewritten);
+  fs.utimesSync(wirePath, before.atime, before.mtime);
+
+  assert.deepEqual(provider.discover({
+    lastCursor: () => initial.meta.currentCursor,
+  }).map(unit => unit.key), [sessionDir]);
+});
+
+test('Kimi discovery detects removal of one member from a multi-wire session', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-member-removal-');
+  const sessionDir = writeSession(root);
+  const childDir = join(sessionDir, 'agents', 'child-1');
+  fs.mkdirSync(childDir, { recursive: true });
+  fs.writeFileSync(join(childDir, 'wire.jsonl'), '{"type":"metadata"}\n');
+  const { createKimiProvider } = await loadKimiProvider('member-removal');
+  const provider = createKimiProvider({ rootDir: root });
+  const initial = provider.discover({ lastCursor: () => null })[0];
+
+  fs.rmSync(childDir, { recursive: true });
+
+  assert.deepEqual(provider.discover({
+    lastCursor: () => initial.meta.currentCursor,
+  }).map(unit => unit.key), [sessionDir]);
+});
+
+test('Kimi parse rejects a wire append that races projection', async () => {
+  const root = makeTempDir('obelisk-kimi-manifest-parse-race-');
+  const sessionDir = writeSession(root);
+  const wirePath = join(sessionDir, 'agents', 'main', 'wire.jsonl');
+  const { createKimiProvider } = await loadKimiProvider('parse-race');
+  const provider = createKimiProvider({ rootDir: root });
+  const unit = provider.discover({ lastCursor: () => null })[0];
+  mutateAfterReadPath = wirePath;
+  mutatedAfterRead = false;
+  try {
+    assert.throws(
+      () => drain(provider.parse(unit, null)),
+      /Kimi session changed while indexing/,
+    );
+  } finally {
+    mutateAfterReadPath = null;
+    mutatedAfterRead = false;
+  }
+});

--- a/tests/kimi-parse.test.mjs
+++ b/tests/kimi-parse.test.mjs
@@ -69,10 +69,20 @@ test('kimi provider discovers a changed session directory and returns a stable c
   assert.equal(units.length, 1);
   assert.equal(units[0].key, sessionDir);
   assert.equal(units[0].sessionId, 'kimi:session-native-1');
-  assert.match(units[0].meta.currentCursor, /^\d+(?:\.\d+)?:\d+$/);
+  assert.match(
+    units[0].meta.currentCursor,
+    /^\d+:0:kimi-manifest-v1:[A-Za-z0-9_-]{43}$/,
+  );
 
   const unchanged = provider.discover({ lastCursor: () => units[0].meta.currentCursor });
   assert.deepEqual(unchanged, []);
+
+  const legacyCursor = units[0].meta.currentCursor.split(':').slice(0, 2).join(':');
+  assert.deepEqual(
+    provider.discover({ lastCursor: () => legacyCursor }).map(unit => unit.key),
+    [sessionDir],
+    'a legacy cursor cannot prove that the session is unchanged',
+  );
 });
 
 test('kimi provider folds main and subagent wire logs into the canonical transcript language', () => {


### PR DESCRIPTION
## Summary

- Replaces Kimi's corpus-wide line-count cursor with a versioned, metadata-only session manifest.
- Preserves atomic full replay for changed sessions while making unchanged discovery independent of wire byte volume.
- Keeps the canonical transcript marker at v6 and migrates legacy cursors per unit through one fail-closed replay.

## Scope

- In scope:
  - private `kimi-manifest.ts` snapshot, cursor encoding, and classification
  - member addition/removal, last-wire tombstones, and whole-session-directory deletion
  - discovery/parse torn-snapshot guards and transient inventory races
  - legacy cursor replay into `kimi-manifest-v1`
  - ADR, sanitized real Kimi v2 fixture, integration tests, and explicit CI coverage
- Out of scope:
  - cursor-only migration from the legacy `maxMtime:totalLines` format
  - Kimi canonical transcript projection changes or a v7 marker bump
  - schema, persist, provider-interface, or app-orchestration changes

## Key Changes

- Hashes a stable, sorted manifest of member-relative paths plus dev/inode/size/mtime/ctime metadata; unchanged discovery never reads state or wire bodies.
- Captures member metadata twice so additions/removals during discovery are rejected instead of committing a torn inventory.
- Treats listed-member stat failures, including permission errors and disappearance races, as incomplete inventory rather than deletion.
- Separates the provider-wide metadata/identity census from changed-path routing, so moves, workspace-level events, round trips, and same-path replacements reconcile by session identity rather than unit order.
- Treats `changedPaths` only as invalidation hints; tombstones and replacement retractions require a complete census and use `IndexUnit.retractSessionIds`.
- Carries identity-census witnesses into destructive and moved units, then revalidates them before and after parse inside the unit transaction so observation races roll back instead of deleting last-good data.
- Distinguishes duplicate live identities from stale empty directories and fails ambiguous live duplicates closed.
- Replays legacy or unknown cursors once, then persists `maxMtime:0:kimi-manifest-v1:<digest>` atomically with the unit.

## Validation

- `npm test` outside the filesystem sandbox: pass, 605/605 tests in 62.2 s on the transaction-witness candidate; the final cursor-skip delta passed its 52/52 targeted suite.
- Final commit CI: pass on Node 22 for macOS, Ubuntu, and Windows; CodeQL pass.
- `npm run typecheck`: pass for root and app TypeScript configurations.
- `npx eslint packages/core/src/providers/kimi-manifest.ts packages/core/src/providers/kimi.ts tests/kimi-manifest.test.mjs tests/app-kimi-index.test.mjs`: pass, 0 errors and 0 warnings.
- Final targeted Kimi provider/integration/inventory suites: pass, 52/52.
- `git diff --check`: pass.
- Real 418-session Kimi corpus:
  - previous unchanged discovery: 1.210 s while returning zero units
  - final provider-wide identity census: 34-36 ms warm while returning only the current changed unit
  - the earlier cursor-clean measurement returned zero units in 32-33 ms; the identity census adds only directory metadata work
  - first legacy migration: 16.17 s for 418 units / 59,995 records, complete with no skips
  - following full incremental build before the double-census hardening: 583 ms total; Kimi discovery 19.9 ms and zero Kimi units

## Risks and Rollback

- The first unhinted build after upgrade replays every legacy Kimi unit once; the measured local migration was 16.17 s. Per-unit cursor commits make failures independently retryable.
- Same-size rewrites with restored mtime rely on ctime/inode support; changed-path invalidations remain authoritative where a platform exposes no metadata change.
- Reverting restores the old cursor writer. Existing manifest-v1 cursors fail its equality check and are conservatively replayed back into the legacy format.

## Related Issues

- Related to #125
- Related to #41
- Related to #87

Closes #128
