### PR TITLE
feat(core): add opt-in OR search fallback

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -28,6 +28,7 @@ interface QueryOptions extends Record<string, any> {
   source?: string;
   includeMeta?: boolean;
   includeInactive?: boolean;
+  fallback?: 'or';
   query?: string;
   projectLimit?: number;
   memoryLimit?: number;
@@ -256,12 +257,12 @@ function assertEnglishMemoryText(value: unknown, label: string): void {
   }
 }
 
-function buildSafeFtsQuery(text: unknown): string {
+function buildSafeFtsQuery(text: unknown, separator = ' '): string {
   const tokens = String(text || '').match(/[\p{Letter}\p{Number}]+/gu) || [];
   return tokens
     .slice(0, 12)
     .map(token => `"${token}"`)
-    .join(' ');
+    .join(separator);
 }
 
 function createQueryApi(
@@ -296,6 +297,7 @@ function createQueryApi(
       source,
       includeMeta = false,
       includeInactive = false,
+      fallback,
     } = opts;
     let where = 'WHERE mf.text MATCH ?';
     const filterParams: any[] = [];
@@ -325,6 +327,10 @@ function createQueryApi(
     } catch {
       const safe = buildSafeFtsQuery(text);
       rows = safe ? runMatch(safe) : [];
+    }
+    if (rows.length === 0 && fallback === 'or') {
+      const broad = buildSafeFtsQuery(text, ' OR ');
+      rows = broad ? runMatch(broad) : [];
     }
     return rows.map((r: DbRow) => {
       const metaClause = includeMeta ? '' : 'AND COALESCE(is_meta,0)=0';

--- a/skill-doc/SKILL.md
+++ b/skill-doc/SKILL.md
@@ -118,9 +118,13 @@ const topic = 'English topic terms translated from the user request';
 return {
   orientation: map.current_project,
   prior_memories: memories({ project, query: topic, limit: 5 }),
-  session_evidence: search(topic.replace(/[-_]/g, ' '), { project, limit: 8 }),
+  session_evidence: search(topic.replace(/[-_]/g, ' '), { project, limit: 8, fallback: 'or' }),
 };
 ```
+
+`fallback: 'or'` is for semantic-history recall: it retries safe token OR only
+when the primary FTS query is empty. Do not use it for exact scopes or sentinels,
+where an empty result is meaningful.
 
 Use `sql()` only as an escalation path for exact joins, aggregations, or schema
 questions that helpers cannot express cleanly. Do not use raw SQL as a generic
@@ -238,7 +242,11 @@ display-suppressed or transport-only records and is never returned by these
 helpers, even with the option enabled.
 
 Opts:
-`{ limit, sessionId, project, after, before, cwd, source, includeMeta, includeInactive }`.
+`{ limit, sessionId, project, after, before, cwd, source, includeMeta, includeInactive, fallback }`.
+
+Set `fallback: 'or'` only for semantic-history queries that may omit prior
+wording. The raw/safe primary query runs first; a non-empty result is returned
+unchanged. Exact-scope and sentinel queries should leave it unset.
 
 `project` is a SQL `LIKE` filter over `sessions.project`, not an exact project
 identity. Results are already ordered by FTS5 rank; lower rank sorts earlier.

--- a/skill-doc/references/api-reference.md
+++ b/skill-doc/references/api-reference.md
@@ -104,6 +104,7 @@ Full-text search across all indexed message text using FTS5.
 | `opts.source` | `string` | Provider ID such as `"claude"`, `"codex"`, `"deepseek"`, `"kimi"`, or `"pi"` |
 | `opts.includeMeta` | `boolean` | Include `is_meta=1` rows, default false |
 | `opts.includeInactive` | `boolean` | Include provider-attested superseded rows, default false |
+| `opts.fallback` | `'or'` | On zero hits only, retry safe tokens joined by OR |
 
 Returns:
 
@@ -129,6 +130,10 @@ Valid FTS5 syntax in `text` is honored. Input that FTS5 would reject as
 malformed (for example a hyphenated term like `foo-bar`) does not error: it
 falls back to safe per-token quoting — the same tokenization `memories()` uses —
 so ordinary text never crashes the query.
+
+`fallback: 'or'` is opt-in and does not alter a non-empty primary result. Use it
+for semantic-history recall, not exact scopes or sentinels where zero hits carry
+meaning. The retry retains all structural, visibility, and meta filters.
 
 #### `context(uuid, opts?)`
 

--- a/tests/query.test.mjs
+++ b/tests/query.test.mjs
@@ -85,6 +85,28 @@ test('search falls back to safe tokenization for FTS-special input instead of th
   db.close();
 });
 
+test('search broadens only an empty query when the OR fallback is explicitly enabled', () => {
+  const db = searchDb();
+  const api = createQueryApi(db);
+
+  assert.deepEqual(api.search('needle absent', { limit: 10 }), []);
+  assert.deepEqual(
+    api.search('needle absent', { fallback: 'or', limit: 10 }).map(row => row.message.uuid),
+    ['msg-text'],
+  );
+  assert.deepEqual(
+    new Set(api.search('needle absent', { fallback: 'or', includeInactive: true, limit: 10 }).map(row => row.message.uuid)),
+    new Set(['msg-text', 'msg-inactive']),
+    'the relaxed retry preserves visibility filtering',
+  );
+  assert.deepEqual(
+    api.search('needle reply', { fallback: 'or', limit: 10 }).map(row => row.message.uuid),
+    ['msg-text'],
+    'a non-empty primary result is not broadened',
+  );
+  db.close();
+});
+
 test('search exposes content_type on hits and temporal context', () => {
   const db = searchDb();
   const api = createQueryApi(db);


### PR DESCRIPTION
## Summary

- add an opt-in `fallback: 'or'` retry when the existing FTS query returns zero rows
- preserve exact search as the unchanged default and keep every existing visibility/source/time filter on the retry
- document the option as a second-pass recall tool in the shipped skill

Closes #143.

## Historical benchmark evidence (not rerun on this revision)

- `npm test -- tests/query.test.mjs`: 32/32 passed
- core typecheck and changed-file lint passed
- skill validation passed
- frozen Mem2ActBench-small development split (50 positive questions, Luna Max reader): end-to-end exact match 0.00 -> 0.18; argument F1 0.0313 -> 0.3047; slot accuracy 0.0283 -> 0.2453
- paired end-to-end wins/harms: 9/0, exact one-sided sign-test p=0.001953
- retrieval p95: 19.82 ms; the original exact arm's prompts and predictions were byte-identical to no-context, confirming the retry only activates after zero hits

The external test split remains sealed and is not used to tune this change.

## September 22 refresh and final-head verification

GitHub Actions run [35703044392](https://github.com/tommy0103/obelisk/actions/runs/35703044392): **Ubuntu, macOS and Windows jobs all passed** on this head. The local WSL results below are retained rather than hidden.

- Merged main `774d4bc` without rewriting the existing PR history. Final head: `c7b6981`.
- Resolved the overlap with upstream bounded temporal-context lookup; both that optimization and opt-in OR fallback remain.
- Focused verification: 59/59 Windows tests across query, runtime, CLI envelope and package suites. Added explicit session/project/source/time/cwd/meta/limit and punctuation-only fallback checks.
- WSL Ubuntu / Node 24.14.1: `npm test` **756 pass / 3 fail / 0 skipped (759 tests)**; not claimed green. Failures are the two Codex touch/ctime tests and OMP same-size title rewrite test. Unmodified main reproduced the title/OMP failures (755 pass / 2 fail of 757); a separate repeated main run also reproduced the intermittent ctime assertion failure. The provider files are unchanged by this PR.
- `npm run typecheck`: passed, root + app.
- `npm run lint`: 0 errors / 11 existing warnings.
- `git diff --check`: passed. No existing assertions loosened.
- Built CLI `--query` smoke passed in an isolated temporary home: default zero-hit result stays empty, opt-in OR returns the expected UUID, and a missing session scope stays empty.
- New regressions run in CI: query suite in the explicit query job and Linux full suite.
- No app/provider implementation changes relative to main. No Electron UI change is being proposed.
- Historical benchmark numbers above are retained as prior evidence, not a new measurement on this head. No fresh performance claim is made.
