### PR TITLE
fix(core): resume provider marker replays after interruption

### DIFF
--- a/packages/core/src/provider-indexing.ts
+++ b/packages/core/src/provider-indexing.ts
@@ -270,13 +270,34 @@ export function indexProviderPlan({
   const committed: ProviderIndexItem[] = [];
   const failedProviders = new Set<string>();
   const failedItems: ProviderIndexItem[] = [];
+  let replayStarted = plan.pendingMarkers.size === 0 && plan.replayKeys.size === 0;
   for (const item of plan.items) {
     try {
       const cursor = runTransaction(`provider:${item.provider.name}:${item.unit.key}`, () => {
+        // Commit the replay schedule with its first completed unit. After an
+        // interruption, newly written cursors identify exactly what can resume.
+        if (!replayStarted) {
+          const clear = db.prepare('DELETE FROM index_state WHERE jsonl_path = ?');
+          const keysToReplay = new Set(
+            plan.items
+              .filter(({ provider }) => plan.pendingMarkers.has(provider.name))
+              .map(({ unit }) => unit.key),
+          );
+          for (const keys of plan.replayKeys.values()) {
+            for (const key of keys) keysToReplay.add(key);
+          }
+          for (const key of keysToReplay) clear.run(key);
+          const write = db.prepare(
+            'INSERT OR REPLACE INTO index_state (jsonl_path, mtime, lines_processed) VALUES (?, ?, 0)',
+          );
+          const now = Date.now();
+          for (const marker of plan.pendingMarkers.values()) write.run(marker, now);
+        }
         const nextCursor = persist(db, item.unit, item.provider.parse(item.unit, item.cursor));
         onPersisted(item, nextCursor);
         return nextCursor;
       });
+      replayStarted = true;
       committed.push(item);
       onCommitted(item, cursor);
     } catch (error) {

--- a/tests/app-rollback-guard.test.mjs
+++ b/tests/app-rollback-guard.test.mjs
@@ -14,6 +14,7 @@ import { makeTempDir } from './temp-dirs.mjs';
 
 const require = createRequire(import.meta.url);
 import { buildIndex } from '../app/src/main/indexer.ts';
+import { createClaudeProvider } from '../packages/core/src/providers/claude.ts';
 const { DatabaseSync } = require('node:sqlite');
 
 // Wraps node:sqlite and simulates SQLite auto-rollback-on-error: a poisoned write
@@ -223,6 +224,49 @@ test('BEGIN contention during finalize defers the build', () => {
   });
   assert.equal(result.deferred, true);
   assert.equal(result.reason, 'database_busy');
+});
+
+test('a marker replay resumes after the last committed file when the next transaction defers', () => {
+  const { home, dbPath, projectsDir } = subagentHome();
+  const StableDb = makeDbClass(() => false);
+  assert.equal(run(home, dbPath, projectsDir, StableDb).complete, true);
+
+  const marker = createClaudeProvider({ rootDir: join(home, '.claude') }).indexVersionMarker;
+  let db = new DatabaseSync(dbPath);
+  db.prepare('DELETE FROM index_state WHERE jsonl_path=?').run(marker);
+  db.close();
+
+  const InterruptedDb = makeBeginBusyDbClass(beginCall => beginCall === 2);
+  const interrupted = buildIndex({
+    force: false,
+    claudeDir: join(home, '.claude'),
+    codexDir: join(home, '.codex'),
+    projectsDir,
+    dbPath,
+    DatabaseImpl: InterruptedDb,
+  });
+  assert.equal(interrupted.deferred, true);
+  assert.equal(interrupted.reason, 'database_busy');
+
+  db = new DatabaseSync(dbPath);
+  assert.equal(db.prepare('SELECT COUNT(*) AS c FROM index_state WHERE jsonl_path=?').get(marker).c, 1);
+  db.close();
+
+  const resumed = buildIndex({
+    force: false,
+    claudeDir: join(home, '.claude'),
+    codexDir: join(home, '.codex'),
+    projectsDir,
+    dbPath,
+    DatabaseImpl: StableDb,
+  });
+  assert.equal(resumed.files, 1, 'the committed file is not replayed after restart');
+  assert.equal(resumed.complete, true);
+
+  db = new DatabaseSync(dbPath);
+  assert.equal(db.prepare('SELECT COUNT(*) AS c FROM sessions').get().c, 1);
+  assert.equal(db.prepare('SELECT COUNT(*) AS c FROM messages').get().c, 2);
+  db.close();
 });
 
 test('a finalize database error is propagated instead of swallowed as malformed input', () => {


### PR DESCRIPTION
## What and why

When an index-version marker is missing for a provider that already has indexed sessions, planning intentionally schedules a full provider replay. Today the marker is written only during finalize. If a later per-unit transaction is deferred after earlier units committed, finalize is skipped, the marker remains missing, and the next build sets every cursor to `null` again. The provider therefore restarts from byte zero after every interruption.

This change commits the replay schedule atomically with the first successfully persisted unit:

- clear every planned unit cursor for providers whose marker changed, including auxiliary units that have no `sessions` provenance;
- clear provenance-derived replay keys that are no longer discoverable;
- write pending version markers in the same transaction;
- persist the first unit before that transaction commits.

If the first unit transaction fails, all schedule changes roll back. Once one unit commits, subsequent interruptions resume from the per-unit cursors already written. Existing failed/incomplete-inventory retry handling remains unchanged.

No schema, provider parsing, query, public API, or dependency changes.

## Reproduction and ablation

The regression fixture creates one Claude main transcript plus one subagent transcript, seeds a complete index, deletes the canonical marker, and injects `SQLITE_BUSY` at the second unit transaction.

- Disabled (`fb4a8ef` parent implementation): the marker count before restart is `0`; the new test fails with `0 !== 1`, so the next plan treats both units as a fresh full replay.
- Enabled (`02b4638`): the marker count is `1`; restart reports `files === 1`, and the final snapshot remains exactly 1 session / 2 messages.

The subagent unit is deliberately absent from `sessions` provenance, so this also guards against clearing only provenance-derived keys.

## Verification

- [x] `npm test` — 659 pass / 0 fail on Ubuntu WSL2 (Node 24.14.1), current head
- [x] `npm run typecheck` — 0 errors (root + app)
- [x] `npm run lint` — 0 errors, 11 pre-existing/generated warnings
- [x] Focused provider/index/finalize/runtime suites — 37 pass / 0 fail on Windows
- [x] Disabled/enabled regression ablation performed on the current parent/head pair
- [x] No existing assertion was loosened

## Deliberately out of scope

- Provider inventory discovery latency; that is a separate bottleneck and needs a separate change and ablation.
- Background scheduling or UI behavior.
- Query-time context lookup; that is isolated in #139.