### PR TITLE
perf(core): index sparse failure results by session

### DIFF
--- a/packages/core/src/schema.sql
+++ b/packages/core/src/schema.sql
@@ -74,6 +74,8 @@ CREATE INDEX IF NOT EXISTS idx_tc_message ON tool_calls(message_uuid);
 CREATE INDEX IF NOT EXISTS idx_tc_file ON tool_calls(file_path);
 CREATE INDEX IF NOT EXISTS idx_tr_session ON tool_results(session_id);
 CREATE INDEX IF NOT EXISTS idx_tr_message ON tool_results(message_uuid);
+CREATE INDEX IF NOT EXISTS idx_tr_failure_session ON tool_results(session_id)
+  WHERE is_error = 1 OR content LIKE 'Exit code %';
 CREATE INDEX IF NOT EXISTS idx_sa_session ON subagents(session_id);
 CREATE INDEX IF NOT EXISTS idx_wf_session ON workflows(session_id);
 CREATE INDEX IF NOT EXISTS idx_wa_run ON workflow_agents(run_id);

--- a/tests/db-schema.test.mjs
+++ b/tests/db-schema.test.mjs
@@ -135,10 +135,17 @@ test('tool results schema limits failure scans to failure rows', async () => {
       EXPLAIN QUERY PLAN
       SELECT tr.*
       FROM tool_results tr
+      LEFT JOIN messages rm ON rm.uuid=tr.message_uuid
+      LEFT JOIN tool_calls tc ON tc.id=tr.tool_use_id
+      LEFT JOIN messages cm ON cm.uuid=tc.message_uuid
       LEFT JOIN sessions s ON s.id=tr.session_id
       WHERE (tr.is_error = 1 OR tr.content LIKE 'Exit code %')
-        AND s.source = ?
-    `).all('codex');
+        AND COALESCE(rm.visibility,'visible')='visible'
+        AND COALESCE(cm.visibility,'visible')='visible'
+        AND COALESCE(s.source, 'claude') = ?
+      ORDER BY rm.timestamp DESC
+      LIMIT ?
+    `).all('codex', 50);
 
     assert.ok(
       plan.some(row => /USING INDEX idx_tr_failure_session/.test(String(row.detail))),

--- a/tests/db-schema.test.mjs
+++ b/tests/db-schema.test.mjs
@@ -127,6 +127,28 @@ test('tool results schema indexes live session patch lookups', async () => {
   }
 });
 
+test('tool results schema limits failure scans to failure rows', async () => {
+  const db = new DatabaseSync(':memory:');
+  try {
+    db.exec(await readExecutableSchema());
+    const plan = db.prepare(`
+      EXPLAIN QUERY PLAN
+      SELECT tr.*
+      FROM tool_results tr
+      LEFT JOIN sessions s ON s.id=tr.session_id
+      WHERE (tr.is_error = 1 OR tr.content LIKE 'Exit code %')
+        AND s.source = ?
+    `).all('codex');
+
+    assert.ok(
+      plan.some(row => /USING INDEX idx_tr_failure_session/.test(String(row.detail))),
+      `expected partial failure index, got: ${plan.map(row => row.detail).join('; ')}`,
+    );
+  } finally {
+    db.close();
+  }
+});
+
 test('session detail queries use the visible main timeline index', async () => {
   const db = new DatabaseSync(':memory:');
   try {

--- a/tests/provider-schema-stability.test.mjs
+++ b/tests/provider-schema-stability.test.mjs
@@ -12,8 +12,8 @@ test('canonical transcript persistence schema changes only by explicit decision'
   const schema = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url));
   assert.equal(
     createHash('sha256').update(schema).digest('hex'),
-    // 2026-08-24: indexed Activity queries and the visible main session timeline.
-    '0417d1a044a574a9adc8f347db5f46428a984e89900504bb082ce7366ebb1d4a',
+    // 2026-09-03: indexed the sparse failure-result subset by session.
+    '1375f420b93f62ad289bc9b2d10f7ba5fb30672195938eb17f54cd8206177e24',
   );
 });
 


### PR DESCRIPTION
## Summary

- add one partial SQLite index for the sparse failure-result subset used by `failures()`
- keep query results and visibility/source semantics unchanged
- add a query-plan regression and update the provider-schema digest

## Historical benchmark evidence (not rerun on this revision)

On a recoverable 3.33 GB real-history snapshot (233,016 tool results; 1,029 failures), 20 repeated provider-filtered calls changed as follows:

| provider | baseline p95 | indexed p95 | speedup |
| --- | ---: | ---: | ---: |
| Claude | 2199.10 ms | 61.27 ms | 35.9x |
| Codex | 2153.65 ms | 54.02 ms | 39.9x |
| Pi | 2256.32 ms | 52.38 ms | 43.1x |

Every before/after result hash matched. One-time index creation on the existing DB was 4.683 s. A fresh 1.94 GB Codex build showed identical row counts and semantic digest; one baseline/candidate pair was 10.69 s / 10.12 s, so no fresh-build regression was observed.

## Prior checks (superseded by the verification below)

- focused query-plan test passed
- core typecheck passed
- changed-file lint passed

## September 22 refresh and final-head verification

GitHub Actions run [35703043890](https://github.com/tommy0103/obelisk/actions/runs/35703043890): Ubuntu and macOS passed; Windows failed in the unchanged `codex strict reconcile heals a touched-but-unchanged source` test (`tests/codex-parse.test.mjs:325`, ctime did not change). This assertion also alternately passed and failed in two targeted runs on unmodified main locally. The contributor account cannot rerun upstream CI (admin rights required); maintainer rerun requested. This is not an all-green CI claim.

- Merged main `774d4bc` without rewriting the existing PR history. Final head: `18a0478`.
- The original review concern was already fixed in e47e2bf. The plan retains production LEFT JOINs and COALESCE(s.source, 'claude'), rather than dropping legacy/missing-session rows.
- Focused verification: 48/48 Windows tests across db-schema and query suites. Added a production-helper regression for NULL source, missing session rows, visibility, scope and limit; indexed and unindexed returned evidence is identical.
- WSL Ubuntu / Node 24.14.1: `npm test` **756 pass / 3 fail / 0 skipped (759 tests)**; not claimed green. Failures are the two Codex touch/ctime tests and OMP same-size title rewrite test. Unmodified main reproduced the title/OMP failures (755 pass / 2 fail of 757); a separate repeated main run also reproduced the intermittent ctime assertion failure. The provider files are unchanged by this PR.
- `npm run typecheck`: passed, root + app.
- `npm run lint`: 0 errors / 11 existing warnings.
- `git diff --check`: passed. No existing assertions loosened.
- New regressions run in CI: db-schema suite through the Linux full-suite job.
- No app/provider implementation changes relative to main. No Electron UI change is being proposed.
- Historical benchmark numbers above are retained as prior evidence, not a new measurement on this head. No fresh performance claim is made.
