### PR TITLE
[Core] Batch canonical replay SQLite probes

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -46,7 +46,7 @@ jobs:
         run: node --test app/tests/electron-vite-schema-asset.mjs
 
       - name: Verify shared persistence idempotency
-        run: node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/persist-idempotency.test.mjs tests/persist.test.mjs tests/indexer-upsert-drift.test.mjs
+        run: node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/persist-idempotency.test.mjs tests/persist-replay-probes.test.mjs tests/persist.test.mjs tests/indexer-upsert-drift.test.mjs
 
       - name: Verify adaptive watcher package
         run: |

--- a/docs/adr/0001-parse-core-and-persist-layers.md
+++ b/docs/adr/0001-parse-core-and-persist-layers.md
@@ -85,6 +85,27 @@ preserve their individual contracts. No provider cursor or canonical transcript
 marker changes for this amendment because the projected canonical values do not
 change.
 
+**Amendment (2026-09-04): bounded canonical replay filtering.** Conditional
+UPSERTs stop physical writes but still execute one primary-key probe for every
+record in a snapshot replay. Once a stream reaches 250 records, the shared
+persist layer fetches existing message/tool state in bounded 250-record batches
+and executes the established UPSERTs only for new or changed values. Shorter
+delta streams retain the direct conditional-UPSERT path and do not pay an extra
+read. Each lookup is further capped at 900 bound keys, below SQLite's portable
+variable limit, and the batch bound prevents a long transcript from being
+materialized in memory at the persistence seam.
+
+Comparison uses the same authoritative field sets as the conditional UPSERTs
+and simulates accepted changes in record order inside the batch. This preserves
+the final state when one key appears more than once, including message duration
+updates. A `delete-session` record is a hard batch boundary so later records
+observe the deletion rather than prefetched stale state. Retractions attached
+to an `IndexUnit` still run before any state is fetched. Sessions, summaries,
+subagents, workflows, workflow agents, and `index_state` retain their existing
+write and merge contracts. This optimization changes neither canonical values
+nor provider cursors and therefore requires no schema migration or canonical
+transcript marker bump.
+
 **Two indexing modes** share all of the above and differ only in trigger:
 **daemon mode** (the app, and potentially a future CLI daemon, watches and keeps
 the index fresh) and **passive pull mode** (a CLI command indexes on invocation

--- a/packages/core/src/persist.ts
+++ b/packages/core/src/persist.ts
@@ -10,14 +10,102 @@
 // only place that knows the schema. Adapters stay pure.
 //
 // Write semantics are the canonical ones reconciled from the drift: messages
-// and tool rows upsert only when canonical values differ; sessions merge with
-// any existing row (started_at MIN, ended_at MAX, message_count
+// and tool rows are prefetched in bounded batches so only new or changed values
+// execute an upsert; sessions merge with any existing row (started_at MIN,
+// ended_at MAX, message_count
 // reset-or-accumulate, fill-if-null for the rest); turn-duration is a targeted
 // conditional UPDATE; delete-session cascades. The generator's return value is
 // the new cursor, persisted verbatim into index_state.
 
-import type { Cursor, TranscriptRecord, IndexUnit } from './providers/types.ts';
-import type { SqliteDb } from './sqlite-types.ts';
+import type {
+  Cursor,
+  IndexUnit,
+  MessageRecord,
+  ToolCallRecord,
+  ToolResultRecord,
+  TranscriptRecord,
+} from './providers/types.ts';
+import type { SqliteDb, SqliteRow } from './sqlite-types.ts';
+
+const REPLAY_FILTER_THRESHOLD = 250;
+const SQLITE_SAFE_KEY_COUNT = 900;
+
+const MESSAGE_FIELDS = [
+  'session_id', 'type', 'parent_uuid', 'timestamp', 'role', 'text',
+  'content_type', 'is_meta', 'visibility', 'model', 'is_sidechain',
+  'agent_id', 'input_tokens', 'output_tokens', 'cwd', 'skill', 'source',
+] as const satisfies readonly (keyof MessageRecord)[];
+const TOOL_CALL_FIELDS = [
+  'message_uuid', 'session_id', 'name', 'presentation', 'input_json', 'file_path',
+] as const satisfies readonly (keyof ToolCallRecord)[];
+const TOOL_RESULT_FIELDS = [
+  'message_uuid', 'session_id', 'content', 'file_path', 'is_error',
+] as const satisfies readonly (keyof ToolResultRecord)[];
+
+interface ReplayState {
+  messages: Map<string, SqliteRow>;
+  toolCalls: Map<string, SqliteRow>;
+  toolResults: Map<string, SqliteRow>;
+}
+
+function sameFields<T extends object>(row: SqliteRow, record: T, fields: readonly (keyof T)[]): boolean {
+  return fields.every(field => row[String(field)] === record[field]);
+}
+
+function uniqueKeys(records: readonly TranscriptRecord[], kinds: readonly TranscriptRecord['kind'][]): string[] {
+  const accepted = new Set(kinds);
+  const keys = new Set<string>();
+  for (const record of records) {
+    if (!accepted.has(record.kind)) continue;
+    if (record.kind === 'message' || record.kind === 'message-turn-duration') keys.add(record.uuid);
+    else if (record.kind === 'tool_call') keys.add(record.id);
+    else if (record.kind === 'tool_result') keys.add(record.tool_use_id);
+  }
+  return [...keys];
+}
+
+function loadRows(
+  db: SqliteDb,
+  table: 'messages' | 'tool_calls' | 'tool_results',
+  keyColumn: 'uuid' | 'id' | 'tool_use_id',
+  columns: string,
+  keys: readonly string[],
+): Map<string, SqliteRow> {
+  if (keys.length === 0) return new Map();
+  // Identifiers are closed unions supplied by this module. Transcript keys
+  // remain bound values and never enter the SQL text.
+  const result = new Map<string, SqliteRow>();
+  for (let offset = 0; offset < keys.length; offset += SQLITE_SAFE_KEY_COUNT) {
+    const chunk = keys.slice(offset, offset + SQLITE_SAFE_KEY_COUNT);
+    const placeholders = chunk.map(() => '?').join(',');
+    const rows = db.prepare(`SELECT ${columns} FROM ${table} WHERE ${keyColumn} IN (${placeholders})`).all(...chunk);
+    for (const row of rows) result.set(String(row[keyColumn]), row);
+  }
+  return result;
+}
+
+function loadReplayState(db: SqliteDb, records: readonly TranscriptRecord[]): ReplayState {
+  const messageKeys = uniqueKeys(records, ['message', 'message-turn-duration']);
+  const toolCallKeys = uniqueKeys(records, ['tool_call']);
+  const toolResultKeys = uniqueKeys(records, ['tool_result']);
+  return {
+    messages: loadRows(
+      db,
+      'messages',
+      'uuid',
+      `uuid,${MESSAGE_FIELDS.join(',')},turn_duration_ms`,
+      messageKeys,
+    ),
+    toolCalls: loadRows(db, 'tool_calls', 'id', `id,${TOOL_CALL_FIELDS.join(',')}`, toolCallKeys),
+    toolResults: loadRows(
+      db,
+      'tool_results',
+      'tool_use_id',
+      `tool_use_id,${TOOL_RESULT_FIELDS.join(',')}`,
+      toolResultKeys,
+    ),
+  };
+}
 
 const minStr = (a: string | null, b: string | null) => (a == null ? b : b == null ? a : a < b ? a : b);
 const maxStr = (a: string | null, b: string | null) => (a == null ? b : b == null ? a : a > b ? a : b);
@@ -137,17 +225,29 @@ export function persist(db: SqliteDb, unit: IndexUnit, gen: Generator<Transcript
   const st = statements(db);
   for (const sessionId of unit.retractSessionIds ?? []) deleteSession(db, sessionId);
 
-  const write = (r: TranscriptRecord) => {
+  const write = (r: TranscriptRecord, replay: ReplayState | null) => {
     switch (r.kind) {
-      case 'message':
+      case 'message': {
+        const previous = replay?.messages.get(r.uuid);
+        if (replay != null && previous != null && sameFields(previous, r, MESSAGE_FIELDS)) break;
         st.msg.run(r.uuid, r.session_id, r.type, r.parent_uuid, r.timestamp, r.role, r.text, r.content_type, r.is_meta, r.visibility, r.model, r.is_sidechain, r.agent_id, r.input_tokens, r.output_tokens, r.cwd, r.skill, r.source);
+        replay?.messages.set(r.uuid, { ...r, turn_duration_ms: previous?.turn_duration_ms ?? null });
         break;
-      case 'tool_call':
+      }
+      case 'tool_call': {
+        const previous = replay?.toolCalls.get(r.id);
+        if (replay != null && previous != null && sameFields(previous, r, TOOL_CALL_FIELDS)) break;
         st.tc.run(r.id, r.message_uuid, r.session_id, r.name, r.presentation, r.input_json, r.file_path);
+        replay?.toolCalls.set(r.id, r);
         break;
-      case 'tool_result':
+      }
+      case 'tool_result': {
+        const previous = replay?.toolResults.get(r.tool_use_id);
+        if (replay != null && previous != null && sameFields(previous, r, TOOL_RESULT_FIELDS)) break;
         st.tr.run(r.tool_use_id, r.message_uuid, r.session_id, r.content, r.file_path, r.is_error);
+        replay?.toolResults.set(r.tool_use_id, r);
         break;
+      }
       case 'summary':
         st.sum.run(
           r.id,
@@ -169,9 +269,15 @@ export function persist(db: SqliteDb, unit: IndexUnit, gen: Generator<Transcript
       case 'workflow_agent':
         st.wa.run(r.agent_id, r.run_id, r.session_id, r.agent_type ?? null, r.description ?? null, r.phase ?? null, r.label ?? null, r.model ?? null, r.state ?? null, r.duration_ms ?? null, r.tokens ?? null, r.tool_calls ?? null);
         break;
-      case 'message-turn-duration':
+      case 'message-turn-duration': {
+        const previous = replay?.messages.get(r.uuid);
+        if (replay != null && (previous == null || previous.turn_duration_ms === r.turn_duration_ms)) break;
         st.turn.run(r.turn_duration_ms, r.uuid, r.turn_duration_ms);
+        if (replay != null && previous != null) {
+          replay.messages.set(r.uuid, { ...previous, turn_duration_ms: r.turn_duration_ms });
+        }
         break;
+      }
       case 'session': {
         const prev = st.getSession.get(r.id);
         // 'delta' accumulates onto the existing count (line-incremental adapters);
@@ -200,8 +306,30 @@ export function persist(db: SqliteDb, unit: IndexUnit, gen: Generator<Transcript
     }
   };
 
+  let replayFiltering = false;
+  let batch: TranscriptRecord[] = [];
+  const flush = () => {
+    if (batch.length === 0) return;
+    if (batch.length >= REPLAY_FILTER_THRESHOLD) replayFiltering = true;
+    const replay = replayFiltering ? loadReplayState(db, batch) : null;
+    for (const record of batch) write(record, replay);
+    batch = [];
+  };
+
   let step = gen.next();
-  while (!step.done) { write(step.value); step = gen.next(); }
+  while (!step.done) {
+    // A stream-level deletion invalidates any prefetched state for the session.
+    // Flush around it so records after the tombstone observe the deletion.
+    if (step.value.kind === 'delete-session') {
+      flush();
+      write(step.value, null);
+    } else {
+      batch.push(step.value);
+      if (batch.length >= REPLAY_FILTER_THRESHOLD) flush();
+    }
+    step = gen.next();
+  }
+  flush();
   const cursor = step.value;
 
   if (cursor != null) {

--- a/tests/persist-idempotency.test.mjs
+++ b/tests/persist-idempotency.test.mjs
@@ -105,8 +105,11 @@ function* canonicalRecords({ message = {}, toolCall = {}, toolResult = {}, durat
   return null;
 }
 
-function* oneRecord(record) {
+function* replaySizedRecord(record) {
   yield record;
+  for (let index = 0; index < 249; index += 1) {
+    yield { kind: 'message-turn-duration', uuid: `missing-${index}`, turn_duration_ms: null };
+  }
   return null;
 }
 
@@ -255,13 +258,13 @@ test('every authoritative field can independently trigger an in-place update', (
 
   for (const [table, key, base, changes] of cases) {
     for (const [column, value] of Object.entries(changes)) {
-      persist(db, unit, oneRecord({ ...base, [column]: value }));
+      persist(db, unit, replaySizedRecord({ ...base, [column]: value }));
       assert.equal(
         db.prepare(`SELECT ${column} AS value FROM ${table} WHERE ${key}=?`).get(base[key]).value,
         value,
         `${table}.${column} did not update`,
       );
-      persist(db, unit, oneRecord(base));
+      persist(db, unit, replaySizedRecord(base));
     }
   }
 

--- a/tests/persist-idempotency.test.mjs
+++ b/tests/persist-idempotency.test.mjs
@@ -3,66 +3,24 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { createRequire } from 'node:module';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 
 import { healWorkflowParentLinks } from '../packages/core/src/indexer.ts';
 import { persist } from '../packages/core/src/persist.ts';
+import {
+  bindings,
+  messageRecord,
+  openNodeSqlite,
+  SCHEMA,
+  toolCallRecord,
+  toolResultRecord,
+} from './persist-test-fixtures.mjs';
 
-const require = createRequire(import.meta.url);
-const { DatabaseSync } = require('node:sqlite');
-const appDir = fileURLToPath(new URL('../app/', import.meta.url));
-const BetterSqlite3 = require(require.resolve('better-sqlite3', { paths: [appDir] }));
-const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
-
-const bindings = [
-  ['node:sqlite', () => new DatabaseSync(':memory:')],
-  ['better-sqlite3', () => new BetterSqlite3(':memory:')],
-];
-
-const BASE_MESSAGE = {
-  kind: 'message',
-  uuid: 'message-1',
-  session_id: 'session-1',
-  type: 'assistant',
-  parent_uuid: null,
+const BASE_MESSAGE = messageRecord(1, {
   timestamp: '2026-09-01T10:00:00.000Z',
-  role: 'assistant',
   text: 'stable searchable text',
-  content_type: 'text',
-  is_meta: 0,
-  visibility: 'visible',
-  model: 'model-1',
-  is_sidechain: 0,
-  agent_id: null,
-  input_tokens: 10,
-  output_tokens: 20,
-  cwd: '/workspace',
-  skill: null,
-  source: 'codex',
-};
-
-const BASE_TOOL_CALL = {
-  kind: 'tool_call',
-  id: 'call-1',
-  message_uuid: 'message-1',
-  session_id: 'session-1',
-  name: 'exec_command',
-  presentation: 'default',
-  input_json: '{"cmd":"true"}',
-  file_path: null,
-};
-
-const BASE_TOOL_RESULT = {
-  kind: 'tool_result',
-  tool_use_id: 'call-1',
-  message_uuid: 'message-1',
-  session_id: 'session-1',
-  content: 'done',
-  file_path: null,
-  is_error: 0,
-};
+});
+const BASE_TOOL_CALL = toolCallRecord(1);
+const BASE_TOOL_RESULT = toolResultRecord(1);
 
 function installWriteAudit(db) {
   db.exec(`
@@ -110,6 +68,11 @@ function* replaySizedRecord(record) {
   for (let index = 0; index < 249; index += 1) {
     yield { kind: 'message-turn-duration', uuid: `missing-${index}`, turn_duration_ms: null };
   }
+  return null;
+}
+
+function* oneRecord(record) {
+  yield record;
   return null;
 }
 
@@ -233,46 +196,54 @@ for (const [binding, openDb] of bindings) {
   });
 }
 
-test('every authoritative field can independently trigger an in-place update', () => {
-  const db = new DatabaseSync(':memory:');
+const AUTHORITATIVE_FIELD_CASES = [
+  ['messages', 'uuid', BASE_MESSAGE, {
+    session_id: 'session-2', type: 'user', parent_uuid: 'parent-1', timestamp: null,
+    role: null, text: null, content_type: null, is_meta: 1, visibility: 'hidden',
+    model: null, is_sidechain: 1, agent_id: 'agent-1', input_tokens: null,
+    output_tokens: null, cwd: null, skill: 'review', source: 'claude',
+  }],
+  ['tool_calls', 'id', BASE_TOOL_CALL, {
+    message_uuid: 'message-2', session_id: 'session-2', name: 'read_file',
+    presentation: 'skill', input_json: '{}', file_path: '/tmp/input',
+  }],
+  ['tool_results', 'tool_use_id', BASE_TOOL_RESULT, {
+    message_uuid: 'message-2', session_id: 'session-2', content: 'changed',
+    file_path: '/tmp/output', is_error: 1,
+  }],
+];
+
+function assertEveryAuthoritativeField(recordStream) {
+  const db = openNodeSqlite();
   db.exec(SCHEMA);
   const unit = { key: 'unit-1', sessionId: 'session-1' };
   persist(db, unit, canonicalRecords());
 
-  const cases = [
-    ['messages', 'uuid', BASE_MESSAGE, {
-      session_id: 'session-2', type: 'user', parent_uuid: 'parent-1', timestamp: null,
-      role: null, text: null, content_type: null, is_meta: 1, visibility: 'hidden',
-      model: null, is_sidechain: 1, agent_id: 'agent-1', input_tokens: null,
-      output_tokens: null, cwd: null, skill: 'review', source: 'claude',
-    }],
-    ['tool_calls', 'id', BASE_TOOL_CALL, {
-      message_uuid: 'message-2', session_id: 'session-2', name: 'read_file',
-      presentation: 'skill', input_json: '{}', file_path: '/tmp/input',
-    }],
-    ['tool_results', 'tool_use_id', BASE_TOOL_RESULT, {
-      message_uuid: 'message-2', session_id: 'session-2', content: 'changed',
-      file_path: '/tmp/output', is_error: 1,
-    }],
-  ];
-
-  for (const [table, key, base, changes] of cases) {
+  for (const [table, key, base, changes] of AUTHORITATIVE_FIELD_CASES) {
     for (const [column, value] of Object.entries(changes)) {
-      persist(db, unit, replaySizedRecord({ ...base, [column]: value }));
+      persist(db, unit, recordStream({ ...base, [column]: value }));
       assert.equal(
         db.prepare(`SELECT ${column} AS value FROM ${table} WHERE ${key}=?`).get(base[key]).value,
         value,
         `${table}.${column} did not update`,
       );
-      persist(db, unit, replaySizedRecord(base));
+      persist(db, unit, recordStream(base));
     }
   }
 
   db.close();
+}
+
+test('direct path lets every authoritative field independently trigger an in-place update', () => {
+  assertEveryAuthoritativeField(oneRecord);
+});
+
+test('replay filtering lets every authoritative field independently trigger an in-place update', () => {
+  assertEveryAuthoritativeField(replaySizedRecord);
 });
 
 test('changed tool-result replay preserves workflow healer candidate order', () => {
-  const db = new DatabaseSync(':memory:');
+  const db = openNodeSqlite();
   db.exec(SCHEMA);
   const unit = { key: 'unit-1', sessionId: 'session-1' };
   const toolResult = (id, content) => ({

--- a/tests/persist-replay-probes.test.mjs
+++ b/tests/persist-replay-probes.test.mjs
@@ -10,10 +10,10 @@ import { ensureFtsReady, refreshSessionProjectPaths } from '../packages/core/src
 import { persist } from '../packages/core/src/persist.ts';
 import {
   bindings,
-  messageRecord,
+  messageRecord as message,
   SCHEMA,
-  toolCallRecord,
-  toolResultRecord,
+  toolCallRecord as toolCall,
+  toolResultRecord as toolResult,
 } from './persist-test-fixtures.mjs';
 
 function canonicalKind(sql) {
@@ -56,18 +56,6 @@ function instrument(db) {
       close() { return db.close(); },
     },
   };
-}
-
-function message(id, changes = {}) {
-  return messageRecord(id, changes);
-}
-
-function toolCall(id, changes = {}) {
-  return toolCallRecord(id, changes);
-}
-
-function toolResult(id, changes = {}) {
-  return toolResultRecord(id, changes);
 }
 
 function* snapshot(count, changedId = null) {

--- a/tests/persist-replay-probes.test.mjs
+++ b/tests/persist-replay-probes.test.mjs
@@ -1,0 +1,218 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { persist } from '../packages/core/src/persist.ts';
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require('node:sqlite');
+const appDir = fileURLToPath(new URL('../app/', import.meta.url));
+const BetterSqlite3 = require(require.resolve('better-sqlite3', { paths: [appDir] }));
+const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+
+const bindings = [
+  ['node:sqlite', () => new DatabaseSync(':memory:')],
+  ['better-sqlite3', () => new BetterSqlite3(':memory:')],
+];
+
+function canonicalKind(sql) {
+  const normalized = sql.replace(/\s+/g, ' ').trim().toLowerCase();
+  if (/\b(?:from|join) messages\b/.test(normalized) || normalized.startsWith('insert into messages ') || normalized.startsWith('update messages ')) return 'messages';
+  if (/\b(?:from|join) tool_calls\b/.test(normalized) || normalized.startsWith('insert into tool_calls ')) return 'tool_calls';
+  if (/\b(?:from|join) tool_results\b/.test(normalized) || normalized.startsWith('insert into tool_results ')) return 'tool_results';
+  return null;
+}
+
+function instrument(db) {
+  const metrics = { reads: 0, writes: 0, byTable: {} };
+  const record = (sql, method) => {
+    const table = canonicalKind(sql);
+    if (table == null) return;
+    const operation = method === 'all' || method === 'get' ? 'reads' : 'writes';
+    metrics[operation] += 1;
+    metrics.byTable[table] ??= { reads: 0, writes: 0 };
+    metrics.byTable[table][operation] += 1;
+  };
+  return {
+    metrics,
+    reset() {
+      metrics.reads = 0;
+      metrics.writes = 0;
+      metrics.byTable = {};
+    },
+    handle: {
+      exec(sql) { return db.exec(sql); },
+      prepare(sql) {
+        const statement = db.prepare(sql);
+        return {
+          all(...bindings) { record(sql, 'all'); return statement.all(...bindings); },
+          get(...bindings) { record(sql, 'get'); return statement.get(...bindings); },
+          run(...bindings) { record(sql, 'run'); return statement.run(...bindings); },
+          get readonly() { return statement.readonly; },
+          get sourceSQL() { return statement.sourceSQL; },
+        };
+      },
+      close() { return db.close(); },
+    },
+  };
+}
+
+function message(id, changes = {}) {
+  return {
+    kind: 'message',
+    uuid: `message-${id}`,
+    session_id: 'session-1',
+    type: 'assistant',
+    parent_uuid: null,
+    timestamp: `2026-09-01T10:${String(id % 60).padStart(2, '0')}:00.000Z`,
+    role: 'assistant',
+    text: `stable searchable text ${id}`,
+    content_type: 'text',
+    is_meta: 0,
+    visibility: 'visible',
+    model: 'model-1',
+    is_sidechain: 0,
+    agent_id: null,
+    input_tokens: 10,
+    output_tokens: 20,
+    cwd: '/workspace',
+    skill: null,
+    source: 'codex',
+    ...changes,
+  };
+}
+
+function toolCall(id, changes = {}) {
+  return {
+    kind: 'tool_call',
+    id: `call-${id}`,
+    message_uuid: `message-${id}`,
+    session_id: 'session-1',
+    name: 'exec_command',
+    presentation: 'default',
+    input_json: '{"cmd":"true"}',
+    file_path: null,
+    ...changes,
+  };
+}
+
+function toolResult(id, changes = {}) {
+  return {
+    kind: 'tool_result',
+    tool_use_id: `call-${id}`,
+    message_uuid: `message-${id}`,
+    session_id: 'session-1',
+    content: 'done',
+    file_path: null,
+    is_error: 0,
+    ...changes,
+  };
+}
+
+function* snapshot(count, changedId = null) {
+  for (let id = 0; id < count; id += 1) {
+    const changed = id === changedId;
+    yield message(id, changed ? { text: `changed searchable text ${id}`, input_tokens: null, skill: 'review' } : {});
+    yield toolCall(id, changed ? { presentation: 'skill', file_path: '/tmp/input' } : {});
+    yield toolResult(id, changed ? { content: 'changed output', file_path: '/tmp/output', is_error: 1 } : {});
+    yield { kind: 'message-turn-duration', uuid: `message-${id}`, turn_duration_ms: changed ? null : 42 };
+  }
+  return null;
+}
+
+function* records(items) {
+  yield* items;
+  return null;
+}
+
+for (const [binding, openDb] of bindings) {
+  test(`${binding}: short delta keeps the direct write path`, () => {
+    const rawDb = openDb();
+    rawDb.exec(SCHEMA);
+    const observed = instrument(rawDb);
+
+    persist(
+      observed.handle,
+      { key: 'delta-unit', sessionId: 'session-1' },
+      records([message('delta')]),
+    );
+
+    assert.equal(observed.metrics.reads, 0);
+    assert.equal(observed.metrics.writes, 1);
+    rawDb.close();
+  });
+
+  test(`${binding}: unchanged snapshot rows do not execute one SQLite statement each`, (t) => {
+    const rawDb = openDb();
+    rawDb.exec(SCHEMA);
+    const observed = instrument(rawDb);
+    const unit = { key: 'unit-1', sessionId: 'session-1' };
+
+    persist(observed.handle, unit, snapshot(1_000));
+    const rowids = {
+      message: rawDb.prepare('SELECT rowid FROM messages WHERE uuid=?').get('message-500').rowid,
+      toolCall: rawDb.prepare('SELECT rowid FROM tool_calls WHERE id=?').get('call-500').rowid,
+      toolResult: rawDb.prepare('SELECT rowid FROM tool_results WHERE tool_use_id=?').get('call-500').rowid,
+    };
+    observed.reset();
+
+    persist(observed.handle, unit, snapshot(1_001, 500));
+
+    const classification = {
+      emitted: 4_004,
+      existing: 4_000,
+      new: 4,
+      modified: 4,
+      unchanged: 3_996,
+    };
+    t.diagnostic(JSON.stringify({ classification, sqlite: observed.metrics }));
+    assert.equal(observed.metrics.writes, classification.new + classification.modified);
+    assert.ok(
+      observed.metrics.reads + observed.metrics.writes < 80,
+      `${observed.metrics.reads + observed.metrics.writes} canonical SQLite executions remain for ${classification.emitted} emitted records`,
+    );
+    assert.deepEqual(
+      {
+        message: rawDb.prepare('SELECT rowid FROM messages WHERE uuid=?').get('message-500').rowid,
+        toolCall: rawDb.prepare('SELECT rowid FROM tool_calls WHERE id=?').get('call-500').rowid,
+        toolResult: rawDb.prepare('SELECT rowid FROM tool_results WHERE tool_use_id=?').get('call-500').rowid,
+      },
+      rowids,
+    );
+    assert.deepEqual(
+      { ...rawDb.prepare('SELECT text,input_tokens,skill,turn_duration_ms FROM messages WHERE uuid=?').get('message-500') },
+      { text: 'changed searchable text 500', input_tokens: null, skill: 'review', turn_duration_ms: null },
+    );
+    assert.equal(rawDb.prepare("SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH 'changed'").get().count, 1);
+    assert.equal(rawDb.prepare("SELECT COUNT(*) AS count FROM messages_fts WHERE messages_fts MATCH 'stable AND 500'").get().count, 0);
+    rawDb.prepare("INSERT INTO messages_fts(messages_fts, rank) VALUES('integrity-check', 1)").run();
+    rawDb.close();
+  });
+
+  test(`${binding}: replay filtering preserves repeated-key order and delete/reinsert order`, () => {
+    const db = openDb();
+    db.exec(SCHEMA);
+    const unit = { key: 'unit-1', sessionId: 'session-1' };
+    persist(db, unit, records([message(1)]));
+    const originalRowid = db.prepare('SELECT rowid FROM messages WHERE uuid=?').get('message-1').rowid;
+
+    persist(db, unit, records([
+      message(1, { text: 'temporary value' }),
+      message(1),
+    ]));
+    assert.equal(db.prepare('SELECT text FROM messages WHERE uuid=?').get('message-1').text, 'stable searchable text 1');
+    assert.equal(db.prepare('SELECT rowid FROM messages WHERE uuid=?').get('message-1').rowid, originalRowid);
+
+    persist(db, unit, records([
+      { kind: 'delete-session', sessionId: 'session-1' },
+      message(1),
+    ]));
+    assert.equal(db.prepare('SELECT text FROM messages WHERE uuid=?').get('message-1').text, 'stable searchable text 1');
+    db.close();
+  });
+}

--- a/tests/persist-replay-probes.test.mjs
+++ b/tests/persist-replay-probes.test.mjs
@@ -3,22 +3,18 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { createRequire } from 'node:module';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { performance } from 'node:perf_hooks';
 
+import { healWorkflowParentLinks } from '../packages/core/src/indexer.ts';
+import { ensureFtsReady, refreshSessionProjectPaths } from '../packages/core/src/index-finalize.ts';
 import { persist } from '../packages/core/src/persist.ts';
-
-const require = createRequire(import.meta.url);
-const { DatabaseSync } = require('node:sqlite');
-const appDir = fileURLToPath(new URL('../app/', import.meta.url));
-const BetterSqlite3 = require(require.resolve('better-sqlite3', { paths: [appDir] }));
-const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
-
-const bindings = [
-  ['node:sqlite', () => new DatabaseSync(':memory:')],
-  ['better-sqlite3', () => new BetterSqlite3(':memory:')],
-];
+import {
+  bindings,
+  messageRecord,
+  SCHEMA,
+  toolCallRecord,
+  toolResultRecord,
+} from './persist-test-fixtures.mjs';
 
 function canonicalKind(sql) {
   const normalized = sql.replace(/\s+/g, ' ').trim().toLowerCase();
@@ -63,55 +59,15 @@ function instrument(db) {
 }
 
 function message(id, changes = {}) {
-  return {
-    kind: 'message',
-    uuid: `message-${id}`,
-    session_id: 'session-1',
-    type: 'assistant',
-    parent_uuid: null,
-    timestamp: `2026-09-01T10:${String(id % 60).padStart(2, '0')}:00.000Z`,
-    role: 'assistant',
-    text: `stable searchable text ${id}`,
-    content_type: 'text',
-    is_meta: 0,
-    visibility: 'visible',
-    model: 'model-1',
-    is_sidechain: 0,
-    agent_id: null,
-    input_tokens: 10,
-    output_tokens: 20,
-    cwd: '/workspace',
-    skill: null,
-    source: 'codex',
-    ...changes,
-  };
+  return messageRecord(id, changes);
 }
 
 function toolCall(id, changes = {}) {
-  return {
-    kind: 'tool_call',
-    id: `call-${id}`,
-    message_uuid: `message-${id}`,
-    session_id: 'session-1',
-    name: 'exec_command',
-    presentation: 'default',
-    input_json: '{"cmd":"true"}',
-    file_path: null,
-    ...changes,
-  };
+  return toolCallRecord(id, changes);
 }
 
 function toolResult(id, changes = {}) {
-  return {
-    kind: 'tool_result',
-    tool_use_id: `call-${id}`,
-    message_uuid: `message-${id}`,
-    session_id: 'session-1',
-    content: 'done',
-    file_path: null,
-    is_error: 0,
-    ...changes,
-  };
+  return toolResultRecord(id, changes);
 }
 
 function* snapshot(count, changedId = null) {
@@ -127,6 +83,14 @@ function* snapshot(count, changedId = null) {
 
 function* records(items) {
   yield* items;
+  return null;
+}
+
+function* replaySizedRecords(items, fillerCount) {
+  yield* items;
+  for (let index = 0; index < fillerCount; index += 1) {
+    yield { kind: 'message-turn-duration', uuid: `missing-${index}`, turn_duration_ms: null };
+  }
   return null;
 }
 
@@ -150,6 +114,9 @@ for (const [binding, openDb] of bindings) {
   test(`${binding}: unchanged snapshot rows do not execute one SQLite statement each`, (t) => {
     const rawDb = openDb();
     rawDb.exec(SCHEMA);
+    rawDb.prepare('INSERT INTO sessions (id,project,source) VALUES (?,?,?)')
+      .run('session-1', 'workspace', 'codex');
+    ensureFtsReady(rawDb);
     const observed = instrument(rawDb);
     const unit = { key: 'unit-1', sessionId: 'session-1' };
 
@@ -161,7 +128,15 @@ for (const [binding, openDb] of bindings) {
     };
     observed.reset();
 
+    const persistenceStarted = performance.now();
     persist(observed.handle, unit, snapshot(1_001, 500));
+    const persistenceMs = performance.now() - persistenceStarted;
+
+    const finalizeStarted = performance.now();
+    refreshSessionProjectPaths(rawDb, new Set(['session-1']));
+    healWorkflowParentLinks(rawDb);
+    ensureFtsReady(rawDb);
+    const finalizeMs = performance.now() - finalizeStarted;
 
     const classification = {
       emitted: 4_004,
@@ -170,7 +145,11 @@ for (const [binding, openDb] of bindings) {
       modified: 4,
       unchanged: 3_996,
     };
-    t.diagnostic(JSON.stringify({ classification, sqlite: observed.metrics }));
+    t.diagnostic(JSON.stringify({
+      classification,
+      sqlite: observed.metrics,
+      timings: { persistenceMs, finalizeMs },
+    }));
     assert.equal(observed.metrics.writes, classification.new + classification.modified);
     assert.ok(
       observed.metrics.reads + observed.metrics.writes < 80,
@@ -195,24 +174,28 @@ for (const [binding, openDb] of bindings) {
   });
 
   test(`${binding}: replay filtering preserves repeated-key order and delete/reinsert order`, () => {
-    const db = openDb();
-    db.exec(SCHEMA);
+    const rawDb = openDb();
+    rawDb.exec(SCHEMA);
+    const observed = instrument(rawDb);
     const unit = { key: 'unit-1', sessionId: 'session-1' };
-    persist(db, unit, records([message(1)]));
-    const originalRowid = db.prepare('SELECT rowid FROM messages WHERE uuid=?').get('message-1').rowid;
+    persist(observed.handle, unit, records([message(1)]));
+    const originalRowid = rawDb.prepare('SELECT rowid FROM messages WHERE uuid=?').get('message-1').rowid;
 
-    persist(db, unit, records([
-      message(1, { text: 'temporary value' }),
-      message(1),
-    ]));
-    assert.equal(db.prepare('SELECT text FROM messages WHERE uuid=?').get('message-1').text, 'stable searchable text 1');
-    assert.equal(db.prepare('SELECT rowid FROM messages WHERE uuid=?').get('message-1').rowid, originalRowid);
+    observed.reset();
+    persist(observed.handle, unit, replaySizedRecords([
+      message(1, { text: 'temporary value' }), message(1),
+    ], 248));
+    assert.ok(observed.metrics.reads > 0, 'the repeated-key replay entered filtering');
+    assert.equal(rawDb.prepare('SELECT text FROM messages WHERE uuid=?').get('message-1').text, 'stable searchable text 1');
+    assert.equal(rawDb.prepare('SELECT rowid FROM messages WHERE uuid=?').get('message-1').rowid, originalRowid);
 
-    persist(db, unit, records([
+    observed.reset();
+    persist(observed.handle, unit, replaySizedRecords([
       { kind: 'delete-session', sessionId: 'session-1' },
       message(1),
-    ]));
-    assert.equal(db.prepare('SELECT text FROM messages WHERE uuid=?').get('message-1').text, 'stable searchable text 1');
-    db.close();
+    ], 249));
+    assert.ok(observed.metrics.reads > 0, 'the post-deletion replay entered filtering');
+    assert.equal(rawDb.prepare('SELECT text FROM messages WHERE uuid=?').get('message-1').text, 'stable searchable text 1');
+    rawDb.close();
   });
 }

--- a/tests/persist-test-fixtures.mjs
+++ b/tests/persist-test-fixtures.mjs
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 tommy0103 and contributors.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require('node:sqlite');
+const appDir = fileURLToPath(new URL('../app/', import.meta.url));
+const BetterSqlite3 = require(require.resolve('better-sqlite3', { paths: [appDir] }));
+
+export const SCHEMA = readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8');
+
+export const bindings = [
+  ['node:sqlite', () => new DatabaseSync(':memory:')],
+  ['better-sqlite3', () => new BetterSqlite3(':memory:')],
+];
+
+export function openNodeSqlite() {
+  return new DatabaseSync(':memory:');
+}
+
+export function messageRecord(id, changes = {}) {
+  return {
+    kind: 'message',
+    uuid: `message-${id}`,
+    session_id: 'session-1',
+    type: 'assistant',
+    parent_uuid: null,
+    timestamp: `2026-09-01T10:${String(Number(id) % 60).padStart(2, '0')}:00.000Z`,
+    role: 'assistant',
+    text: `stable searchable text ${id}`,
+    content_type: 'text',
+    is_meta: 0,
+    visibility: 'visible',
+    model: 'model-1',
+    is_sidechain: 0,
+    agent_id: null,
+    input_tokens: 10,
+    output_tokens: 20,
+    cwd: '/workspace',
+    skill: null,
+    source: 'codex',
+    ...changes,
+  };
+}
+
+export function toolCallRecord(id, changes = {}) {
+  return {
+    kind: 'tool_call',
+    id: `call-${id}`,
+    message_uuid: `message-${id}`,
+    session_id: 'session-1',
+    name: 'exec_command',
+    presentation: 'default',
+    input_json: '{"cmd":"true"}',
+    file_path: null,
+    ...changes,
+  };
+}
+
+export function toolResultRecord(id, changes = {}) {
+  return {
+    kind: 'tool_result',
+    tool_use_id: `call-${id}`,
+    message_uuid: `message-${id}`,
+    session_id: 'session-1',
+    content: 'done',
+    file_path: null,
+    is_error: 0,
+    ...changes,
+  };
+}


### PR DESCRIPTION
## Summary

- Batch existing canonical-row reads so large snapshot replay no longer executes one SQLite UPSERT/probe per unchanged message, tool call, or tool result.
- Preserve the existing conditional UPSERT, FTS, stable-rowid, duration, retraction, and transaction contracts through the shared app/Core persistence seam.
- Keep record streams below 250 entries on the direct write path so small delta providers do not pay an extra database read.

## Scope

- In scope:
  - Bounded replay batches and binding-independent existing-row prefetch
  - Ordered in-memory comparison of all authoritative message/tool fields
  - Duration comparison against the same evolving message state
  - Cross-binding statement-count, FTS, NULL-transition, rowid, and ordering coverage
- Out of scope:
  - Provider parsing/checkpoint strategy, including the independent Codex append work in PR #148
  - Project-path history scans tracked by #105
  - Write policies for sessions, summaries, subagents, workflows, workflow agents, or `index_state`

## Key Changes

- `packages/core/src/persist.ts` activates bounded replay filtering once a stream reaches 250 records, prefetches canonical rows in key-safe batches, and sends only new or changed exact-value records through the existing UPSERTs.
- The replay cache advances in record order and treats `delete-session` as a hard boundary, preserving duplicate-key, duration, retraction, and delete/reinsert semantics.
- `tests/persist-replay-probes.test.mjs` makes SQLite statement executions observable on both real bindings and proves a 4,004-record replay needs only 51 bulk reads plus 8 genuine writes.
- Direct and replay-filter paths independently run the complete authoritative-field matrix. Repeated-key and delete/reinsert tests explicitly cross the 250-record threshold and assert that prefetch ran.
- Shared persistence fixtures now live in `tests/persist-test-fixtures.mjs`, avoiding duplicate binding and canonical-record setup.
- The persistence ADR and three-platform CI contract pin the batching boundary and regression suite.

## Validation

- `npm test`: pass, 667/667 tests under normal filesystem-event permissions
- `npm run typecheck`: pass for root and app tsconfigs
- `node --experimental-strip-types --experimental-sqlite --experimental-test-module-mocks --test tests/persist-replay-probes.test.mjs tests/persist-idempotency.test.mjs tests/persist.test.mjs tests/indexer-upsert-drift.test.mjs`: pass, 20/20 tests
- `npx eslint packages/core/src/persist.ts tests/persist-test-fixtures.mjs tests/persist-idempotency.test.mjs tests/persist-replay-probes.test.mjs`: pass, 0 errors
- `git diff --check`: pass
- Repository-wide `npm run lint`: locally blocked by 94 pre-existing errors in user-owned untracked generated artifacts under `docs/book/site/dist`, `resume_rebuild`, `tmp`, and `output`; no errors are reported for this PR's files

### Statement-count regression benchmark

Both `node:sqlite` and `better-sqlite3` run the same controlled replay:

| Classification | Records |
|---|---:|
| Emitted | 4,004 |
| Existing | 4,000 |
| New | 4 |
| Modified | 4 |
| Unchanged | 3,996 |

Canonical SQLite executions fall from 4,004 per-record UPSERT/probes to 59 total: 51 bounded reads and 8 new/modified writes. The same suite verifies that a one-record delta performs zero prefetch reads and one direct write.

The regression benchmark records persistence and finalize in separate timer regions rather than treating their sum as persistence. One representative local run reported:

| Binding | Persistence | Finalize |
|---|---:|---:|
| `node:sqlite` | 10.1 ms | 0.95 ms |
| `better-sqlite3` | 5.1 ms | 0.79 ms |

These synthetic timings are diagnostics, not pass/fail thresholds; statement counts are the regression assertion.

### Controlled real-corpus phase measurements

The benchmark replayed the same 24,197,667-byte Codex session against the same 1,098,883,072-byte local index inside rollback-only transactions.

| Phase | Elapsed |
|---|---:|
| Provider parse | 71.6 ms |
| Persistence (`origin/main`) | 63.5 ms |
| Persistence (this PR) | 14.3 ms |
| Finalize, independently measured | 862.8 ms |

The independent finalize measurement separates its own work further: project-path refresh 862.1 ms, unresolved backfill 0.46 ms, workflow healing 0.20 ms, and FTS readiness 0.04 ms. The dominant finalize cost is the separate #105 project-path scan and is not attributed to persistence.

| Kind | Emitted | Existing | New | Modified | Unchanged |
|---|---:|---:|---:|---:|---:|
| Messages | 1,999 | 1,999 | 0 | 0 | 1,999 |
| Tool calls | 1,094 | 1,094 | 0 | 0 | 1,094 |
| Tool results | 1,094 | 1,094 | 0 | 0 | 1,094 |
| Durations | 59 | 59 | 0 | 1 | 58 |

| Persistence | `origin/main` | This PR |
|---|---:|---:|
| Canonical statement executions | 4,246 | 53 |
| Elapsed | 63.5 ms | 14.3 ms |

The residual 53 executions are 51 batch reads plus 2 ordered duration updates present in the replay. Statement executions fell 98.8%; persistence latency fell 77.6%.

### Controlled complete incremental-build A/B

A copy-on-write clone of the same 1.10 GB index received the same appended real transcript record for each trial. Each arm ran complete `buildIndex` work, including discovery, parse, persistence, project-path refresh, and finalize; order alternated across three restored trials.

| Complete build | Trial 1 | Trial 2 | Trial 3 | Median |
|---|---:|---:|---:|---:|
| `origin/main` | 292.1 ms | 1,283.5 ms | 1,437.9 ms | 1,283.5 ms |
| This PR | 283.4 ms | 251.9 ms | 915.8 ms | 283.4 ms |

Cold-cache variance is visible and #105 finalize work remains in both arms, but the new implementation was faster in every paired trial; median complete-build latency fell 77.9%.

## Risks and Rollback

- The comparison field lists mirror the existing conditional UPSERT field sets; regression tests independently change every authoritative field on both the direct and replay-filter paths and cover NULL transitions.
- Batches retain only 250 records and split key lookups below SQLite's portable binding limit. Transcript values stay bound parameters.
- Rollback is a single implementation commit revert. There is no schema migration, provider cursor change, or canonical marker bump.

## Related Issues

- Related to #130
- Related to #105
- Related to #125

Closes #132
