### PR TITLE
perf(core): make Codex guardian discovery linear

### DIFF
--- a/packages/core/src/parsing.ts
+++ b/packages/core/src/parsing.ts
@@ -270,8 +270,9 @@ function codexIsGuardianThread(meta: JsonRecord, records: CodexLineRecord[] = []
 }
 
 function readCodexGuardianThreadInfo(filePath: string): { threadRawId: string; lineNum: number } | null {
-  const records: CodexLineRecord[] = [];
   let metaRecord: CodexLineRecord | null = null;
+  let sawAutoReviewModel = false;
+  let guardian = false;
   let lineNum = 0;
   readLines(filePath, (line) => {
     lineNum++;
@@ -281,17 +282,24 @@ function readCodexGuardianThreadInfo(filePath: string): { threadRawId: string; l
     } catch {
       return;
     }
-    records.push({ lineNum, obj });
+    sawAutoReviewModel ||= obj?.payload?.model === 'codex-auto-review'
+      || obj?.model === 'codex-auto-review';
     if (obj?.type === 'session_meta' && obj.payload?.id) {
       metaRecord = { lineNum, obj };
-      if (obj.payload?.source?.subagent?.other === 'guardian') return false;
+      if (obj.payload?.source?.subagent?.other === 'guardian') {
+        guardian = true;
+        return false;
+      }
       if (obj.payload?.thread_source !== 'subagent') return false;
     }
-    if (metaRecord && codexIsGuardianThread(metaRecord.obj.payload, records)) return false;
+    if (metaRecord && sawAutoReviewModel) {
+      guardian = true;
+      return false;
+    }
   });
   const capturedMeta = metaRecord as CodexLineRecord | null;
   const meta = capturedMeta?.obj?.payload;
-  if (!meta || !codexIsGuardianThread(meta, records)) return null;
+  if (!meta || !guardian) return null;
   const threadRawId = codexRawId(meta.id);
   return threadRawId ? { threadRawId, lineNum } : null;
 }

--- a/tests/codex-discover.test.mjs
+++ b/tests/codex-discover.test.mjs
@@ -76,6 +76,25 @@ test('codex discovery re-plans a guardian transcript rewritten at the same mtime
   assert.equal(units[0].meta.guardian, true, 'guardian detection runs for re-planned files');
 });
 
+test('codex discovery recognizes a legacy guardian model before session metadata', () => {
+  const rootDir = makeTempDir('obelisk-codex-discover-');
+  const dir = join(rootDir, 'sessions', '2026', '06', '15');
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `rollout-2026-06-15T10-00-00-${GUARDIAN_ID}.jsonl`);
+  writeFileSync(path, [
+    JSON.stringify({ type: 'turn_context', payload: { model: 'codex-auto-review' } }),
+    JSON.stringify({
+      type: 'session_meta',
+      payload: { id: GUARDIAN_ID, cwd: '/tmp/cdx', thread_source: 'subagent' },
+    }),
+    '',
+  ].join('\n'));
+
+  const units = discoverWith(rootDir, new Map());
+  assert.equal(units[0].sessionId, '');
+  assert.equal(units[0].meta.guardian, true);
+});
+
 test('codex discovery fails closed on a legacy mtime-only cursor, even at the current mtime', () => {
   const rootDir = makeTempDir('obelisk-codex-discover-');
   const guardianPath = writeRollout(rootDir, GUARDIAN_ID, GUARDIAN_META);


### PR DESCRIPTION
## What and why

`readCodexGuardianThreadInfo()` currently stores every parsed record and calls `codexIsGuardianThread(meta, records)` after each line. For a non-guardian subagent transcript, each call scans the growing array again, making discovery O(n²) in transcript length and retaining O(n) records before indexing even begins.

This change keeps two scalar facts while reading once:

- the latest valid `session_meta` record;
- whether `codex-auto-review` has appeared before or after that metadata.

Direct guardian metadata and non-subagent early exits are unchanged. Legacy guardian detection still works when the model record appears before the session metadata; the new regression pins that ordering.

No schema, cursor, parser output, provider contract, public API, or dependency changes.

## Reproduction and ablation

Windows 11, Node 24.16.0. The benchmark generates one 20,001-line non-guardian Codex subagent transcript in a temporary directory, warms discovery once, then reports five discovery samples.

| arm | samples (ms, sorted) | p50 | reduction |
| --- | --- | ---: | ---: |
| disabled (`69d9e21`) | 252.49, 261.11, 262.29, 449.62, 463.36 | 262.29 ms | — |
| enabled (`57e8979`) | 6.60, 6.81, 7.15, 7.23, 9.56 | 7.15 ms | 97.3% (36.7x) |

Both arms discover the same single non-guardian unit. The regression suite additionally covers direct guardians, legacy model-based guardians, matching five-part cursors, legacy cursors, same-mtime rewrites, exact changed paths, parsing, and incremental persistence.

## Verification

- [x] `npm test` — 661 pass / 0 fail on Ubuntu WSL2 (Node 24.14.1), current head after rebasing onto `69d9e21`
- [x] `npm run typecheck` — 0 errors (root + app)
- [x] `npm run lint` — 0 errors, 11 pre-existing/generated warnings
- [x] Focused Codex discovery/parse/index suites — 13 pass / 0 fail on Windows before the unrelated upstream rebase
- [x] Disabled/enabled benchmark rerun on the current parent/head pair
- [x] No existing assertion was loosened

## Deliberately out of scope

- Codex full-file parsing and persistence after discovery.
- Combining the separate metadata-header read; this PR removes the measured quadratic loop only.
- Provider replay resumability (#140) and search context lookup (#139).