### PR TITLE
perf(core): bound temporal search context lookup

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -384,7 +384,12 @@ function createQueryApi(
       const ctx = (indexedTimestamp ? indexedContext : scanContext)
         .all(contextParams)
         .map(withVisibility)
-        .sort((a: DbRow, b: DbRow) => a.timestamp < b.timestamp ? -1 : 1);
+        .sort((a: DbRow, b: DbRow) => {
+          if (a.timestamp === b.timestamp) return 0;
+          if (a.timestamp == null) return -1;
+          if (b.timestamp == null) return 1;
+          return a.timestamp < b.timestamp ? -1 : 1;
+        });
       const sourceValue = r.m_source || r.s_source || 'claude';
       const session: DbRow = { id: r.s_id, title: r.s_title, project: r.s_project, started_at: r.s_started, source: r.s_source || sourceValue };
       // is_invoking marks the session that ran this query; it is the agent's

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -326,18 +326,63 @@ function createQueryApi(
       const safe = buildSafeFtsQuery(text);
       rows = safe ? runMatch(safe) : [];
     }
+    const metaClause = includeMeta ? '' : 'AND COALESCE(is_meta,0)=0';
+    const contextWhere = `
+      session_id=$sessionId AND uuid!=$messageUuid ${metaClause}
+        AND ${visibilitySql('messages', includeInactive)}
+    `;
+    // All provider timestamps are normalized ISO-8601 strings, so their text
+    // order is chronological. Pull at most six candidates from each side via
+    // idx_messages_ts, then preserve the old JULIANDAY distance ordering.
+    const indexedContext = db.prepare(`
+      WITH
+        null_rows AS (
+          SELECT rowid AS message_rowid FROM messages
+          WHERE ${contextWhere} AND timestamp IS NULL
+          ORDER BY rowid LIMIT 6
+        ),
+        before_rows AS (
+          SELECT rowid AS message_rowid FROM messages
+          WHERE ${contextWhere} AND timestamp<=$timestamp
+          ORDER BY timestamp DESC, rowid ASC LIMIT 6
+        ),
+        after_rows AS (
+          SELECT rowid AS message_rowid FROM messages
+          WHERE ${contextWhere} AND timestamp>$timestamp
+          ORDER BY timestamp ASC, rowid ASC LIMIT 6
+        ),
+        candidates AS (
+          SELECT * FROM null_rows UNION ALL SELECT * FROM before_rows
+          UNION ALL SELECT * FROM after_rows
+        )
+      SELECT uuid,text,content_type,is_meta,role,timestamp,model,
+             COALESCE(visibility,'visible') AS visibility,
+             COALESCE(source, 'claude') AS source
+      FROM candidates JOIN messages ON messages.rowid=candidates.message_rowid
+      ORDER BY ABS(JULIANDAY(timestamp)-JULIANDAY($timestamp)), message_rowid
+      LIMIT 6
+    `);
+    // Null or non-canonical hits have no safe lexical ordering; retain the
+    // original scan instead of forcing them through the indexed path.
+    const scanContext = db.prepare(`
+      SELECT uuid,text,content_type,is_meta,role,timestamp,model,
+             COALESCE(visibility,'visible') AS visibility,
+             COALESCE(source, 'claude') AS source
+      FROM messages
+      WHERE ${contextWhere}
+      ORDER BY ABS(JULIANDAY(timestamp)-JULIANDAY($timestamp))
+      LIMIT 6
+    `);
     return rows.map((r: DbRow) => {
-      const metaClause = includeMeta ? '' : 'AND COALESCE(is_meta,0)=0';
-      const ctx = db.prepare(
-        `SELECT uuid,text,content_type,is_meta,role,timestamp,model,
-                COALESCE(visibility,'visible') AS visibility,
-                COALESCE(source, 'claude') as source
-         FROM messages
-         WHERE session_id=? AND uuid!=? ${metaClause}
-           AND ${visibilitySql('messages', includeInactive)}
-         ORDER BY ABS(JULIANDAY(timestamp)-JULIANDAY(?))
-         LIMIT 6`
-      ).all(r.session_id, r.uuid, r.timestamp)
+      const contextParams = {
+        $sessionId: r.session_id,
+        $messageUuid: r.uuid,
+        $timestamp: r.timestamp,
+      };
+      const indexedTimestamp = typeof r.timestamp === 'string'
+        && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(r.timestamp);
+      const ctx = (indexedTimestamp ? indexedContext : scanContext)
+        .all(contextParams)
         .map(withVisibility)
         .sort((a: DbRow, b: DbRow) => a.timestamp < b.timestamp ? -1 : 1);
       const sourceValue = r.m_source || r.s_source || 'claude';

--- a/tests/query.test.mjs
+++ b/tests/query.test.mjs
@@ -52,6 +52,7 @@ function searchDb() {
       uuid UNINDEXED, session_id UNINDEXED, text,
       content=messages, content_rowid=rowid
     );
+    CREATE INDEX idx_messages_ts ON messages(session_id, timestamp);
   `);
   db.prepare(`
     INSERT INTO sessions (id, title, project, started_at)
@@ -97,6 +98,44 @@ test('search exposes content_type on hits and temporal context', () => {
   assert.equal(rows[0].context[0].uuid, 'msg-thinking');
   assert.equal(rows[0].context[0].content_type, 'thinking');
   assert.equal(rows[0].context[0].is_meta, 0);
+  db.close();
+});
+
+test('search temporal context preserves null and duplicate-timestamp neighbors', () => {
+  const db = new DatabaseSync(':memory:');
+  db.exec(SCHEMA);
+  db.prepare("INSERT INTO sessions (id, title) VALUES ('sid-neighbors', 'Neighbors')").run();
+  const insert = db.prepare(`
+    INSERT INTO messages (uuid, session_id, role, text, timestamp, is_meta, visibility)
+    VALUES (?, 'sid-neighbors', 'assistant', ?, ?, ?, ?)
+  `);
+  insert.run('hit', 'temporal-neighbor-needle', '2026-06-10T10:00:05.000Z', 0, 'visible');
+  insert.run('null-visible', 'context', null, 0, 'visible');
+  insert.run('equal-a', 'context', '2026-06-10T10:00:05.000Z', 0, 'visible');
+  insert.run('equal-meta', 'context', '2026-06-10T10:00:05.000Z', 1, 'visible');
+  insert.run('equal-b', 'context', '2026-06-10T10:00:05.000Z', 0, 'visible');
+  insert.run('before-1', 'context', '2026-06-10T10:00:04.000Z', 0, 'visible');
+  insert.run('after-1', 'context', '2026-06-10T10:00:06.000Z', 0, 'visible');
+  insert.run('before-2-inactive', 'context', '2026-06-10T10:00:03.000Z', 0, 'inactive');
+  insert.run('after-2', 'context', '2026-06-10T10:00:07.000Z', 0, 'visible');
+  insert.run('hidden', 'context', '2026-06-10T10:00:05.500Z', 0, 'hidden');
+  insert.run('before-3', 'context', '2026-06-10T10:00:02.000Z', 0, 'visible');
+  insert.run('after-3', 'context', '2026-06-10T10:00:08.000Z', 0, 'visible');
+  insert.run('null-hit', 'null-temporal-needle', null, 0, 'visible');
+
+  const api = createQueryApi(db);
+  const contextIds = api.search('temporal-neighbor-needle', { limit: 1 })[0]
+    .context.map(row => row.uuid).sort();
+
+  assert.deepEqual(contextIds, [
+    'after-1', 'before-1', 'equal-a', 'equal-b', 'null-hit', 'null-visible',
+  ]);
+
+  assert.deepEqual(
+    api.search('null-temporal-needle', { limit: 1 })[0]
+      .context.map(row => row.uuid).sort(),
+    ['after-1', 'before-1', 'equal-a', 'equal-b', 'hit', 'null-visible'],
+  );
   db.close();
 });
 

--- a/tests/query.test.mjs
+++ b/tests/query.test.mjs
@@ -125,16 +125,16 @@ test('search temporal context preserves null and duplicate-timestamp neighbors',
 
   const api = createQueryApi(db);
   const contextIds = api.search('temporal-neighbor-needle', { limit: 1 })[0]
-    .context.map(row => row.uuid).sort();
+    .context.map(row => row.uuid);
 
   assert.deepEqual(contextIds, [
-    'after-1', 'before-1', 'equal-a', 'equal-b', 'null-hit', 'null-visible',
+    'null-visible', 'null-hit', 'before-1', 'equal-a', 'equal-b', 'after-1',
   ]);
 
   assert.deepEqual(
     api.search('null-temporal-needle', { limit: 1 })[0]
-      .context.map(row => row.uuid).sort(),
-    ['after-1', 'before-1', 'equal-a', 'equal-b', 'hit', 'null-visible'],
+      .context.map(row => row.uuid),
+    ['null-visible', 'before-1', 'hit', 'equal-a', 'equal-b', 'after-1'],
   );
   db.close();
 });


### PR DESCRIPTION
## What and why

`search()` currently runs one temporal-context query per FTS hit. That query
orders every other message in the hit session by a `JULIANDAY()` expression, so
SQLite cannot use `idx_messages_ts`; a hit in a 102,648-message session costs
about 206-235 ms just to collect six neighbors.

This change bounds that work without changing the result contract:

- canonical provider timestamps use `idx_messages_ts` to take at most six rows
  from each side of the hit (plus at most six null-timestamp rows);
- the final 18-or-fewer candidates retain the prior `JULIANDAY()` distance and
  rowid tie ordering;
- null or non-canonical hit timestamps keep the original scan;
- both statements are prepared once per `search()` call instead of once per hit.

No schema, dependency, provider, visibility, or public API changes.

### Reproduction and ablation

Windows 11, Node 24.16.0, immutable 3.33 GB SQLite snapshot with 1,627,293
messages. Each value is the median of five warm `search(query, { limit: 20 })`
runs. "Disabled" is current parent `fb4a8ef`; "enabled" is this commit.

| query | disabled p50 | enabled p50 | reduction |
| --- | ---: | ---: | ---: |
| `索引` | 863.70 ms | 9.66 ms | 98.9% |
| `index` | 3,657.46 ms | 23.31 ms | 99.4% |
| `error` | 3,783.40 ms | 30.60 ms | 99.2% |
| `python` | 1,174.78 ms | 51.94 ms | 95.6% |
| `obelisk` | 3,344.95 ms | 38.67 ms | 98.8% |
| `EqOp` | 998.55 ms | 76.22 ms | 92.4% |

The six ordered hit-ID digests were identical with the optimization disabled
and enabled. An old-vs-new temporal-context differential over 120 real hits had
0 context UUID/order mismatches. The new regression test separately pins null
timestamps, duplicate timestamps, meta filtering, and inactive/hidden rows.

## Verification

- [x] `npm test` — 659 pass / 0 fail on Ubuntu WSL2 (Node 24.14.1)
- [x] `npm run typecheck` — 0 errors (root + app)
- [x] `npm run lint` — 0 errors, 11 pre-existing/generated warnings
- [x] New test runs in root CI (`tests/query.test.mjs` is matched by `tests/*.test.mjs`)
- [x] No existing assertion was loosened
- [x] Re-ran the checks above on the current head

The current-head query suite also passes 32/32 on Windows. Linux verification
was rerun after rebasing onto `fb4a8ef`.

## Deliberately out of scope

- Provider discovery/index refresh and FTS rebuild latency; this PR only fixes
  post-FTS result context lookup.
- Adding another index: the existing `idx_messages_ts(session_id, timestamp)` is
  sufficient.
- Electron tests, because no `app/` files changed.
