### PR TITLE
fix(core): ignore exported Pi subagent artifacts

### DIFF
--- a/packages/core/src/providers/pi.ts
+++ b/packages/core/src/providers/pi.ts
@@ -366,7 +366,11 @@ function listJsonlFiles(root: string): {
     }
     for (const entry of entries) {
       const path = join(current, entry.name);
-      if (entry.isDirectory()) stack.push(path);
+      if (entry.isDirectory()) {
+        // Pi subagent integrations store exported transcripts here; they are
+        // not Pi sessions and have a different JSONL header contract.
+        if (entry.name.toLowerCase() !== 'subagent-artifacts') stack.push(path);
+      }
       else if (entry.name.toLowerCase().endsWith('.jsonl')) {
         if (entry.isFile()) {
           files.push(normalize(path));

--- a/tests/pi-parse.test.mjs
+++ b/tests/pi-parse.test.mjs
@@ -1819,6 +1819,21 @@ test('a malformed Pi file does not force unrelated unchanged sessions to reparse
   assert.throws(() => drain(provider.parse(units[0], null)), /Empty Pi session/);
 });
 
+test('discovery ignores exported subagent artifact transcripts', () => {
+  const root = makeTempDir('obelisk-pi-subagent-artifacts-');
+  const session = writeSession(fixture('tool-session.jsonl'), { root });
+  writeSession(jsonl([{
+    version: 1,
+    recordType: 'message',
+    source: 'subagent',
+    text: 'not a Pi session',
+  }]), { root, relativePath: 'project/subagent-artifacts/worker_transcript.jsonl' });
+
+  const units = createPiProvider({ rootDir: root }).discover({ lastCursor: () => null });
+
+  assert.deepEqual(units.map(unit => unit.key), [session.path]);
+});
+
 test('a moved session with an unreadable identity cannot retract its last good snapshot', () => {
   const written = writeSession(jsonl([
     header({ id: 'moved-torn-session' }),


### PR DESCRIPTION
## Summary

- skip `subagent-artifacts` directories while discovering Pi JSONL sessions
- keep malformed files elsewhere fail-closed as before
- add a focused discovery regression

## Evidence

A real Pi root contained a 250 KB exported Luna worker transcript whose first record uses the subagent artifact contract, not Pi's required `type: "session"` header. Before this change every incremental build retried it and reported `complete: false`.

After the change, 20 repeated real-root Pi builds were complete with p95 35.09 ms. A combined Claude/Codex/Pi run was complete with p95 592.90 ms. The focused regression passes.