### PR TITLE
ci(dsh): publish standalone plugin mirror

### DIFF
--- a/.github/workflows/publish-dsh-plugin.yml
+++ b/.github/workflows/publish-dsh-plugin.yml
@@ -1,0 +1,60 @@
+name: Publish DSH Plugin
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-dsh-plugin
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build:core
+
+      - run: npm run build --workspace @obelisk/dsh-obelisk-plugin
+
+      - name: Push to obelisk-dsh-plugin
+        env:
+          DEPLOY_KEY: ${{ secrets.DSH_PLUGIN_REPO_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          : "${DEPLOY_KEY:?Missing DSH_PLUGIN_REPO_DEPLOY_KEY}"
+          mkdir -p ~/.ssh
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/dsh_plugin_deploy
+          chmod 600 ~/.ssh/dsh_plugin_deploy
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/dsh_plugin_deploy -o StrictHostKeyChecking=no"
+
+          PLUGIN_DIR=$(mktemp -d)
+          git clone --depth 1 git@github.com:tommy0103/obelisk-dsh-plugin.git "$PLUGIN_DIR" || {
+            git init "$PLUGIN_DIR"
+            git -C "$PLUGIN_DIR" remote add origin git@github.com:tommy0103/obelisk-dsh-plugin.git
+          }
+
+          bash packaging/stage-dsh-plugin-repo.sh "$PLUGIN_DIR"
+
+          cd "$PLUGIN_DIR"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to publish"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "publish: $(date -u +%Y-%m-%dT%H:%M:%SZ) from tommy0103/obelisk@${GITHUB_SHA::7}"
+          git push --force origin HEAD:main

--- a/packages/dsh-plugin/README.md
+++ b/packages/dsh-plugin/README.md
@@ -111,10 +111,10 @@ from Obelisk's shared retrieval contract but has its own lifecycle and may
 adopt DSH-specific guidance while preserving the common CLI, evidence, and
 human-approved memory boundaries.
 
-The Obelisk repository remains the source of this plugin directory. A future
-standalone plugin repository can be synchronized from it by GitHub Actions as a
-distribution mirror; no Git submodule or second hand-maintained source is
-required.
+The Obelisk repository remains the source of this plugin directory. GitHub
+Actions synchronizes an installable distribution mirror to
+[`tommy0103/obelisk-dsh-plugin`](https://github.com/tommy0103/obelisk-dsh-plugin);
+no Git submodule or second hand-maintained source is required.
 
 ## Presentation
 

--- a/packaging/dsh-plugin-README.md
+++ b/packaging/dsh-plugin-README.md
@@ -1,0 +1,56 @@
+# Obelisk for DeepSeek Harness
+
+Installable distribution mirror of
+[`@obelisk/dsh-obelisk-plugin`](https://github.com/tommy0103/obelisk/tree/main/packages/dsh-plugin).
+It provides the Obelisk retrieval skill for DeepSeek Harness (DSH) and an
+optional context-window rollover plugin.
+
+This repository is generated from the Obelisk monorepo by GitHub Actions. Do
+not edit it directly; changes are overwritten by the next publication.
+
+## Prerequisite
+
+Install the Obelisk CLI so `obelisk` is available on `PATH`:
+
+```bash
+npm install --global @obelisk-apps/cli
+```
+
+## Install
+
+Clone this generated package, install its runtime dependencies, and add it to
+the desired DSH profile:
+
+```bash
+git clone https://github.com/tommy0103/obelisk-dsh-plugin.git
+cd obelisk-dsh-plugin
+npm install --ignore-scripts
+dsh plugin --profile web add --workspace-root "$PWD"
+```
+
+Replace `web` with another profile name if needed. The default bundle adds the
+plugin-owned `obelisk` skill without changing DSH's normal tool surface.
+
+## Optional context-window rollover
+
+The context-window plugin is exported separately and is not mounted by the
+default bundle. Add it only to an agent composition that should receive prose
+handoffs, structured related-file references, pressure reminders, and safe
+active-context rollover:
+
+```yaml
+- insert:
+    - id: obelisk-context-window
+      name: '@obelisk/dsh-obelisk-plugin/context-window'
+```
+
+That composition must disable `compaction-basic.auto`; manual `/compact` may
+remain available.
+
+See the
+[source package documentation](https://github.com/tommy0103/obelisk/tree/main/packages/dsh-plugin)
+for configuration, development, and uninstall instructions.
+
+## License
+
+AGPL-3.0-only. See [LICENSE](LICENSE).

--- a/packaging/stage-dsh-plugin-repo.sh
+++ b/packaging/stage-dsh-plugin-repo.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_DIR="${1:-}"
+PLUGIN_DIR="${2:-$ROOT_DIR/packages/dsh-plugin}"
+
+if [ -z "$TARGET_DIR" ]; then
+  echo "Usage: packaging/stage-dsh-plugin-repo.sh <target-repo> [plugin-artifact]" >&2
+  exit 1
+fi
+
+if [ "$TARGET_DIR" = "/" ] || [ "$TARGET_DIR" = "." ] || [ "$TARGET_DIR" = "$ROOT_DIR" ] || [ "$TARGET_DIR" = "$PLUGIN_DIR" ]; then
+  echo "Error: refusing to replace unsafe target directory: $TARGET_DIR" >&2
+  exit 1
+fi
+
+for required in package.json obelisk.cordis.yml dist/index.js dist/index.d.ts; do
+  if [ ! -e "$PLUGIN_DIR/$required" ]; then
+    echo "Error: plugin artifact missing $required at $PLUGIN_DIR" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$TARGET_DIR"
+find "$TARGET_DIR" -mindepth 1 \
+  ! -path "$TARGET_DIR/.git" \
+  ! -path "$TARGET_DIR/.git/*" \
+  -delete
+
+cp -R "$PLUGIN_DIR/dist" "$TARGET_DIR/dist"
+cp "$PLUGIN_DIR/package.json" "$TARGET_DIR/package.json"
+cp "$PLUGIN_DIR/obelisk.cordis.yml" "$TARGET_DIR/obelisk.cordis.yml"
+cp "$ROOT_DIR/packaging/dsh-plugin-README.md" "$TARGET_DIR/README.md"
+cp "$ROOT_DIR/LICENSE" "$TARGET_DIR/LICENSE"

--- a/tests/publish-dsh-plugin-layout.test.mjs
+++ b/tests/publish-dsh-plugin-layout.test.mjs
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { makeTempDir } from './temp-dirs.mjs'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const stageScript = join(repoRoot, 'packaging', 'stage-dsh-plugin-repo.sh')
+
+test('DSH plugin release staging produces an installable standalone repository', () => {
+  const root = makeTempDir('obelisk-dsh-plugin-release-')
+  const artifact = join(root, 'artifact')
+  const target = join(root, 'repo')
+  try {
+    mkdirSync(join(artifact, 'dist'), { recursive: true })
+    mkdirSync(join(target, '.git'), { recursive: true })
+    writeFileSync(join(artifact, 'package.json'), '{"name":"@obelisk/dsh-obelisk-plugin"}\n')
+    writeFileSync(join(artifact, 'obelisk.cordis.yml'), 'plugins: []\n')
+    writeFileSync(join(artifact, 'dist', 'index.js'), 'export default {}\n')
+    writeFileSync(join(artifact, 'dist', 'index.d.ts'), 'declare const plugin: object\nexport default plugin\n')
+    writeFileSync(join(target, '.git', 'keep'), 'preserved\n')
+    writeFileSync(join(target, 'stale.txt'), 'remove me\n')
+
+    const result = spawnSync('bash', [stageScript, target, artifact], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+
+    assert.deepEqual(readdirSync(target).sort(), [
+      '.git',
+      'LICENSE',
+      'README.md',
+      'dist',
+      'obelisk.cordis.yml',
+      'package.json',
+    ])
+    for (const relativePath of [
+      'dist/index.js',
+      'dist/index.d.ts',
+      'obelisk.cordis.yml',
+      'package.json',
+      'README.md',
+      'LICENSE',
+    ]) {
+      assert.equal(existsSync(join(target, relativePath)), true, relativePath)
+    }
+    assert.equal(existsSync(join(target, '.git', 'keep')), true)
+    assert.equal(existsSync(join(target, 'stale.txt')), false)
+    assert.match(readFileSync(join(target, 'README.md'), 'utf8'), /generated from the Obelisk monorepo/)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('DSH plugin publication builds and stages the standalone mirror', () => {
+  const workflow = readFileSync(join(repoRoot, '.github', 'workflows', 'publish-dsh-plugin.yml'), 'utf8')
+
+  assert.match(workflow, /npm run build:core/)
+  assert.match(workflow, /npm run build --workspace @obelisk\/dsh-obelisk-plugin/)
+  assert.match(workflow, /packaging\/stage-dsh-plugin-repo\.sh/)
+  assert.match(workflow, /tommy0103\/obelisk-dsh-plugin\.git/)
+  assert.match(workflow, /secrets\.DSH_PLUGIN_REPO_DEPLOY_KEY/)
+  assert.match(workflow, /git push --force origin HEAD:main/)
+  assert.doesNotMatch(workflow, /stage-skill-repo/)
+})


### PR DESCRIPTION
## Summary
- add a main-branch GitHub Actions workflow that builds the DSH plugin and force-syncs its installable artifact to `tommy0103/obelisk-dsh-plugin`
- add a shared staging script and generated-repository README
- preserve target Git metadata while removing stale generated files
- cover the standalone layout and workflow contract with tests

## Verification
- `npm run build:core`
- `npm run build --workspace @obelisk/dsh-obelisk-plugin`
- `node --experimental-test-module-mocks --test tests/publish-dsh-plugin-layout.test.mjs tests/dsh-plugin.test.mjs tests/dsh-context-window-plugin.test.mjs` (43/43)
- plugin typecheck, ESLint, Shell syntax, workflow YAML parse
- staged artifact `npm pack --dry-run` (41 files)

## Activation requirement
Before merge, configure `DSH_PLUGIN_REPO_DEPLOY_KEY` in this repository and the matching write-enabled deploy key in `tommy0103/obelisk-dsh-plugin`.