### PR TITLE
[Core] Skip unchanged canonical replay writes

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -39,6 +39,9 @@ jobs:
           npm --prefix app ci
           node --test app/tests/electron-vite-schema-asset.mjs
 
+      - name: Verify shared persistence idempotency
+        run: node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/persist-idempotency.test.mjs tests/persist.test.mjs tests/indexer-upsert-drift.test.mjs
+
       - name: Verify adaptive watcher package
         run: |
           npm run build --workspace @obelisk-apps/adaptive-watcher

--- a/docs/adr/0001-parse-core-and-persist-layers.md
+++ b/docs/adr/0001-parse-core-and-persist-layers.md
@@ -61,6 +61,30 @@ binding-agnostic and does not need a per-binding implementation.
   (CLI) and `better-sqlite3` (app) run the same code — there is no
   per-binding persist layer.
 
+**Amendment (2026-09-01): idempotent exact-value persistence.** Snapshot
+providers may correctly replay a complete canonical session after a small
+source change. The shared persist layer must not turn an identical replay into
+physical database churn. `messages`, `tool_calls`, and `tool_results` therefore
+use primary-key UPSERTs whose update branch runs only when at least one
+authoritative persisted value differs, using NULL-safe comparison. Message
+comparison deliberately excludes `turn_duration_ms`, which is owned by the
+separate `message-turn-duration` record; that targeted update is itself skipped
+when the stored duration already matches. A skipped message update also skips
+the schema's `AFTER UPDATE` FTS maintenance, while a real message change retains
+the existing atomic content-row and FTS update behavior. Tool rowids remain
+stable across both identical and changed replay, preserving insertion order for
+consumers such as workflow-parent healing.
+
+This is a table-specific rule, not permission to mechanically replace every
+write in `persist()`. Sessions derive merge values and counts from prior state;
+subagents and workflow agents merge multiple contributors with `COALESCE`;
+summaries and workflows retain whole-row replacement semantics; and
+`index_state` must continue publishing provider progress. Any later no-op
+optimization for those records must compare their computed post-merge state and
+preserve their individual contracts. No provider cursor or canonical transcript
+marker changes for this amendment because the projected canonical values do not
+change.
+
 **Two indexing modes** share all of the above and differ only in trigger:
 **daemon mode** (the app, and potentially a future CLI daemon, watches and keeps
 the index fresh) and **passive pull mode** (a CLI command indexes on invocation

--- a/packages/core/src/persist.ts
+++ b/packages/core/src/persist.ts
@@ -10,10 +10,11 @@
 // only place that knows the schema. Adapters stay pure.
 //
 // Write semantics are the canonical ones reconciled from the drift: messages
-// upsert via ON CONFLICT; sessions merge with any existing row (started_at MIN,
-// ended_at MAX, message_count reset-or-accumulate, fill-if-null for the rest);
-// turn-duration is a targeted UPDATE; delete-session cascades. The generator's
-// return value is the new cursor, persisted verbatim into index_state.
+// and tool rows upsert only when canonical values differ; sessions merge with
+// any existing row (started_at MIN, ended_at MAX, message_count
+// reset-or-accumulate, fill-if-null for the rest); turn-duration is a targeted
+// conditional UPDATE; delete-session cascades. The generator's return value is
+// the new cursor, persisted verbatim into index_state.
 
 import type { Cursor, TranscriptRecord, IndexUnit } from './providers/types.ts';
 import type { SqliteDb } from './sqlite-types.ts';
@@ -33,9 +34,54 @@ function statements(db: SqliteDb) {
         visibility=excluded.visibility, model=excluded.model,
         is_sidechain=excluded.is_sidechain, agent_id=excluded.agent_id,
         input_tokens=excluded.input_tokens, output_tokens=excluded.output_tokens,
-        cwd=excluded.cwd, skill=excluded.skill, source=excluded.source`),
-    tc: db.prepare('INSERT OR REPLACE INTO tool_calls (id,message_uuid,session_id,name,presentation,input_json,file_path) VALUES (?,?,?,?,?,?,?)'),
-    tr: db.prepare('INSERT OR REPLACE INTO tool_results (tool_use_id,message_uuid,session_id,content,file_path,is_error) VALUES (?,?,?,?,?,?)'),
+        cwd=excluded.cwd, skill=excluded.skill, source=excluded.source
+      WHERE messages.session_id IS NOT excluded.session_id
+        OR messages.type IS NOT excluded.type
+        OR messages.parent_uuid IS NOT excluded.parent_uuid
+        OR messages.timestamp IS NOT excluded.timestamp
+        OR messages.role IS NOT excluded.role
+        OR messages.text IS NOT excluded.text
+        OR messages.content_type IS NOT excluded.content_type
+        OR messages.is_meta IS NOT excluded.is_meta
+        OR messages.visibility IS NOT excluded.visibility
+        OR messages.model IS NOT excluded.model
+        OR messages.is_sidechain IS NOT excluded.is_sidechain
+        OR messages.agent_id IS NOT excluded.agent_id
+        OR messages.input_tokens IS NOT excluded.input_tokens
+        OR messages.output_tokens IS NOT excluded.output_tokens
+        OR messages.cwd IS NOT excluded.cwd
+        OR messages.skill IS NOT excluded.skill
+        OR messages.source IS NOT excluded.source`),
+    tc: db.prepare(`
+      INSERT INTO tool_calls (id,message_uuid,session_id,name,presentation,input_json,file_path)
+      VALUES (?,?,?,?,?,?,?)
+      ON CONFLICT(id) DO UPDATE SET
+        message_uuid=excluded.message_uuid,
+        session_id=excluded.session_id,
+        name=excluded.name,
+        presentation=excluded.presentation,
+        input_json=excluded.input_json,
+        file_path=excluded.file_path
+      WHERE tool_calls.message_uuid IS NOT excluded.message_uuid
+        OR tool_calls.session_id IS NOT excluded.session_id
+        OR tool_calls.name IS NOT excluded.name
+        OR tool_calls.presentation IS NOT excluded.presentation
+        OR tool_calls.input_json IS NOT excluded.input_json
+        OR tool_calls.file_path IS NOT excluded.file_path`),
+    tr: db.prepare(`
+      INSERT INTO tool_results (tool_use_id,message_uuid,session_id,content,file_path,is_error)
+      VALUES (?,?,?,?,?,?)
+      ON CONFLICT(tool_use_id) DO UPDATE SET
+        message_uuid=excluded.message_uuid,
+        session_id=excluded.session_id,
+        content=excluded.content,
+        file_path=excluded.file_path,
+        is_error=excluded.is_error
+      WHERE tool_results.message_uuid IS NOT excluded.message_uuid
+        OR tool_results.session_id IS NOT excluded.session_id
+        OR tool_results.content IS NOT excluded.content
+        OR tool_results.file_path IS NOT excluded.file_path
+        OR tool_results.is_error IS NOT excluded.is_error`),
     sum: db.prepare('INSERT OR REPLACE INTO summaries (id,session_id,timestamp,source,content,visibility,input_tokens,output_tokens) VALUES (?,?,?,?,?,?,?,?)'),
     ses: db.prepare('INSERT OR REPLACE INTO sessions (id,title,project,project_path,started_at,ended_at,git_branch,version,message_count,jsonl_path,source) VALUES (?,?,?,?,?,?,?,?,?,?,?)'),
     sub: db.prepare(`
@@ -67,7 +113,7 @@ function statements(db: SqliteDb) {
         duration_ms=COALESCE(excluded.duration_ms, workflow_agents.duration_ms),
         tokens=COALESCE(excluded.tokens, workflow_agents.tokens),
         tool_calls=COALESCE(excluded.tool_calls, workflow_agents.tool_calls)`),
-    turn: db.prepare('UPDATE messages SET turn_duration_ms=? WHERE uuid=?'),
+    turn: db.prepare('UPDATE messages SET turn_duration_ms=? WHERE uuid=? AND turn_duration_ms IS NOT ?'),
     idx: db.prepare('INSERT OR REPLACE INTO index_state (jsonl_path,mtime,lines_processed,cursor) VALUES (?,?,?,?)'),
     getSession: db.prepare('SELECT * FROM sessions WHERE id=?'),
   };
@@ -124,7 +170,7 @@ export function persist(db: SqliteDb, unit: IndexUnit, gen: Generator<Transcript
         st.wa.run(r.agent_id, r.run_id, r.session_id, r.agent_type ?? null, r.description ?? null, r.phase ?? null, r.label ?? null, r.model ?? null, r.state ?? null, r.duration_ms ?? null, r.tokens ?? null, r.tool_calls ?? null);
         break;
       case 'message-turn-duration':
-        st.turn.run(r.turn_duration_ms, r.uuid);
+        st.turn.run(r.turn_duration_ms, r.uuid, r.turn_duration_ms);
         break;
       case 'session': {
         const prev = st.getSession.get(r.id);

--- a/tests/persist-idempotency.test.mjs
+++ b/tests/persist-idempotency.test.mjs
@@ -1,0 +1,318 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { healWorkflowParentLinks } from '../packages/core/src/indexer.ts';
+import { persist } from '../packages/core/src/persist.ts';
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require('node:sqlite');
+const appDir = fileURLToPath(new URL('../app/', import.meta.url));
+const BetterSqlite3 = require(require.resolve('better-sqlite3', { paths: [appDir] }));
+const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+
+const bindings = [
+  ['node:sqlite', () => new DatabaseSync(':memory:')],
+  ['better-sqlite3', () => new BetterSqlite3(':memory:')],
+];
+
+const BASE_MESSAGE = {
+  kind: 'message',
+  uuid: 'message-1',
+  session_id: 'session-1',
+  type: 'assistant',
+  parent_uuid: null,
+  timestamp: '2026-09-01T10:00:00.000Z',
+  role: 'assistant',
+  text: 'stable searchable text',
+  content_type: 'text',
+  is_meta: 0,
+  visibility: 'visible',
+  model: 'model-1',
+  is_sidechain: 0,
+  agent_id: null,
+  input_tokens: 10,
+  output_tokens: 20,
+  cwd: '/workspace',
+  skill: null,
+  source: 'codex',
+};
+
+const BASE_TOOL_CALL = {
+  kind: 'tool_call',
+  id: 'call-1',
+  message_uuid: 'message-1',
+  session_id: 'session-1',
+  name: 'exec_command',
+  presentation: 'default',
+  input_json: '{"cmd":"true"}',
+  file_path: null,
+};
+
+const BASE_TOOL_RESULT = {
+  kind: 'tool_result',
+  tool_use_id: 'call-1',
+  message_uuid: 'message-1',
+  session_id: 'session-1',
+  content: 'done',
+  file_path: null,
+  is_error: 0,
+};
+
+function installWriteAudit(db) {
+  db.exec(`
+    CREATE TABLE write_audit (table_name TEXT NOT NULL, operation TEXT NOT NULL);
+    CREATE TRIGGER audit_messages_insert AFTER INSERT ON messages BEGIN
+      INSERT INTO write_audit VALUES ('messages', 'insert');
+    END;
+    CREATE TRIGGER audit_messages_update AFTER UPDATE ON messages BEGIN
+      INSERT INTO write_audit VALUES ('messages', 'update');
+    END;
+    CREATE TRIGGER audit_messages_delete AFTER DELETE ON messages BEGIN
+      INSERT INTO write_audit VALUES ('messages', 'delete');
+    END;
+    CREATE TRIGGER audit_tool_calls_insert AFTER INSERT ON tool_calls BEGIN
+      INSERT INTO write_audit VALUES ('tool_calls', 'insert');
+    END;
+    CREATE TRIGGER audit_tool_calls_update AFTER UPDATE ON tool_calls BEGIN
+      INSERT INTO write_audit VALUES ('tool_calls', 'update');
+    END;
+    CREATE TRIGGER audit_tool_calls_delete AFTER DELETE ON tool_calls BEGIN
+      INSERT INTO write_audit VALUES ('tool_calls', 'delete');
+    END;
+    CREATE TRIGGER audit_tool_results_insert AFTER INSERT ON tool_results BEGIN
+      INSERT INTO write_audit VALUES ('tool_results', 'insert');
+    END;
+    CREATE TRIGGER audit_tool_results_update AFTER UPDATE ON tool_results BEGIN
+      INSERT INTO write_audit VALUES ('tool_results', 'update');
+    END;
+    CREATE TRIGGER audit_tool_results_delete AFTER DELETE ON tool_results BEGIN
+      INSERT INTO write_audit VALUES ('tool_results', 'delete');
+    END;
+  `);
+}
+
+function* canonicalRecords({ message = {}, toolCall = {}, toolResult = {}, duration = 42 } = {}) {
+  yield { ...BASE_MESSAGE, ...message };
+  yield { ...BASE_TOOL_CALL, ...toolCall };
+  yield { ...BASE_TOOL_RESULT, ...toolResult };
+  yield { kind: 'message-turn-duration', uuid: 'message-1', turn_duration_ms: duration };
+  return null;
+}
+
+function* oneRecord(record) {
+  yield record;
+  return null;
+}
+
+for (const [binding, openDb] of bindings) {
+  test(`${binding}: identical replay performs no canonical writes`, () => {
+    const db = openDb();
+    db.exec(SCHEMA);
+    installWriteAudit(db);
+    const unit = { key: 'unit-1', sessionId: 'session-1' };
+
+    persist(db, unit, canonicalRecords());
+    const rowids = {
+      message: db.prepare('SELECT rowid FROM messages WHERE uuid=?').get('message-1').rowid,
+      toolCall: db.prepare('SELECT rowid FROM tool_calls WHERE id=?').get('call-1').rowid,
+      toolResult: db.prepare('SELECT rowid FROM tool_results WHERE tool_use_id=?').get('call-1').rowid,
+    };
+    db.prepare('DELETE FROM write_audit').run();
+
+    persist(db, unit, canonicalRecords());
+
+    assert.deepEqual(db.prepare('SELECT * FROM write_audit').all(), []);
+    assert.deepEqual(
+      {
+        message: db.prepare('SELECT rowid FROM messages WHERE uuid=?').get('message-1').rowid,
+        toolCall: db.prepare('SELECT rowid FROM tool_calls WHERE id=?').get('call-1').rowid,
+        toolResult: db.prepare('SELECT rowid FROM tool_results WHERE tool_use_id=?').get('call-1').rowid,
+      },
+      rowids,
+    );
+    assert.equal(
+      db.prepare("SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH 'searchable'").get().count,
+      1,
+    );
+    db.close();
+  });
+
+  test(`${binding}: changed and NULL-transitioned values update in place`, () => {
+    const db = openDb();
+    db.exec(SCHEMA);
+    installWriteAudit(db);
+    const unit = { key: 'unit-1', sessionId: 'session-1' };
+    const changed = {
+      message: {
+        text: 'changed searchable text',
+        agent_id: 'agent-1',
+        input_tokens: null,
+        skill: 'review',
+      },
+      toolCall: {
+        presentation: 'skill',
+        input_json: '{"cmd":"false"}',
+        file_path: '/tmp/input',
+      },
+      toolResult: {
+        content: 'changed output',
+        file_path: '/tmp/output',
+        is_error: 1,
+      },
+      duration: null,
+    };
+
+    persist(db, unit, canonicalRecords());
+    const rowids = {
+      message: db.prepare('SELECT rowid FROM messages WHERE uuid=?').get('message-1').rowid,
+      toolCall: db.prepare('SELECT rowid FROM tool_calls WHERE id=?').get('call-1').rowid,
+      toolResult: db.prepare('SELECT rowid FROM tool_results WHERE tool_use_id=?').get('call-1').rowid,
+    };
+    db.prepare('DELETE FROM write_audit').run();
+
+    persist(db, unit, canonicalRecords(changed));
+
+    assert.deepEqual(
+      { ...db.prepare('SELECT text,agent_id,input_tokens,skill,turn_duration_ms FROM messages WHERE uuid=?').get('message-1') },
+      {
+        text: 'changed searchable text',
+        agent_id: 'agent-1',
+        input_tokens: null,
+        skill: 'review',
+        turn_duration_ms: null,
+      },
+    );
+    assert.deepEqual(
+      { ...db.prepare('SELECT presentation,input_json,file_path FROM tool_calls WHERE id=?').get('call-1') },
+      { presentation: 'skill', input_json: '{"cmd":"false"}', file_path: '/tmp/input' },
+    );
+    assert.deepEqual(
+      { ...db.prepare('SELECT content,file_path,is_error FROM tool_results WHERE tool_use_id=?').get('call-1') },
+      { content: 'changed output', file_path: '/tmp/output', is_error: 1 },
+    );
+    assert.deepEqual(
+      {
+        message: db.prepare('SELECT rowid FROM messages WHERE uuid=?').get('message-1').rowid,
+        toolCall: db.prepare('SELECT rowid FROM tool_calls WHERE id=?').get('call-1').rowid,
+        toolResult: db.prepare('SELECT rowid FROM tool_results WHERE tool_use_id=?').get('call-1').rowid,
+      },
+      rowids,
+    );
+    assert.deepEqual(
+      db.prepare(`
+        SELECT table_name, operation, COUNT(*) AS count
+        FROM write_audit
+        GROUP BY table_name, operation
+        ORDER BY table_name
+      `).all().map(row => ({ ...row })),
+      [
+        { table_name: 'messages', operation: 'update', count: 2 },
+        { table_name: 'tool_calls', operation: 'update', count: 1 },
+        { table_name: 'tool_results', operation: 'update', count: 1 },
+      ],
+    );
+    assert.equal(
+      db.prepare("SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH 'stable'").get().count,
+      0,
+    );
+    assert.equal(
+      db.prepare("SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH 'changed'").get().count,
+      1,
+    );
+    db.prepare("INSERT INTO messages_fts(messages_fts, rank) VALUES('integrity-check', 1)").run();
+    db.close();
+  });
+}
+
+test('every authoritative field can independently trigger an in-place update', () => {
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  const unit = { key: 'unit-1', sessionId: 'session-1' };
+  persist(db, unit, canonicalRecords());
+
+  const cases = [
+    ['messages', 'uuid', BASE_MESSAGE, {
+      session_id: 'session-2', type: 'user', parent_uuid: 'parent-1', timestamp: null,
+      role: null, text: null, content_type: null, is_meta: 1, visibility: 'hidden',
+      model: null, is_sidechain: 1, agent_id: 'agent-1', input_tokens: null,
+      output_tokens: null, cwd: null, skill: 'review', source: 'claude',
+    }],
+    ['tool_calls', 'id', BASE_TOOL_CALL, {
+      message_uuid: 'message-2', session_id: 'session-2', name: 'read_file',
+      presentation: 'skill', input_json: '{}', file_path: '/tmp/input',
+    }],
+    ['tool_results', 'tool_use_id', BASE_TOOL_RESULT, {
+      message_uuid: 'message-2', session_id: 'session-2', content: 'changed',
+      file_path: '/tmp/output', is_error: 1,
+    }],
+  ];
+
+  for (const [table, key, base, changes] of cases) {
+    for (const [column, value] of Object.entries(changes)) {
+      persist(db, unit, oneRecord({ ...base, [column]: value }));
+      assert.equal(
+        db.prepare(`SELECT ${column} AS value FROM ${table} WHERE ${key}=?`).get(base[key]).value,
+        value,
+        `${table}.${column} did not update`,
+      );
+      persist(db, unit, oneRecord(base));
+    }
+  }
+
+  db.close();
+});
+
+test('changed tool-result replay preserves workflow healer candidate order', () => {
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  const unit = { key: 'unit-1', sessionId: 'session-1' };
+  const toolResult = (id, content) => ({
+    kind: 'tool_result',
+    tool_use_id: id,
+    message_uuid: 'message-1',
+    session_id: 'session-1',
+    content,
+    file_path: null,
+    is_error: 0,
+  });
+  function* initialRecords() {
+    for (const id of ['call-1', 'call-2']) {
+      yield {
+        kind: 'tool_call',
+        id,
+        message_uuid: 'message-1',
+        session_id: 'session-1',
+        name: 'Workflow',
+        presentation: 'default',
+        input_json: '{}',
+        file_path: null,
+      };
+      yield toolResult(id, `Run ID: run-1; result from ${id}`);
+    }
+    return null;
+  }
+  function* changedFirstResult() {
+    yield toolResult('call-1', 'Run ID: run-1; updated result from call-1');
+    return null;
+  }
+
+  persist(db, unit, initialRecords());
+  const firstRowid = db.prepare('SELECT rowid FROM tool_results WHERE tool_use_id=?').get('call-1').rowid;
+  persist(db, unit, changedFirstResult());
+  db.prepare(`
+    INSERT INTO workflows (run_id, session_id, parent_tool_use_id)
+    VALUES ('run-1', 'session-1', NULL)
+  `).run();
+
+  healWorkflowParentLinks(db);
+
+  assert.equal(db.prepare('SELECT rowid FROM tool_results WHERE tool_use_id=?').get('call-1').rowid, firstRowid);
+  assert.equal(db.prepare('SELECT parent_tool_use_id FROM workflows WHERE run_id=?').get('run-1').parent_tool_use_id, 'call-1');
+  db.close();
+});


### PR DESCRIPTION
## Summary

- Make repeated canonical replay idempotent for messages, tool calls, tool results, and turn durations.
- Avoid message FTS update-trigger work when the replayed row is byte-for-byte unchanged.
- Preserve all existing canonical values, transaction boundaries, cursor publication, and app/Core parity.

## Scope

- In scope:
  - NULL-safe conditional UPSERTs for `messages`, `tool_calls`, and `tool_results`
  - Conditional targeted updates for `message-turn-duration`
  - Stable tool rowids across identical and changed replay
  - Cross-binding audit-trigger, FTS, rowid, and workflow-healer regression coverage
- Out of scope:
  - Session, summary, subagent, workflow, workflow-agent, and index-state write optimization
  - Provider checkpoint parsing or cursor/manifest changes
  - Codex snapshot subtraction for keys that disappear from a replay

## Key Changes

- `packages/core/src/persist.ts` updates exact-replacement rows only when an authoritative persisted field differs. Message comparison intentionally excludes separately-owned `turn_duration_ms`.
- `tests/persist-idempotency.test.mjs` proves identical replay produces zero canonical write events on both `node:sqlite` and `better-sqlite3`, while changed and NULL-transitioned values still update in place and keep FTS consistent.
- The persistence ADR records why this policy is table-specific and why no provider cursor or canonical marker bump is required.
- Cross-platform CI runs the persistence contract after installing the app's real SQLite binding.

## Validation

- `npm test`: pass, 611/611 tests (run outside the filesystem-event sandbox so native watcher tests receive OS events)
- `npm run typecheck`: pass
- `npx eslint packages/core/src/persist.ts tests/persist-idempotency.test.mjs`: pass
- `node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/persist-idempotency.test.mjs tests/persist.test.mjs tests/indexer-upsert-drift.test.mjs`: pass, 13/13 tests
- `git diff --check`: pass
- Repository-wide `npm run lint` is locally blocked by pre-existing user-owned untracked generated artifacts under `docs/book/site/dist`, `resume_rebuild`, and `tmp`; no errors are reported for this PR's source or test files.

### Controlled real-corpus end-to-end benchmark

The benchmark used the same 6.84 MB prefix from a real Codex transcript, the same pre-indexed seed database, and the same 100-line append for both implementations. Each measurement ran complete incremental `buildIndex` work (discovery, parse, persistence, and finalize). Three trials alternated implementation order to reduce cache-order bias.

| Complete incremental build | Trial 1 | Trial 2 | Trial 3 | Median |
|---|---:|---:|---:|---:|
| `origin/main` | 77.8 ms | 77.3 ms | 70.4 ms | 77.3 ms |
| This PR | 45.2 ms | 50.9 ms | 42.3 ms | 45.2 ms |

Median complete-build latency fell by 41.5% under the controlled append.

| Canonical kind | Emitted | Already existed | New |
|---|---:|---:|---:|
| Messages | 650 | 620 | 30 |
| Tool calls | 336 | 322 | 14 |
| Tool results | 335 | 321 | 14 |
| **Total** | **1,321** | **1,263 (95.6%)** | **58** |

### Controlled persistence-only benchmark

A separate rollback-only A/B replay used the same 22.7 MB live Codex snapshot and the same parsed record stream against the same database state:

| Metric | `origin/main` | This PR |
|---|---:|---:|
| Codex parse | 94.3 ms | 94.3 ms (shared parse) |
| Persistence | 298.2 ms | 20.4 ms |
| Physical writes for message/tool/duration records | 3,985 | 238 |

The replay emitted 1,875 messages, 1,030 calls, 1,029 results, and 51 durations. Of the three canonical row kinds, 3,698 already existed and 236 were new; one existing message had genuinely changed. Fifty durations were unchanged and one targeted a newly emitted message. The patch therefore skipped 3,747 unchanged physical writes while committing every new or modified value.

### Uncontrolled live observations

Before the patch, live complete incremental builds were observed at 1.60-1.85 s for a replay with 3,496 emitted rows, 3,409 existing rows, and 87 new rows. After the patch, a later single-append build completed in 198.6 ms, while a build that accumulated several concurrently active transcripts still took 1.90 s; true no-op builds were 74-90 ms. These live runs are reported as operational context, not as a controlled before/after comparison: transcript backlog, project-path refresh (#105), and cache state vary. The controlled end-to-end benchmark above is the comparable latency result for this PR.

## Risks and Rollback

- The observable SQLite event contract changes intentionally: identical UPSERTs now report zero changes, and changed tool rows use UPDATE rather than REPLACE. Repository consumers do not use change counters or update hooks.
- Stable tool-result rowids preserve workflow healer first-candidate ordering instead of allowing replay to reorder candidates.
- Rollback is a single commit revert; no schema, cursor, or migration state needs repair.

## Related Issues

- Related to #105

Closes #130
