### PR TITLE
chore(release): cli v0.2.6-rc.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1746,7 +1746,7 @@
     },
     "packages/cli": {
       "name": "@obelisk-apps/cli",
-      "version": "0.2.3",
+      "version": "0.2.6-rc.0",
       "license": "AGPL-3.0",
       "bin": {
         "obelisk": "dist/cli/src/obelisk.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@obelisk-apps/cli",
-  "version": "0.2.3",
+  "version": "0.2.6-rc.0",
   "description": "Local Obelisk runtime for coding agents.",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Updates the npm CLI package and workspace lockfile to 0.2.6-rc.0. Verified with npm run build:cli.